### PR TITLE
fix(pumba-lib): fixing regex for the pumba pod

### DIFF
--- a/chaoslib/pumba/network-chaos/lib/network-chaos.go
+++ b/chaoslib/pumba/network-chaos/lib/network-chaos.go
@@ -57,10 +57,12 @@ func PrepareAndInjectChaos(experimentsDetails *experimentTypes.ExperimentDetails
 			"PodName":  pod.Name,
 			"NodeName": pod.Spec.NodeName,
 		})
-
-		args = append(args, "re2:k8s_POD_"+pod.Name+"_"+experimentsDetails.AppNS)
-		log.Infof("Arguments for running %v are %v", experimentsDetails.ExperimentName, args)
-		err = CreateHelperPod(experimentsDetails, clients, pod.Spec.NodeName, runID, args)
+		// args contains details of the specific chaos injection
+		// constructing `argsWithRegex` based on updated regex with a diff pod name
+		// without extending/concatenating the args var itself
+		argsWithRegex := append(args, "re2:k8s_POD_"+pod.Name+"_"+experimentsDetails.AppNS)
+		log.Infof("Arguments for running %v are %v", experimentsDetails.ExperimentName, argsWithRegex)
+		err = CreateHelperPod(experimentsDetails, clients, pod.Spec.NodeName, runID, argsWithRegex)
 		if err != nil {
 			return errors.Errorf("Unable to create the helper pod, err: %v", err)
 		}


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- It was appending regex with the same args in each iteration means we were passing cumulative value. It will fail if targeted pod > 1 as regex correspond to higher indexes have cumulative regex( regex expression belongs to other replicas as well). 