### PR TITLE
update(container-kill): refactor the container-kill experiment

### DIFF
--- a/chaoslib/pumba/container_kill/container-kill.go
+++ b/chaoslib/pumba/container_kill/container-kill.go
@@ -81,17 +81,17 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 	log.Infof("[Wait]: Waiting for the %vs chaos duration", strconv.Itoa(experimentsDetails.ChaosDuration))
 	common.WaitForDuration(experimentsDetails.ChaosDuration)
 
+	// It will verify that the restart count of container should increase after chaos injection
+	err = VerifyRestartCount(experimentsDetails, appName, clients, restartCountBefore)
+	if err != nil {
+		return errors.Errorf("Target container is not restarted , err: %v", err)
+	}
+
 	//Deleting the the helper pod for container-kill
 	log.Info("[Cleanup]: Deleting the helper pod")
 	err = common.DeletePod(experimentsDetails.ExperimentName+"-"+experimentsDetails.RunID, "name="+experimentsDetails.ExperimentName+"-"+experimentsDetails.RunID, experimentsDetails.ChaosNamespace, chaosDetails.Timeout, chaosDetails.Delay, clients)
 	if err != nil {
 		return errors.Errorf("Unable to delete the helper pod, err: %v", err)
-	}
-
-	// It will verify that the restart count of container should increase after chaos injection
-	err = VerifyRestartCount(experimentsDetails, appName, clients, restartCountBefore)
-	if err != nil {
-		return errors.Errorf("Target container is not restarted , err: %v", err)
 	}
 
 	//Waiting for the ramp time after chaos injection


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- For the negative cases where helper pod failed and it is unable to kill the target container. As we are verifying the restart count after the cleanup of the pod. We can't check the logs oof the helper pod. The cleanup step should present after the verification of the restart count so that we can check the logs of the helper pod for negative cases.