### PR TITLE
feat(events): Making event recording optional if run via engine only

### DIFF
--- a/chaoslib/litmus/pod_delete/pod-delete.go
+++ b/chaoslib/litmus/pod_delete/pod-delete.go
@@ -34,7 +34,9 @@ func PodDeleteChaos(experimentsDetails *types.ExperimentDetails, clients environ
 				return err
 			}
 		}
+		if experimentsDetails.EngineName != "" {
 		recorder.ChaosInject(experimentsDetails)
+		}
 
 		//ChaosCurrentTimeStamp contains the current timestamp
 		ChaosCurrentTimeStamp := time.Now().Unix()

--- a/experiments/generic/pod-delete/pod-delete.go
+++ b/experiments/generic/pod-delete/pod-delete.go
@@ -56,8 +56,9 @@ func main() {
 		resultDetails.FailStep = "Verify that the AUT (Application Under Test) is running (pre-chaos)"
 		result.ChaosResult(&experimentsDetails, clients,&resultDetails,"EOT"); return
 	}
-
+	if experimentsDetails.EngineName != "" {
 	recorder.PreChaosCheck(experimentsDetails)
+	}
 
 	// Including the litmus lib for pod-delete
 	if experimentsDetails.ChaosLib == "litmus" {
@@ -82,7 +83,9 @@ func main() {
 		resultDetails.FailStep = "Verify that the AUT (Application Under Test) is running (post-chaos)"
 		result.ChaosResult(&experimentsDetails, clients,&resultDetails,"EOT"); return
 	}
+	if experimentsDetails.EngineName != "" {
 	recorder.PostChaosCheck(experimentsDetails)
+	}
 
 	//Updating the chaosResult in the end of experiment
 	klog.V(0).Infof("[The End]: Updating the chaos result of %v experiment (EOT)",experimentsDetails.ExperimentName)
@@ -91,5 +94,7 @@ func main() {
 		klog.V(0).Infof("Unable to Update the Chaos Result due to %v\n", err)
 		return
 	}
+	if experimentsDetails.EngineName != "" {
 	recorder.Summary(&experimentsDetails,&resultDetails)
+	}
 }

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -31,5 +31,9 @@ func SetResultAttributes(resultDetails *types.ResultDetails, experimentDetails *
 	resultDetails.Verdict = "Awaited"
 	resultDetails.Phase = "Running"
 	resultDetails.FailStep = "N/A"
+	if experimentDetails.EngineName != ""{
 	resultDetails.Name = experimentDetails.EngineName+"-"+experimentDetails.ExperimentName
+	} else {
+		resultDetails.Name = experimentDetails.ExperimentName
+	}
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Making event recording optional if run via engine only