### PR TITLE
chore(target-pod): Adding ability to pass the target_pod as env

### DIFF
--- a/chaoslib/litmus/container_kill/helper/crictl.go
+++ b/chaoslib/litmus/container_kill/helper/crictl.go
@@ -64,7 +64,7 @@ func KillContainer(experimentsDetails *experimentTypes.ExperimentDetails, client
 		}
 
 		//GetRestartCount return the restart count of target container
-		restartCountBefore, err := GetRestartCount(experimentsDetails, experimentsDetails.ApplicationPod, clients)
+		restartCountBefore, err := GetRestartCount(experimentsDetails, experimentsDetails.TargetPod, clients)
 		if err != nil {
 			return err
 		}
@@ -77,7 +77,7 @@ func KillContainer(experimentsDetails *experimentTypes.ExperimentDetails, client
 		}
 
 		log.InfoWithValues("[Info]: Details of application under chaos injection", logrus.Fields{
-			"PodName":            experimentsDetails.ApplicationPod,
+			"PodName":            experimentsDetails.TargetPod,
 			"ContainerName":      experimentsDetails.TargetContainer,
 			"RestartCountBefore": restartCountBefore,
 		})
@@ -99,13 +99,13 @@ func KillContainer(experimentsDetails *experimentTypes.ExperimentDetails, client
 		}
 
 		//Check the status of restarted container
-		err = CheckContainerStatus(experimentsDetails, clients, experimentsDetails.ApplicationPod)
+		err = CheckContainerStatus(experimentsDetails, clients, experimentsDetails.TargetPod)
 		if err != nil {
 			return errors.Errorf("Application container is not running, %v", err)
 		}
 
 		// It will verify that the restart count of container should increase after chaos injection
-		err = VerifyRestartCount(experimentsDetails, experimentsDetails.ApplicationPod, clients, restartCountBefore)
+		err = VerifyRestartCount(experimentsDetails, experimentsDetails.TargetPod, clients, restartCountBefore)
 		if err != nil {
 			return errors.Errorf("Target container is not restarted , err: %v", err)
 		}
