### PR TITLE
fix(pod-memory-hog): Fixing the oom-kill(137) error

### DIFF
--- a/chaoslib/litmus/pod-memory-hog/lib/pod-memory-hog.go
+++ b/chaoslib/litmus/pod-memory-hog/lib/pod-memory-hog.go
@@ -108,7 +108,7 @@ func ExperimentMemory(experimentsDetails *experimentTypes.ExperimentDetails, cli
 				case err := <-stressErr:
 					// skipping the execution, if recieved any error other than 137, while executing stress command and marked result as fail
 					// it will ignore the error code 137(oom kill), it will skip further execution and marked the result as pass
-					// oom kill is happend if memory to be stressed exceed than the resource limit for the target container
+					// oom kill occurs if memory to be stressed exceed than the resource limit for the target container
 					if err != nil {
 						if strings.Contains(err.Error(), "137") {
 							return nil

--- a/pkg/utils/exec/exec.go
+++ b/pkg/utils/exec/exec.go
@@ -68,7 +68,11 @@ func Exec(commandDetails *PodDetails, clients clients.ClientSets, command []stri
 	if err != nil {
 		errorCode := strings.Contains(err.Error(), "143")
 		if errorCode != true {
-			log.Infof("[Prepare]: Unable to run command inside container due to, err : %v", err.Error())
+			if strings.Contains(err.Error(), "137") {
+				log.Warn("[Skip]: Skipping chaos execution as stressed value exceed resource limit value")
+			} else {
+				log.Infof("[Prepare]: Unable to run command inside container due to, err : %v", err.Error())
+			}
 			return "", err
 		}
 	}

--- a/pkg/utils/exec/exec.go
+++ b/pkg/utils/exec/exec.go
@@ -69,7 +69,7 @@ func Exec(commandDetails *PodDetails, clients clients.ClientSets, command []stri
 		errorCode := strings.Contains(err.Error(), "143")
 		if errorCode != true {
 			if strings.Contains(err.Error(), "137") {
-				log.Warn("[Skip]: Skipping chaos execution as stressed value exceed resource limit value")
+				log.Warn("Chaos process OOM killed as the provided value exceeds resource limits")
 			} else {
 				log.Infof("[Prepare]: Unable to run command inside container due to, err : %v", err.Error())
 			}


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- When chaos-experiment try to eat more memory than the limit value for the target container. Either the target container got restarted or the dd cmd/stress process got killed immediately(block size has the same value as requested m/m to be stressed). In both scenarios, the process won't be available for cleanup. 
- Skipping the cleanup portion, if faced oom-kill(137 error-code) with a warning as it crossed the limit value otherwise it will clean the process.