### PR TITLE
(chore)dockerfile: Optimize Dockerfile

### DIFF
--- a/build/litmus-go/Dockerfile
+++ b/build/litmus-go/Dockerfile
@@ -1,29 +1,12 @@
-FROM ubuntu:18.04 as builder
-
-# intall gcc and supporting packages
-RUN apt-get update && apt-get install -yq make gcc
-
-WORKDIR /code
-
-# download stress-ng sources
-ARG STRESS_NG_VERSION
-ENV STRESS_NG_VERSION ${STRESS_NG_VERSION:-0.10.10}
-ADD https://github.com/ColinIanKing/stress-ng/archive/V${STRESS_NG_VERSION}.tar.gz .
-RUN tar -xf V${STRESS_NG_VERSION}.tar.gz && mv stress-ng-${STRESS_NG_VERSION} stress-ng
-
-# make static version
-WORKDIR /code/stress-ng
-RUN STATIC=1 make
-
 FROM ubuntu:bionic
 
 LABEL maintainer="LitmusChaos"
 
 #Installing necessary ubuntu packages
-RUN apt-get update && apt-get install -y curl bash systemd iproute2
+RUN apt-get update && apt-get install -y curl bash systemd iproute2 stress-ng
 
 #Installing Kubectl
-ENV KUBE_LATEST_VERSION="v1.18.0"
+ENV KUBE_LATEST_VERSION="v1.19.0"
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
@@ -34,8 +17,6 @@ RUN curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.16
 #Installing pumba binaries
 ENV PUMBA_VERSION="0.6.5"
 RUN curl -L https://github.com/alexei-led/pumba/releases/download/${PUMBA_VERSION}/pumba_linux_amd64 --output /usr/local/bin/pumba && chmod +x /usr/local/bin/pumba
-
-COPY --from=builder /code/stress-ng/stress-ng /
 
 #Copying Necessary Files
 COPY ./build/_output ./litmus/experiments

--- a/chaoslib/litmus/node-cpu-hog/lib/node-cpu-hog.go
+++ b/chaoslib/litmus/node-cpu-hog/lib/node-cpu-hog.go
@@ -144,7 +144,7 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 					Image:           experimentsDetails.LIBImage,
 					ImagePullPolicy: apiv1.PullAlways,
 					Command: []string{
-						"/stress-ng",
+						"stress-ng",
 					},
 					Args: []string{
 						"--cpu",

--- a/chaoslib/litmus/node-memory-hog/lib/node-memory-hog.go
+++ b/chaoslib/litmus/node-memory-hog/lib/node-memory-hog.go
@@ -164,7 +164,7 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 					Image:           experimentsDetails.LIBImage,
 					ImagePullPolicy: apiv1.PullAlways,
 					Command: []string{
-						"/stress-ng",
+						"stress-ng",
 					},
 					Args: []string{
 						"--vm",


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

This PR is for:

- Optimising Dockerfile by removing stress-ng build in dockerfile and removing the multi-stage build.

Stress-ng is directly used in:
- node-cpu-hog
- node-mem-hog