### PR TITLE
feat(events): Adding the client-go events

### DIFF
--- a/chaoslib/litmus/pod_delete/pod-delete.go
+++ b/chaoslib/litmus/pod_delete/pod-delete.go
@@ -22,7 +22,7 @@ var GracePeriod int64 = 0
 var err error
 
 //PodDeleteChaos deletes the random single/multiple pods
-func PodDeleteChaos(experimentsDetails *types.ExperimentDetails, clients environment.ClientSets, Iterations int, resultDetails *types.ResultDetails, recorder *events.Recorder) error {
+func PodDeleteChaos(experimentsDetails *types.ExperimentDetails, clients environment.ClientSets, Iterations int, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails) error {
 
 	//ChaosStartTimeStamp contains the start timestamp, when the chaos injection begin
 	ChaosStartTimeStamp := time.Now().Unix()
@@ -49,7 +49,9 @@ func PodDeleteChaos(experimentsDetails *types.ExperimentDetails, clients environ
 			}
 		}
 		if experimentsDetails.EngineName != "" {
-			recorder.ChaosInject(experimentsDetails)
+			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
+			environment.SetEventAttributes(eventsDetails, types.ChaosInject, msg)
+			events.GenerateEvents(experimentsDetails, clients, eventsDetails)
 		}
 
 		//ChaosCurrentTimeStamp contains the current timestamp
@@ -82,7 +84,7 @@ func PodDeleteChaos(experimentsDetails *types.ExperimentDetails, clients environ
 }
 
 //PreparePodDelete contains the steps for prepration before chaos
-func PreparePodDelete(experimentsDetails *types.ExperimentDetails, clients environment.ClientSets, resultDetails *types.ResultDetails, recorder *events.Recorder) error {
+func PreparePodDelete(experimentsDetails *types.ExperimentDetails, clients environment.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails) error {
 
 	//It will get the total iteration for the pod-delete
 	Iterations := GetIterations(experimentsDetails)
@@ -92,7 +94,7 @@ func PreparePodDelete(experimentsDetails *types.ExperimentDetails, clients envir
 		waitForRampTime(experimentsDetails)
 	}
 	//Deleting for the application pod
-	err := PodDeleteChaos(experimentsDetails, clients, Iterations, resultDetails, recorder)
+	err := PodDeleteChaos(experimentsDetails, clients, Iterations, resultDetails, eventsDetails)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v0.0.0-20190918200256-06eb1244587a
-	k8s.io/klog v1.0.0
+	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c // indirect
 	k8s.io/utils v0.0.0-20200414100711-2df71ebbae66 // indirect
 	sigs.k8s.io/controller-runtime v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,7 @@ k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c h1:/KUFqjjqAcY4Us6luF5RDNZ16KJtb49HfR3ZHB9qYXM=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
+k8s.io/kubernetes v1.18.3 h1:6qtm8v3z+OwYm2SnsTxYUtGCsIbGBZ/Dh9yER+aNIoI=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200414100711-2df71ebbae66 h1:Ly1Oxdu5p5ZFmiVT71LFgeZETvMfZ1iBIGeOenT2JeM=

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strconv"
 
+	clientTypes "k8s.io/apimachinery/pkg/types"
+
 	types "github.com/litmuschaos/litmus-go/pkg/types"
 )
 
@@ -21,7 +23,7 @@ func GetENV(experimentDetails *types.ExperimentDetails, expName string) {
 	experimentDetails.AppLabel = os.Getenv("APP_LABEL")
 	experimentDetails.AppKind = os.Getenv("APP_KIND")
 	experimentDetails.KillCount, _ = strconv.Atoi(os.Getenv("KILL_COUNT"))
-	experimentDetails.ChaosUID = os.Getenv("CHAOS_UID")
+	experimentDetails.ChaosUID = clientTypes.UID(os.Getenv("CHAOS_UID"))
 	experimentDetails.AuxiliaryAppInfo = os.Getenv("AUXILIARY_APPINFO")
 	experimentDetails.InstanceID = os.Getenv("INSTANCE_ID")
 	experimentDetails.ChaosPodName = os.Getenv("POD_NAME")
@@ -38,4 +40,11 @@ func SetResultAttributes(resultDetails *types.ResultDetails, experimentDetails *
 	} else {
 		resultDetails.Name = experimentDetails.ExperimentName
 	}
+}
+
+//SetEventAttributes initialise all the chaos result ENV
+func SetEventAttributes(eventsDetails *types.EventDetails, Reason string, Message string) {
+
+	eventsDetails.Reason = Reason
+	eventsDetails.Message = Message
 }

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -1,0 +1,61 @@
+package events
+
+import (
+	"time"
+
+	"github.com/litmuschaos/litmus-go/pkg/environment"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//CreateEvents create the events
+func CreateEvents(experimentsDetails *types.ExperimentDetails, clients environment.ClientSets, eventsDetails *types.EventDetails) error {
+
+	events := &apiv1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      eventsDetails.Reason + string(experimentsDetails.ChaosUID),
+			Namespace: experimentsDetails.ChaosNamespace,
+		},
+		Source: apiv1.EventSource{
+			Component: experimentsDetails.ChaosPodName,
+		},
+		Message:        eventsDetails.Message,
+		Reason:         eventsDetails.Reason,
+		Type:           "Normal",
+		Count:          1,
+		FirstTimestamp: metav1.Time{Time: time.Now()},
+		LastTimestamp:  metav1.Time{Time: time.Now()},
+		InvolvedObject: apiv1.ObjectReference{
+			APIVersion: "litmuschaos.io/v1alpha1",
+			Kind:       "ChaosEngine",
+			Name:       experimentsDetails.EngineName,
+			Namespace:  experimentsDetails.ChaosNamespace,
+			UID:        experimentsDetails.ChaosUID,
+		},
+	}
+
+	_, err := clients.KubeClient.CoreV1().Events(experimentsDetails.ChaosNamespace).Create(events)
+	return err
+
+}
+
+//GenerateEvents update the events
+func GenerateEvents(experimentsDetails *types.ExperimentDetails, clients environment.ClientSets, eventsDetails *types.EventDetails) error {
+
+	var err error
+	event, err := clients.KubeClient.CoreV1().Events(experimentsDetails.ChaosNamespace).Get(eventsDetails.Reason+string(experimentsDetails.ChaosUID), metav1.GetOptions{})
+
+	if event.Name != eventsDetails.Reason+string(experimentsDetails.ChaosUID) {
+
+		err = CreateEvents(experimentsDetails, clients, eventsDetails)
+
+	} else {
+
+		event.Count = event.Count + 1
+		event.LastTimestamp = metav1.Time{Time: time.Now()}
+
+		_, err = clients.KubeClient.CoreV1().Events(experimentsDetails.ChaosNamespace).Update(event)
+	}
+	return err
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,10 +1,14 @@
 package types
 
+import (
+	clientTypes "k8s.io/apimachinery/pkg/types"
+)
+
 const (
-	PreChaosCheck                   string = "PreChaosCheck"
-	PostChaosCheck                  string = "PostChaosCheck"
-	Summary                         string = "Summary"
-	ChaosInject                     string = "ChaosInject"
+	PreChaosCheck  string = "PreChaosCheck"
+	PostChaosCheck string = "PostChaosCheck"
+	Summary        string = "Summary"
+	ChaosInject    string = "ChaosInject"
 )
 
 // ExperimentDetails is for collecting all the experiment-related details
@@ -21,7 +25,7 @@ type ExperimentDetails struct {
 	AppLabel            string
 	AppKind             string
 	KillCount           int
-	ChaosUID            string
+	ChaosUID            clientTypes.UID
 	AuxiliaryAppInfo    string
 	InstanceID          string
 	ChaosNamespace      string
@@ -30,8 +34,14 @@ type ExperimentDetails struct {
 
 // ResultDetails is for collecting all the chaos-result-related details
 type ResultDetails struct {
-	Name                string
-	Verdict             string
-	FailStep            string
-	Phase               string
+	Name     string
+	Verdict  string
+	FailStep string
+	Phase    string
+}
+
+// EventDetails is for collecting all the events-related details
+type EventDetails struct {
+	Message string
+	Reason  string
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Earlier it was not able to patch the events counts concurrently (one by one). Instead, it is patching many counts at a time. 
- It will add the ability to patch the events after each occurrence of events concurrently.