### PR TITLE
feat(abort): Adding summary event in chaosresult in case of abort

### DIFF
--- a/chaoslib/litmus/pod_cpu_hog/pod-cpu-hog.go
+++ b/chaoslib/litmus/pod_cpu_hog/pod-cpu-hog.go
@@ -130,7 +130,10 @@ func ExperimentCPU(experimentsDetails *experimentTypes.ExperimentDetails, client
 						}
 						resultDetails.FailStep = "CPU hog Chaos injection stopped!"
 						resultDetails.Verdict = "Stopped"
+						msg := experimentsDetails.ExperimentName + " experiment has been aborted"
 						result.ChaosResult(chaosDetails, clients, resultDetails, "EOT")
+						types.SetResultEventAttributes(eventsDetails, types.Summary, msg, resultDetails)
+						events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosResult")
 						os.Exit(1)
 					case <-endTime:
 						log.Infof("[Chaos]: Time is up for experiment: %v", experimentsDetails.ExperimentName)


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding summary event in chaosresult in case of abort

- fixes: #48 