### PR TITLE
feat(experiments): Add pod memory hog experiment

### DIFF
--- a/experiments/generic/pod-memory-hog/pod-memory-hog-k8s-job.yml
+++ b/experiments/generic/pod-memory-hog/pod-memory-hog-k8s-job.yml
@@ -1,0 +1,69 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: pod-memory-hog-
+spec:
+  template:
+    metadata:
+      labels:
+        experiment: pod-memory-hog
+    spec:
+      # Placeholder that is updated by the executor for automated runs
+      # Provide appropriate SA (with desired permissions) if executed manually
+      serviceAccountName: %CHAOS_SERVICE_ACCOUNT%
+      restartPolicy: Never
+      containers:
+      - name: gotest
+        image: litmuschaos/go-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: APP_NAMESPACE
+            value: ''
+
+          - name: APP_LABEL
+            value: ''
+
+          - name: APP_KIND
+            value: '' 
+
+          ## Total duration to infuse chaos
+          - name: TOTAL_CHAOS_DURATION
+            value: '60'
+          
+          - name: CHAOS_INTERVAL
+            value: '10'
+
+          # enter the amount of memory in megabytes to be consumed by the application pod
+          # default: 500 (Megabytes) 
+          - name: MEMORY_CONSUMPTION
+            value: '500'
+
+          ## Percentage of total pods to target
+          - name: PODS_AFFECTED_PERC
+            value: '100'
+
+          ## Period to wait before injection of chaos in sec
+          - name: RAMP_TIME
+            value: ''
+
+          - name: CHAOS_NAMESPACE
+            value: ''          
+
+          ## env var that describes the library used to execute the chaos
+          ## default: litmus. Supported values: litmus, powerfulseal, chaoskube
+          - name: LIB
+            value: ''
+        
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
+          - name: CHAOS_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+
+        command: ["/bin/bash"]
+        args: ["-c", "./experiments/pod-memory-hog"]

