### PR TITLE
(cmd_fixes)fix: make chaos inject and kill cmds as tunable

### DIFF
--- a/pkg/generic/pod-cpu-hog/environment/environment.go
+++ b/pkg/generic/pod-cpu-hog/environment/environment.go
@@ -29,6 +29,8 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
 	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
+	experimentDetails.ChaosInjectCmd = Getenv("CHAOS_INJECT_COMMAND", "md5sum /dev/zero")
+	experimentDetails.ChaosKillCmd = Getenv("CHAOS_KILL_COMMAND", "kill $(find /proc -name exe -lname '*/md5sum' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1)")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/pod-cpu-hog/types/types.go
+++ b/pkg/generic/pod-cpu-hog/types/types.go
@@ -24,4 +24,6 @@ type ExperimentDetails struct {
 	Timeout          int
 	Delay            int
 	TargetPod        string
+	ChaosInjectCmd	 string
+	ChaosKillCmd	 string
 }

--- a/pkg/generic/pod-memory-hog/environment/environment.go
+++ b/pkg/generic/pod-memory-hog/environment/environment.go
@@ -29,6 +29,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
 	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
+	experimentDetails.ChaosKillCmd = Getenv("CHAOS_KILL_COMMAND", "kill $(find /proc -name exe -lname '*/dd' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1)")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/pod-memory-hog/types/types.go
+++ b/pkg/generic/pod-memory-hog/types/types.go
@@ -24,4 +24,5 @@ type ExperimentDetails struct {
 	Timeout           int
 	Delay             int
 	TargetPod         string
+	ChaosKillCmd	  string
 }


### PR DESCRIPTION
- Introduces the CHAOS_INJECT_COMMAND & CHAOS_KILL_COMMAND env vars to control the chaos processes declaratively

Signed-off-by: ksatchit <karthik.s@mayadata.io>