### PR TITLE
chore(container-kill): Adding all the CRI in litmus lib

### DIFF
--- a/chaoslib/litmus/container_kill/container-kill.go
+++ b/chaoslib/litmus/container_kill/container-kill.go
@@ -129,7 +129,10 @@ func GetTargetContainer(experimentsDetails *experimentTypes.ExperimentDetails, a
 // CreateHelperPod derive the attributes for helper pod and create the helper pod
 func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, podName, nodeName string) error {
 
-	privilegedEnable := true
+	privilegedEnable := false
+	if experimentsDetails.ContainerRuntime == "crio" {
+		privilegedEnable = true
+	}
 
 	helperPod := &apiv1.Pod{
 		ObjectMeta: v1.ObjectMeta{

--- a/experiments/generic/container-kill/container-kill.go
+++ b/experiments/generic/container-kill/container-kill.go
@@ -107,22 +107,24 @@ func main() {
 	}
 
 	// Including the litmus lib for container-kill
-	if experimentsDetails.ChaosLib == "litmus" {
+	if experimentsDetails.ChaosLib == "litmus" && (experimentsDetails.ContainerRuntime == "containerd" || experimentsDetails.ContainerRuntime == "crio") {
 		err = litmusLIB.PrepareContainerKill(&experimentsDetails, clients, &resultDetails, &eventsDetails, &chaosDetails)
 		if err != nil {
-			log.Errorf("Chaos injection failed due to %v\n", err)
 			failStep := "Executing litmus lib for the container-kill"
 			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
-			return
+			log.Fatalf("Chaos injection failed due to %v\n", err)
 		}
-	} else {
+	} else if experimentsDetails.ChaosLib == "litmus" && experimentsDetails.ContainerRuntime == "docker" {
 		err = pumbaLIB.PrepareContainerKill(&experimentsDetails, clients, &resultDetails, &eventsDetails, &chaosDetails)
 		if err != nil {
-			log.Errorf("Chaos injection failed due to %v\n", err)
 			failStep := "Executing pumba lib for the container-kill"
 			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
-			return
+			log.Fatalf("Chaos injection failed due to %v\n", err)
 		}
+	} else {
+		failStep := "lib and container-runtime combination not supported!"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		log.Fatal("lib and container-runtime combination not supported, provide the correct value of lib & container-runtime")
 	}
 
 	log.Infof("[Confirmation]: %v chaos has been injected successfully", experimentsDetails.ExperimentName)

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.37.4/go.mod h1:NHPJ89PdicEuT9hdPXMROBD91xc5uRDxsMtSB16k7hw=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/Azure/azure-sdk-for-go v32.5.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=

--- a/pkg/generic/container-kill/environment/environment.go
+++ b/pkg/generic/container-kill/environment/environment.go
@@ -18,7 +18,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	experimentDetails.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION", "20"))
 	experimentDetails.ChaosInterval, _ = strconv.Atoi(Getenv("CHAOS_INTERVAL", "10"))
 	experimentDetails.RampTime, _ = strconv.Atoi(Getenv("RAMP_TIME", "0"))
-	experimentDetails.ChaosLib = Getenv("LIB", "pumba")
+	experimentDetails.ChaosLib = Getenv("LIB", "litmus")
 	experimentDetails.AppNS = Getenv("APP_NAMESPACE", "")
 	experimentDetails.AppLabel = Getenv("APP_LABEL", "")
 	experimentDetails.AppKind = Getenv("APP_KIND", "")
@@ -32,6 +32,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
 	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
+	experimentDetails.ContainerRuntime = Getenv("CONTAINER_RUNTIME", "docker")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/container-kill/types/types.go
+++ b/pkg/generic/container-kill/types/types.go
@@ -28,4 +28,5 @@ type ExperimentDetails struct {
 	Timeout             int
 	Delay               int
 	TargetPod           string
+	ContainerRuntime    string
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -10,6 +10,12 @@ func Fatalf(msg string, err error) {
 	logrus.WithFields(logrus.Fields{}).Fatalf(msg, err)
 }
 
+//Fatal Logs first and then calls `logger.Exit(1)`
+// logging level is set to Panic.
+func Fatal(msg string) {
+	logrus.WithFields(logrus.Fields{}).Fatal(msg)
+}
+
 //Infof log the General operational entries about what's going on inside the application
 func Infof(msg string, val ...interface{}) {
 	logrus.WithFields(logrus.Fields{}).Infof(msg, val...)


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding all the CRI in the litmus lib.

- The value of container-runtime can be provided in the `CONTAINER_RUNTIME` env. It supports docker, containerd and crio values.