--- a/experiments/generic/pod-memory-hog/pod-memory-hog.go
+++ b/experiments/generic/pod-memory-hog/pod-memory-hog.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"github.com/litmuschaos/litmus-go/chaoslib/litmus/pod_memory_hog"
+	"github.com/litmuschaos/litmus-go/pkg/environment"
+	"github.com/litmuschaos/litmus-go/pkg/events"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/result"
+	"github.com/litmuschaos/litmus-go/pkg/status"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
+)
+
+func init() {
+	// Log as JSON instead of the default ASCII formatter.
+	logrus.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: true,
+		// ForceColors:            true,
+		DisableSorting:         true,
+		DisableLevelTruncation: true,
+	})
+}
+
+func main() {
+
+	var err error
+	experimentsDetails := types.ExperimentDetails{}
+	resultDetails := types.ResultDetails{}
+	clients := environment.ClientSets{}
+
+	//Getting kubeConfig and Generate ClientSets
+	if err := clients.GenerateClientSetFromKubeConfig(); err != nil {
+		log.Fatalf("Unable to Get the kubeconfig due to %v", err)
+	}
+
+	//Fetching all the ENV passed for the runner pod
+	log.Infof("[PreReq]: Getting the ENV for the %v experiment", experimentsDetails.ExperimentName)
+	environment.GetENV(&experimentsDetails, "pod-memory-hog")
+
+	recorder, err := events.NewEventRecorder(clients, experimentsDetails)
+	if err != nil {
+		log.Warn("Unable to initiate EventRecorder for chaos-experiment, would not be able to add events")
+	}
+
+	// Intialise Chaos Result Parameters
+	environment.SetResultAttributes(&resultDetails, &experimentsDetails)
+
+	//Updating the chaos result in the beggining of experiment
+	log.Infof("[PreReq]: Updating the chaos result of %v experiment (SOT)", experimentsDetails.ExperimentName)
+	err = result.ChaosResult(&experimentsDetails, clients, &resultDetails, "SOT")
+	if err != nil {
+		log.Errorf("Unable to Create the Chaos Result due to %v", err)
+		resultDetails.FailStep = "Updating the chaos result of pod-memory-hog experiment (SOT)"
+		err = result.ChaosResult(&experimentsDetails, clients, &resultDetails, "EOT")
+		return
+	}
+
+	//DISPLAY THE APP INFORMATION
+	log.InfoWithValues("The application informations are as follows", logrus.Fields{
+		"Namespace":          experimentsDetails.AppNS,
+		"Label":              experimentsDetails.AppLabel,
+		"Chaos Duration":     experimentsDetails.ChaosDuration,
+		"Ramp Time":          experimentsDetails.RampTime,
+		"Memory Consumption": experimentsDetails.MemoryConsumption,
+	})
+
+	// ADD A PRE-CHAOS CHECK OF YOUR CHOICE HERE
+	// POD STATUS CHECKS FOR THE APPLICATION UNDER TEST AND AUXILIARY APPLICATIONS ARE ADDED BY DEFAULT
+
+	//PRE-CHAOS APPLICATION STATUS CHECK
+	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (pre-chaos)")
+	err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, clients)
+	if err != nil {
+		log.Errorf("Application status check failed due to %v\n", err)
+		resultDetails.FailStep = "Verify that the AUT (Application Under Test) is running (pre-chaos)"
+		result.ChaosResult(&experimentsDetails, clients, &resultDetails, "EOT")
+		return
+	}
+
+	if experimentsDetails.EngineName != "" {
+		recorder.PreChaosCheck(experimentsDetails)
+	}
+
+	// Including the litmus lib for pod-memory-hog
+	if experimentsDetails.ChaosLib == "litmus" {
+		err = pod_memory_hog.PrepareMemoryStress(&experimentsDetails, clients, &resultDetails, recorder)
+		if err != nil {
+			log.Errorf("[Error]: pod memory hog failed due to %v\n", err)
+			resultDetails.FailStep = "pod memory hog chaos injection failed"
+			resultDetails.Verdict = "Fail"
+			result.ChaosResult(&experimentsDetails, clients, &resultDetails, "EOT")
+			return
+		} else {
+			log.Info("[Confirmation]: Memory of the application pod has been stressed successfully")
+			resultDetails.Verdict = "Pass"
+		}
+	} else {
+		log.Error("[Invalid]: Please Provide the correct LIB")
+		resultDetails.FailStep = "Including the litmus lib for pod-memory-hog"
+		result.ChaosResult(&experimentsDetails, clients, &resultDetails, "EOT")
+		return
+	}
+
+	//POST-CHAOS APPLICATION STATUS CHECK
+	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (post-chaos)")
+	err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, clients)
+	if err != nil {
+		klog.V(0).Infof("Application status check failed due to %v\n", err)
+		resultDetails.FailStep = "Verify that the AUT (Application Under Test) is running (post-chaos)"
+		result.ChaosResult(&experimentsDetails, clients, &resultDetails, "EOT")
+		return
+	}
+
+	if experimentsDetails.EngineName != "" {
+		recorder.PostChaosCheck(experimentsDetails)
+	}
+
+	//Updating the chaosResult in the end of experiment
+	log.Infof("[The End]: Updating the chaos result of %v experiment (EOT)", experimentsDetails.ExperimentName)
+	err = result.ChaosResult(&experimentsDetails, clients, &resultDetails, "EOT")
+	if err != nil {
+		log.Fatalf("Unable to Update the Chaos Result due to %v\n", err)
+	}
+	if experimentsDetails.EngineName != "" {
+		recorder.Summary(&experimentsDetails, &resultDetails)
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,7 @@ k8s.io/apiextensions-apiserver v0.0.0-20190918201827-3de75813f604/go.mod h1:7H8s
 k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d h1:7Kns6qqhMAQWvGkxYOLSLRZ5hJO0/5pcE5lPGP2fxUw=
 k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d/go.mod h1:3jediapYqJ2w1BFw7lAZPCx7scubsTfosqHkhXCWJKw=
 k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
+k8s.io/apimachinery v0.18.4 h1:ST2beySjhqwJoIFk6p7Hp5v5O0hYY6Gngq/gUYXTPIA=
 k8s.io/apiserver v0.0.0-20190918200908-1e17798da8c1/go.mod h1:4FuDU+iKPjdsdQSN3GsEKZLB/feQsj1y9dhhBDVV2Ns=
 k8s.io/client-go v0.0.0-20190918200256-06eb1244587a h1:huOvPq1vO7dkuw9rZPYsLGpFmyGvy6L8q6mDItgkdQ4=
 k8s.io/client-go v0.0.0-20190918200256-06eb1244587a/go.mod h1:3YAcTbI2ArBRmhHns5vlHRX8YQqvkVYpz+U/N5i1mVU=

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -12,25 +12,26 @@ import (
 //GetENV fetches all the env variables from the runner pod
 func GetENV(experimentDetails *types.ExperimentDetails, expName string) {
 	experimentDetails.ExperimentName = expName
-	experimentDetails.ChaosNamespace = Getenv("CHAOS_NAMESPACE","litmus")
-	experimentDetails.EngineName = Getenv("CHAOSENGINE","")
-	experimentDetails.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION","30"))
-	experimentDetails.ChaosInterval, _ = strconv.Atoi(Getenv("CHAOS_INTERVAL","10"))
-	experimentDetails.RampTime, _ = strconv.Atoi(Getenv("RAMP_TIME","0"))
-	experimentDetails.ChaosLib = Getenv("LIB","litmus")
-	experimentDetails.ChaosServiceAccount = Getenv("CHAOS_SERVICE_ACCOUNT","")
-	experimentDetails.AppNS = Getenv("APP_NAMESPACE","")
-	experimentDetails.AppLabel = Getenv("APP_LABEL","")
-	experimentDetails.AppKind = Getenv("APP_KIND","")
-	experimentDetails.KillCount, _ = strconv.Atoi(Getenv("KILL_COUNT","1"))
-	experimentDetails.ChaosUID = clientTypes.UID(Getenv("CHAOS_UID",""))
-	experimentDetails.AuxiliaryAppInfo = Getenv("AUXILIARY_APPINFO","")
-	experimentDetails.InstanceID = Getenv("INSTANCE_ID","")
-	experimentDetails.ChaosPodName = Getenv("POD_NAME","")
-	experimentDetails.Force, _ = strconv.ParseBool(Getenv("FORCE","false"))
-	experimentDetails.LIBImage = Getenv("LIB_IMAGE","")
-  	experimentDetails.CPUcores, _ = strconv.Atoi(Getenv("CPU_CORES","1"))
-	experimentDetails.PodsAffectedPerc, _ = strconv.Atoi(Getenv("PODS_AFFECTED_PERC","100"))
+	experimentDetails.ChaosNamespace = Getenv("CHAOS_NAMESPACE", "litmus")
+	experimentDetails.EngineName = Getenv("CHAOSENGINE", "")
+	experimentDetails.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION", "30"))
+	experimentDetails.ChaosInterval, _ = strconv.Atoi(Getenv("CHAOS_INTERVAL", "10"))
+	experimentDetails.RampTime, _ = strconv.Atoi(Getenv("RAMP_TIME", "0"))
+	experimentDetails.ChaosLib = Getenv("LIB", "litmus")
+	experimentDetails.ChaosServiceAccount = Getenv("CHAOS_SERVICE_ACCOUNT", "")
+	experimentDetails.AppNS = Getenv("APP_NAMESPACE", "")
+	experimentDetails.AppLabel = Getenv("APP_LABEL", "")
+	experimentDetails.AppKind = Getenv("APP_KIND", "")
+	experimentDetails.KillCount, _ = strconv.Atoi(Getenv("KILL_COUNT", "1"))
+	experimentDetails.ChaosUID = clientTypes.UID(Getenv("CHAOS_UID", ""))
+	experimentDetails.AuxiliaryAppInfo = Getenv("AUXILIARY_APPINFO", "")
+	experimentDetails.InstanceID = Getenv("INSTANCE_ID", "")
+	experimentDetails.ChaosPodName = Getenv("POD_NAME", "")
+	experimentDetails.Force, _ = strconv.ParseBool(Getenv("FORCE", "false"))
+	experimentDetails.LIBImage = Getenv("LIB_IMAGE", "")
+	experimentDetails.CPUcores, _ = strconv.Atoi(Getenv("CPU_CORES", "1"))
+	experimentDetails.MemoryConsumption, _ = strconv.Atoi(Getenv("MEMORY_CONSUMPTION", "500"))
+	experimentDetails.PodsAffectedPerc, _ = strconv.Atoi(Getenv("PODS_AFFECTED_PERC", "100"))
 }
 
 //SetResultAttributes initialise all the chaos result ENV
@@ -53,9 +54,9 @@ func SetEventAttributes(eventsDetails *types.EventDetails, Reason string, Messag
 }
 
 // Getenv fetch the env and set the default value, if any
-func Getenv(key string, defaultValue string) string{
+func Getenv(key string, defaultValue string) string {
 	value := os.Getenv(key)
-	if value == ""{
+	if value == "" {
 		value = defaultValue
 	}
 	return value

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -32,7 +32,8 @@ type ExperimentDetails struct {
 	ChaosPodName        string
 	Iterations          int
 	LIBImage            string
-  	CPUcores            int
+	CPUcores            int
+	MemoryConsumption   int
 	PodsAffectedPerc    int
 }
 


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

**This PR contains:**

- Adding one more resource chaos experiment in the generic experiment of LitmusChaos. The experiment is pod-memory-hog which is used to give a memory spike on a container inside a pod for a certain chaos duration.
- The experiment uses `dd` command to give a chaos spike.
- After the total chaos duration, the command terminates using kill command inside the container.

**Issue:**
fixes: https://github.com/litmuschaos/litmus/issues/1559

**Special notes for your reviewer:**



