### PR TITLE
update(chaos-result): Add the warning summary event in chaosresult for negative cases

### DIFF
--- a/chaoslib/litmus/pod_cpu_hog/pod-cpu-hog.go
+++ b/chaoslib/litmus/pod_cpu_hog/pod-cpu-hog.go
@@ -128,11 +128,18 @@ func ExperimentCPU(experimentsDetails *experimentTypes.ExperimentDetails, client
 							klog.V(0).Infof("Error in Kill stress after")
 							return err
 						}
-						resultDetails.FailStep = "CPU hog Chaos injection stopped!"
-						resultDetails.Verdict = "Stopped"
-						msg := experimentsDetails.ExperimentName + " experiment has been aborted"
+						// updating the chaosresult after stopped
+						failStep := "CPU hog Chaos injection stopped!"
+						types.SetResultAfterCompletion(resultDetails, "Fail", "Stopped", failStep)
 						result.ChaosResult(chaosDetails, clients, resultDetails, "EOT")
-						types.SetResultEventAttributes(eventsDetails, types.Summary, msg, resultDetails)
+
+						// generating summary event in chaosengine
+						msg := experimentsDetails.ExperimentName + " experiment has been aborted"
+						types.SetEngineEventAttributes(eventsDetails, types.Summary, msg, "Warning", chaosDetails)
+						events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+
+						// generating summary event in chaosresult
+						types.SetResultEventAttributes(eventsDetails, types.Summary, msg, "Warning", resultDetails)
 						events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosResult")
 						os.Exit(1)
 					case <-endTime:

--- a/chaoslib/litmus/pod_memory_hog/pod-memory-hog.go
+++ b/chaoslib/litmus/pod_memory_hog/pod-memory-hog.go
@@ -129,9 +129,19 @@ func ExperimentMemory(experimentsDetails *experimentTypes.ExperimentDetails, cli
 						klog.V(0).Infof("Error in Kill stress after")
 						return err
 					}
-					resultDetails.FailStep = "Memory hog Chaos injection stopped!"
-					resultDetails.Verdict = "Stopped"
+					// updating the chaosresult after stopped
+					failStep := "Memory hog Chaos injection stopped!"
+					types.SetResultAfterCompletion(resultDetails, "Fail", "Stopped", failStep)
 					result.ChaosResult(chaosDetails, clients, resultDetails, "EOT")
+
+					// generating summary event in chaosengine
+					msg := experimentsDetails.ExperimentName + " experiment has been aborted"
+					types.SetEngineEventAttributes(eventsDetails, types.Summary, msg, "Warning", chaosDetails)
+					events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+
+					// generating summary event in chaosresult
+					types.SetResultEventAttributes(eventsDetails, types.Summary, msg, "Warning", resultDetails)
+					events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosResult")
 					os.Exit(1)
 				case <-endTime:
 					log.Infof("[Chaos]: Time is up for experiment: %v", experimentsDetails.ExperimentName)

--- a/contribute/developer-guide/templates/experiment.tmpl
+++ b/contribute/developer-guide/templates/experiment.tmpl
@@ -157,6 +157,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/container-kill/container-kill.go
+++ b/experiments/generic/container-kill/container-kill.go
@@ -130,6 +130,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/disk-fill/disk-fill.go
+++ b/experiments/generic/disk-fill/disk-fill.go
@@ -151,6 +151,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/kubelet-service-kill/kubelet-service-kill.go
+++ b/experiments/generic/kubelet-service-kill/kubelet-service-kill.go
@@ -151,6 +151,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/node-cpu-hog/node-cpu-hog.go
+++ b/experiments/generic/node-cpu-hog/node-cpu-hog.go
@@ -153,6 +153,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/node-drain/node-drain.go
+++ b/experiments/generic/node-drain/node-drain.go
@@ -152,6 +152,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/node-memory-hog/node-memory-hog.go
+++ b/experiments/generic/node-memory-hog/node-memory-hog.go
@@ -130,6 +130,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/node-taint/node-taint.go
+++ b/experiments/generic/node-taint/node-taint.go
@@ -151,6 +151,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/pod-cpu-hog/pod-cpu-hog.go
+++ b/experiments/generic/pod-cpu-hog/pod-cpu-hog.go
@@ -129,6 +129,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/pod-delete/pod-delete.go
+++ b/experiments/generic/pod-delete/pod-delete.go
@@ -125,6 +125,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/pod-memory-hog/pod-memory-hog.go
+++ b/experiments/generic/pod-memory-hog/pod-memory-hog.go
@@ -130,6 +130,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/pod-network-corruption/pod-network-corruption.go
+++ b/experiments/generic/pod-network-corruption/pod-network-corruption.go
@@ -127,6 +127,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/pod-network-duplication/pod-network-duplication.go
+++ b/experiments/generic/pod-network-duplication/pod-network-duplication.go
@@ -127,6 +127,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/pod-network-latency/pod-network-latency.go
+++ b/experiments/generic/pod-network-latency/pod-network-latency.go
@@ -127,6 +127,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/experiments/generic/pod-network-loss/pod-network-loss.go
+++ b/experiments/generic/pod-network-loss/pod-network-loss.go
@@ -127,6 +127,6 @@ func main() {
 	}
 
 	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
-	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, &resultDetails)
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
 	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
 }

--- a/pkg/result/chaosresult.go
+++ b/pkg/result/chaosresult.go
@@ -153,9 +153,13 @@ func RecordAfterFailure(chaosDetails *types.ChaosDetails, resultDetails *types.R
 	types.SetResultAfterCompletion(resultDetails, "Fail", "Completed", failStep)
 	ChaosResult(chaosDetails, clients, resultDetails, "EOT")
 
-	// add the summary event
+	// add the summary event in chaos result
+	msg := chaosDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
+	types.SetResultEventAttributes(eventsDetails, types.Summary, msg, "Warning", resultDetails)
+	events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosResult")
+
+	// add the summary event in chaos engine
 	if chaosDetails.EngineName != "" {
-		msg := chaosDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
 		types.SetEngineEventAttributes(eventsDetails, types.Summary, msg, "Warning", chaosDetails)
 		events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -72,11 +72,12 @@ func SetEngineEventAttributes(eventsDetails *EventDetails, Reason, Message, Type
 }
 
 //SetResultEventAttributes initialise attributes for event generation in chaos result
-func SetResultEventAttributes(eventsDetails *EventDetails, Reason string, Message string, resultDetails *ResultDetails) {
+func SetResultEventAttributes(eventsDetails *EventDetails, Reason, Message, Type string, resultDetails *ResultDetails) {
 
 	eventsDetails.Reason = Reason
 	eventsDetails.Message = Message
 	eventsDetails.ResourceName = resultDetails.Name
 	eventsDetails.ResourceUID = resultDetails.ResultUID
+	eventsDetails.Type = Type
 
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Add the summary events in chaos result for the negative cases of type warning