### PR TITLE
chore(helper): Merge helper image with go-runner for kubelet-service-kill

### DIFF
--- a/build/litmus-go/Dockerfile
+++ b/build/litmus-go/Dockerfile
@@ -21,13 +21,12 @@ RUN apt-get install stress
 WORKDIR /code/stress-ng
 RUN STATIC=1 make
 
-FROM alpine:latest
+FROM ubuntu:bionic
 
 LABEL maintainer="LitmusChaos"
 
 #Installing necessary ubuntu packages
-RUN apk update && apk add curl bash
-RUN apk add --no-cache libc6-compat
+RUN apt-get update && apt-get install -y curl bash systemd 
 
 #Installing Kubectl
 ENV KUBE_LATEST_VERSION="v1.18.0"

--- a/chaoslib/litmus/kubelet-service-kill/lib/kubelet-service-kill.go
+++ b/chaoslib/litmus/kubelet-service-kill/lib/kubelet-service-kill.go
@@ -161,7 +161,7 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 			Containers: []apiv1.Container{
 				{
 					Name:            experimentsDetails.ExperimentName,
-					Image:           "ubuntu:16.04",
+					Image:           experimentsDetails.LIBImage,
 					ImagePullPolicy: apiv1.PullAlways,
 					Command: []string{
 						"/bin/bash",

--- a/pkg/generic/kubelet-service-kill/environment/environment.go
+++ b/pkg/generic/kubelet-service-kill/environment/environment.go
@@ -28,7 +28,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.AppNode = Getenv("APP_NODE", "")
 	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
-	experimentDetails.LIBImage = Getenv("LIB_IMAGE", "litmuschaos/go-runner:latest")
+	experimentDetails.LIBImage = Getenv("LIB_IMAGE", "litmuschaos/go-runner:ci")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/kubelet-service-kill/environment/environment.go
+++ b/pkg/generic/kubelet-service-kill/environment/environment.go
@@ -28,6 +28,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.AppNode = Getenv("APP_NODE", "")
 	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
+	experimentDetails.LIBImage = Getenv("LIB_IMAGE", "litmuschaos/go-runner:latest")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/kubelet-service-kill/types/types.go
+++ b/pkg/generic/kubelet-service-kill/types/types.go
@@ -24,4 +24,5 @@ type ExperimentDetails struct {
 	Timeout          int
 	Delay            int
 	Annotations      map[string]string
+	LIBImage         string
 }


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

#### Issue:
- fixes: https://github.com/litmuschaos/litmus/issues/2037

**_This PR is for:_**

- This PR is for merging helper image with the go-runner image for kubelet service kill experiment.

- The `ubuntu:bionic` image used is having an image size of size in 64MB.