@@ -134,7 +134,7 @@ func GetPodID(experimentsDetails *experimentTypes.ExperimentDetails) (string, er
 	pods := RemoveExtraSpaces(stdout)
 	for i := 0; i < len(pods)-1; i++ {
 		attributes := strings.Split(pods[i], " ")
-		if attributes[3] == experimentsDetails.ApplicationPod {
+		if attributes[3] == experimentsDetails.TargetPod {
 			return attributes[0], nil
 		}
 
@@ -278,7 +278,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, name string) {
 	experimentDetails.ExperimentName = name
 	experimentDetails.AppNS = Getenv("APP_NS", "")
 	experimentDetails.TargetContainer = Getenv("APP_CONTAINER", "")
-	experimentDetails.ApplicationPod = Getenv("APP_POD", "")
+	experimentDetails.TargetPod = Getenv("APP_POD", "")
 	experimentDetails.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION", "30"))
 	experimentDetails.ChaosInterval, _ = strconv.Atoi(Getenv("CHAOS_INTERVAL", "10"))
 	experimentDetails.Iterations, _ = strconv.Atoi(Getenv("ITERATIONS", "3"))

--- a/chaoslib/litmus/disk_fill/disk-fill.go
+++ b/chaoslib/litmus/disk_fill/disk-fill.go
@@ -2,10 +2,8 @@ package disk_fill
 
 import (
 	"fmt"
-	"math/rand"
 	"strconv"
 	"strings"
-	"time"
 
 	clients "github.com/litmuschaos/litmus-go/pkg/clients"
 	"github.com/litmuschaos/litmus-go/pkg/events"
@@ -29,7 +27,7 @@ func PrepareDiskFill(experimentsDetails *experimentTypes.ExperimentDetails, clie
 	execCommandDetails := exec.PodDetails{}
 
 	//Select application pod & node for the disk fill chaos
-	appName, appNodeName, err := GetApplicationPod(experimentsDetails, clients)
+	appName, appNodeName, err := common.GetPodAndNodeName(experimentsDetails.AppNS, experimentsDetails.TargetPod, experimentsDetails.AppLabel, clients)
 	if err != nil {
 		return errors.Errorf("Unable to get the application pod and node name due to, err: %v", err)
 	}
@@ -148,22 +146,6 @@ func PrepareDiskFill(experimentsDetails *experimentTypes.ExperimentDetails, clie
 		common.WaitForDuration(experimentsDetails.RampTime)
 	}
 	return nil
-}
-
-//GetApplicationPod will select a random replica of application pod for chaos
-//It will also get the node name of the application pod
-func GetApplicationPod(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets) (string, string, error) {
-	podList, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).List(v1.ListOptions{LabelSelector: experimentsDetails.AppLabel})
-	if err != nil || len(podList.Items) == 0 {
-		return "", "", errors.Wrapf(err, "Fail to get the application pod in %v namespace", experimentsDetails.AppNS)
-	}
-
-	rand.Seed(time.Now().Unix())
-	randomIndex := rand.Intn(len(podList.Items))
-	applicationName := podList.Items[randomIndex].Name
-	nodeName := podList.Items[randomIndex].Spec.NodeName
-
-	return applicationName, nodeName, nil
 }
 
 //GetTargetContainer will fetch the container name from application pod

--- a/chaoslib/litmus/pod_delete/pod-delete.go
+++ b/chaoslib/litmus/pod_delete/pod-delete.go
@@ -65,11 +65,25 @@ func PodDeleteChaos(experimentsDetails *experimentTypes.ExperimentDetails, clien
 	var GracePeriod int64 = 0
 
 	for x := 0; x < experimentsDetails.Iterations; x++ {
-		//Getting the list of all the target pod for deletion
-		targetPodList, err := PreparePodList(experimentsDetails, clients)
+
+		targetPodList := []string{}
+
+		isPodAvailable, err := common.CheckForAvailibiltyOfPod(experimentsDetails.AppNS, experimentsDetails.TargetPod, clients)
 		if err != nil {
 			return err
 		}
+
+		if isPodAvailable {
+			targetPodList = append(targetPodList, experimentsDetails.TargetPod)
+
+		} else {
+			log.Info("selecting a random pod with specified labels")
+			targetPodList, err = PreparePodList(experimentsDetails, clients)
+			if err != nil {
+				return err
+			}
+		}
+
 		log.InfoWithValues("[Info]: Killing the following pods", logrus.Fields{
 			"PodList": targetPodList})
 

--- a/chaoslib/pumba/container_kill/container-kill.go
+++ b/chaoslib/pumba/container_kill/container-kill.go
@@ -1,7 +1,6 @@
 package container_kill
 
 import (
-	"math/rand"
 	"strconv"
 	"time"
 
@@ -22,8 +21,8 @@ import (
 //PrepareContainerKill contains the prepration steps before chaos injection
 func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
-	//Select application pod & node name for container-kill
-	appName, appNodeName, err := GetApplicationPod(experimentsDetails, clients)
+	//Select application pod & node for the container kill chaos
+	appName, appNodeName, err := common.GetPodAndNodeName(experimentsDetails.AppNS, experimentsDetails.TargetPod, experimentsDetails.AppLabel, clients)
 	if err != nil {
 		return errors.Errorf("Unable to get the application pod and node name due to, err: %v", err)
 	}
@@ -100,22 +99,6 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 		common.WaitForDuration(experimentsDetails.RampTime)
 	}
 	return nil
-}
-
-//GetApplicationPod will select a random replica of application pod for chaos
-//It will also get the node name of the application pod
-func GetApplicationPod(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets) (string, string, error) {
-	podList, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).List(v1.ListOptions{LabelSelector: experimentsDetails.AppLabel})
-	if err != nil || len(podList.Items) == 0 {
-		return "", "", errors.Wrapf(err, "Fail to get the application pod in %v namespace", experimentsDetails.AppNS)
-	}
-
-	rand.Seed(time.Now().Unix())
-	randomIndex := rand.Intn(len(podList.Items))
-	applicationName := podList.Items[randomIndex].Name
-	nodeName := podList.Items[randomIndex].Spec.NodeName
-
-	return applicationName, nodeName, nil
 }
 
 //GetTargetContainer will fetch the conatiner name from application pod

--- a/chaoslib/pumba/network_chaos/network-chaos.go
+++ b/chaoslib/pumba/network_chaos/network-chaos.go
@@ -1,9 +1,7 @@
 package network_chaos
 
 import (
-	"math/rand"
 	"strconv"
-	"time"
 
 	clients "github.com/litmuschaos/litmus-go/pkg/clients"
 	"github.com/litmuschaos/litmus-go/pkg/events"
@@ -23,8 +21,8 @@ var err error
 //PreparePodNetworkChaos contains the prepration steps before chaos injection
 func PreparePodNetworkChaos(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
-	//Select application pod for network chaos
-	appName, appNodeName, err := GetApplicationPod(experimentsDetails, clients)
+	//Select application pod & node for the network chaos
+	appName, appNodeName, err := common.GetPodAndNodeName(experimentsDetails.AppNS, experimentsDetails.TargetPod, experimentsDetails.AppLabel, clients)
 	if err != nil {
 		return errors.Errorf("Unable to get the application pod and node name due to, err: %v", err)
 	}
@@ -91,22 +89,6 @@ func PreparePodNetworkChaos(experimentsDetails *experimentTypes.ExperimentDetail
 		common.WaitForDuration(experimentsDetails.RampTime)
 	}
 	return nil
-}
-
-//GetApplicationPod will select a random replica of application pod for chaos
-//It will also get the node name of the application pod
-func GetApplicationPod(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets) (string, string, error) {
-	podList, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).List(v1.ListOptions{LabelSelector: experimentsDetails.AppLabel})
-	if err != nil || len(podList.Items) == 0 {
-		return "", "", errors.Wrapf(err, "Fail to get the application pod in %v namespace", experimentsDetails.AppNS)
-	}
-
-	rand.Seed(time.Now().Unix())
-	randomIndex := rand.Intn(len(podList.Items))
-	applicationName := podList.Items[randomIndex].Name
-	nodeName := podList.Items[randomIndex].Spec.NodeName
-
-	return applicationName, nodeName, nil
 }
 
 //GetTargetContainer will fetch the conatiner name from application pod

--- a/experiments/generic/container-kill/test/test.yml
+++ b/experiments/generic/container-kill/test/test.yml
@@ -50,6 +50,9 @@ spec:
 
           - name: LIB 
             value: 'pumba'
+          
+          - name: TARGET_POD
+            value: ''
 
           - name: CHAOS_SERVICE_ACCOUNT
             valueFrom:

--- a/experiments/generic/disk-fill/test/test.yml
+++ b/experiments/generic/disk-fill/test/test.yml
@@ -39,6 +39,9 @@ spec:
           - name: LIB
             value: 'litmus'
 
+          - name: TARGET_POD
+            value: ''
+
           - name: LIB_IMAGE
             value: 'litmuschaos/go-runner:ci'
 

--- a/experiments/generic/pod-cpu-hog/test/test.yml
+++ b/experiments/generic/pod-cpu-hog/test/test.yml
@@ -46,6 +46,9 @@ spec:
           - name: LIB
             value: 'litmus'
 
+          - name: TARGET_POD
+            value: ''
+
           - name: CHAOS_NAMESPACE
             value: 'default'
 

--- a/experiments/generic/pod-delete/test/test.yml
+++ b/experiments/generic/pod-delete/test/test.yml
@@ -42,6 +42,9 @@ spec:
           - name: LIB
             value: 'litmus'
 
+          - name: TARGET_POD
+            value: ''
+
           - name: CHAOS_NAMESPACE
             value: 'default'
 

--- a/experiments/generic/pod-memory-hog/test/test.yml
+++ b/experiments/generic/pod-memory-hog/test/test.yml
@@ -46,6 +46,9 @@ spec:
           - name: LIB
             value: 'litmus'
 
+          - name: TARGET_POD
+            value: ''
+
           - name: CHAOS_NAMESPACE
             value: 'default'
 

--- a/experiments/generic/pod-network-corruption/test/test.yml
+++ b/experiments/generic/pod-network-corruption/test/test.yml
@@ -48,6 +48,9 @@ spec:
           - name: LIB
             value: 'pumba'
 
+          - name: TARGET_POD
+            value: ''
+
           - name: LIB_IMAGE
             value: 'litmuschaos/go-runner:ci'
 

--- a/experiments/generic/pod-network-duplication/test/test.yml
+++ b/experiments/generic/pod-network-duplication/test/test.yml
@@ -48,6 +48,9 @@ spec:
           - name: LIB
             value: 'pumba'
 
+          - name: TARGET_POD
+            value: ''
+
           - name: LIB_IMAGE
             value: 'litmuschaos/go-runner:ci'
 

--- a/experiments/generic/pod-network-latency/test/test.yml
+++ b/experiments/generic/pod-network-latency/test/test.yml
@@ -51,6 +51,9 @@ spec:
           - name: LIB
             value: 'pumba'
 
+          - name: TARGET_POD
+            value: ''
+
           - name: LIB_IMAGE
             value: 'litmuschaos/go-runner:ci'
 

--- a/experiments/generic/pod-network-loss/test/test.yml
+++ b/experiments/generic/pod-network-loss/test/test.yml
@@ -48,6 +48,9 @@ spec:
           - name: LIB
             value: 'pumba'
 
+          - name: TARGET_POD
+            value: ''
+
           - name: LIB_IMAGE
             value: 'litmuschaos/go-runner:ci'
 

--- a/pkg/generic/container-kill/environment/environment.go
+++ b/pkg/generic/container-kill/environment/environment.go
@@ -31,6 +31,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	experimentDetails.ContainerPath = Getenv("CONTAINER_PATH", "/run/containerd/containerd.sock")
 	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
+	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/container-kill/types/types.go
+++ b/pkg/generic/container-kill/types/types.go
@@ -27,5 +27,5 @@ type ExperimentDetails struct {
 	RunID               string
 	Timeout             int
 	Delay               int
-	ApplicationPod      string
+	TargetPod           string
 }

--- a/pkg/generic/disk-fill/environment/environment.go
+++ b/pkg/generic/disk-fill/environment/environment.go
@@ -31,6 +31,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
 	experimentDetails.LIBImage = Getenv("LIB_IMAGE", "litmuschaos/go-runner:latest")
+	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/disk-fill/types/types.go
+++ b/pkg/generic/disk-fill/types/types.go
@@ -26,4 +26,5 @@ type ExperimentDetails struct {
 	Timeout          int
 	Delay            int
 	LIBImage         string
+	TargetPod        string
 }

--- a/pkg/generic/network-chaos/environment/environment.go
+++ b/pkg/generic/network-chaos/environment/environment.go
@@ -34,6 +34,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	experimentDetails.TCImage = Getenv("TC_IMAGE", "gaiadocker/iproute2")
 	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
+	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/network-chaos/types/types.go
+++ b/pkg/generic/network-chaos/types/types.go
@@ -29,4 +29,5 @@ type ExperimentDetails struct {
 	TCImage                            string
 	Timeout                            int
 	Delay                              int
+	TargetPod                          string
 }

--- a/pkg/generic/pod-cpu-hog/environment/environment.go
+++ b/pkg/generic/pod-cpu-hog/environment/environment.go
@@ -28,6 +28,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	experimentDetails.PodsAffectedPerc, _ = strconv.Atoi(Getenv("PODS_AFFECTED_PERC", "0"))
 	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
+	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/pod-cpu-hog/types/types.go
+++ b/pkg/generic/pod-cpu-hog/types/types.go
@@ -23,4 +23,5 @@ type ExperimentDetails struct {
 	PodsAffectedPerc int
 	Timeout          int
 	Delay            int
+	TargetPod        string
 }

--- a/pkg/generic/pod-delete/environment/environment.go
+++ b/pkg/generic/pod-delete/environment/environment.go
@@ -30,6 +30,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	experimentDetails.Force, _ = strconv.ParseBool(Getenv("FORCE", "false"))
 	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
+	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/pod-delete/types/types.go
+++ b/pkg/generic/pod-delete/types/types.go
@@ -25,4 +25,5 @@ type ExperimentDetails struct {
 	Iterations          int
 	Timeout             int
 	Delay               int
+	TargetPod           string
 }

--- a/pkg/generic/pod-memory-hog/environment/environment.go
+++ b/pkg/generic/pod-memory-hog/environment/environment.go
@@ -28,6 +28,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	experimentDetails.MemoryConsumption, _ = strconv.Atoi(Getenv("MEMORY_CONSUMPTION", "500"))
 	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
+	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/pod-memory-hog/types/types.go
+++ b/pkg/generic/pod-memory-hog/types/types.go
@@ -23,4 +23,5 @@ type ExperimentDetails struct {
 	MemoryConsumption int
 	Timeout           int
 	Delay             int
+	TargetPod         string
 }

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -7,6 +7,7 @@ import (
 	"github.com/litmuschaos/litmus-go/pkg/clients"
 	"github.com/litmuschaos/litmus-go/pkg/utils/retry"
 	"github.com/pkg/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,4 +48,53 @@ func DeletePod(podName, podLabel, namespace string, timeout, delay int, clients 
 		})
 
 	return err
+}
+
+// CheckForAvailibiltyOfPod check the availibility of the specified pod
+func CheckForAvailibiltyOfPod(namespace, name string, clients clients.ClientSets) (bool, error) {
+
+	if name == "" {
+		return false, nil
+	}
+	_, err := clients.KubeClient.CoreV1().Pods(namespace).Get(name, v1.GetOptions{})
+
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return false, err
+	} else if err != nil && k8serrors.IsNotFound(err) {
+		return false, nil
+	}
+	return true, nil
+}
+
+//GetPodAndNodeName will select the pod & node name for the chaos
+// if the targetpod is not available it will derive the pod name randomly from the specified labels
+func GetPodAndNodeName(namespace, targetPod, appLabels string, clients clients.ClientSets) (string, string, error) {
+	var podName, nodeName string
+	podList, err := clients.KubeClient.CoreV1().Pods(namespace).List(v1.ListOptions{LabelSelector: appLabels})
+	if err != nil || len(podList.Items) == 0 {
+		return "", "", errors.Wrapf(err, "Fail to get the application pod in %v namespace", namespace)
+	}
+
+	isPodAvailable, err := CheckForAvailibiltyOfPod(namespace, targetPod, clients)
+	if err != nil {
+		return "", "", err
+	}
+
+	// getting the node name, if the target pod is defined
+	// else select a random target pod from the specified labels
+	if isPodAvailable {
+		pod, err := clients.KubeClient.CoreV1().Pods(namespace).Get(targetPod, v1.GetOptions{})
+		if err != nil {
+			return "", "", err
+		}
+		podName = targetPod
+		nodeName = pod.Spec.NodeName
+	} else {
+		rand.Seed(time.Now().Unix())
+		randomIndex := rand.Intn(len(podList.Items))
+		podName = podList.Items[randomIndex].Name
+		nodeName = podList.Items[randomIndex].Spec.NodeName
+	}
+
+	return podName, nodeName, nil
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding ability to provide the target-pod name as an env in the experiment/engine. If the target-pod name is not defined or not found. it will select a random pod.

### Tested For
- [x] Container-kill for containerd
- [x] Container-kill for docker
- [x] Pod-delete
- [x] disk-fill
- [x] pod-cpu-hog
- [x] pod-memory-hog
- [x] network-chaos