### PR TITLE
bug(fix): Remove extra index from the list in pod duplication experiment

### DIFF
--- a/chaoslib/pumba/network_chaos/pod-network-duplication.go
+++ b/chaoslib/pumba/network_chaos/pod-network-duplication.go
@@ -96,7 +96,7 @@ func GetApplicationPod(experimentsDetails *experimentTypes.ExperimentDetails, cl
 		return "", "", errors.Wrapf(err, "Fail to get the application pod in %v namespace", experimentsDetails.AppNS)
 	}
 
-	podNameListSize := len(podList.Items) + 1
+	podNameListSize := len(podList.Items)
 	podNameList := make([]string, podNameListSize)
 	podNodeName := make([]string, podNameListSize)
 


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

- This PR is for removing extra index from the list of pods so that it would not take extra index while running the experiment and results in empty application detail in pod network duplication.