### PR TITLE
Add nodeRestart via SSH experiment

### DIFF
--- a/bin/go-runner.go
+++ b/bin/go-runner.go
@@ -20,6 +20,7 @@ import (
 	nodeDrain "github.com/litmuschaos/litmus-go/experiments/generic/node-drain/experiment"
 	nodeIOStress "github.com/litmuschaos/litmus-go/experiments/generic/node-io-stress/experiment"
 	nodeMemoryHog "github.com/litmuschaos/litmus-go/experiments/generic/node-memory-hog/experiment"
+	nodeRestart "github.com/litmuschaos/litmus-go/experiments/generic/node-restart/experiment"
 	nodeTaint "github.com/litmuschaos/litmus-go/experiments/generic/node-taint/experiment"
 	podAutoscaler "github.com/litmuschaos/litmus-go/experiments/generic/pod-autoscaler/experiment"
 	podCPUHog "github.com/litmuschaos/litmus-go/experiments/generic/pod-cpu-hog/experiment"
@@ -31,8 +32,8 @@ import (
 	podNetworkLatency "github.com/litmuschaos/litmus-go/experiments/generic/pod-network-latency/experiment"
 	podNetworkLoss "github.com/litmuschaos/litmus-go/experiments/generic/pod-network-loss/experiment"
 	kafkaBrokerPodFailure "github.com/litmuschaos/litmus-go/experiments/kafka/kafka-broker-pod-failure/experiment"
-	ec2terminate "github.com/litmuschaos/litmus-go/experiments/kube-aws/ec2-terminate/experiment"
 	ebsLoss "github.com/litmuschaos/litmus-go/experiments/kube-aws/ebs-loss/experiment"
+	ec2terminate "github.com/litmuschaos/litmus-go/experiments/kube-aws/ec2-terminate/experiment"
 
 	"github.com/litmuschaos/litmus-go/pkg/clients"
 	"github.com/litmuschaos/litmus-go/pkg/log"
@@ -106,6 +107,8 @@ func main() {
 		ec2terminate.EC2Terminate(clients)
 	case "ebs-loss":
 		ebsLoss.EBSLoss(clients)
+	case "node-restart":
+		nodeRestart.NodeRestart(clients)
 	default:
 		log.Fatalf("Unsupported -name %v, please provide the correct value of -name args", *experimentName)
 	}

--- a/build/litmus-go/Dockerfile
+++ b/build/litmus-go/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:bionic
 LABEL maintainer="LitmusChaos"
 
 #Installing necessary ubuntu packages
-RUN apt-get update && apt-get install -y curl bash systemd iproute2 stress-ng
+RUN apt-get update && apt-get install -y curl bash systemd iproute2 stress-ng openssh-client
 
 #Installing Kubectl
 ENV KUBE_LATEST_VERSION="v1.19.0"

--- a/chaoslib/litmus/node-restart/lib/node-restart.go
+++ b/chaoslib/litmus/node-restart/lib/node-restart.go
@@ -1,0 +1,197 @@
+package lib
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+
+	clients "github.com/litmuschaos/litmus-go/pkg/clients"
+	"github.com/litmuschaos/litmus-go/pkg/events"
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/generic/node-restart/types"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/status"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/litmuschaos/litmus-go/pkg/utils/common"
+	"github.com/pkg/errors"
+	apiv1 "k8s.io/api/core/v1"
+	k8stypes "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var err error
+
+const (
+	secretName      string = "id-rsa"
+	privateKeyMount string = "/mnt"
+	privateKeyPath  string = "/mnt/ssh-privatekey"
+	emptyDirMount   string = "/data"
+	emptyDirPath    string = "/data/ssh-privatekey"
+
+	privateKeySecret string = "private-key-cm-"
+	emptyDirVolume   string = "empty-dir-"
+)
+
+// PrepareNodeRestart contains preparation steps before chaos injection
+func PrepareNodeRestart(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+
+	//Select the node
+	if experimentsDetails.TargetNode == "" {
+		//Select node for node-restart
+		targetNode, err := GetNode(experimentsDetails, clients)
+		if err != nil {
+			return err
+		}
+
+		experimentsDetails.TargetNode = targetNode.Spec.NodeName
+		experimentsDetails.TargetNodeIP = targetNode.Status.HostIP
+	}
+
+	// Checking the status of target node
+	log.Info("[Status]: Getting the status of target node")
+	err = status.CheckNodeStatus(experimentsDetails.TargetNode, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	if err != nil {
+		return errors.Errorf("Target node is not in the ready state, you may need to manually recover the node: %v", err)
+	}
+
+	experimentsDetails.RunID = common.GetRunID()
+	appLabel := "name=" + experimentsDetails.ExperimentName + "-" + experimentsDetails.RunID
+
+	//Waiting for the ramp time before chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time before injecting chaos", strconv.Itoa(experimentsDetails.RampTime))
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+
+	if experimentsDetails.EngineName != "" {
+		msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on " + experimentsDetails.TargetNode + " node"
+		types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
+		events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+	}
+
+	// Get Chaos Pod Annotation
+	experimentsDetails.Annotations, err = common.GetChaosPodAnnotation(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+	if err != nil {
+		return errors.Errorf("unable to get annotation, due to %v", err)
+	}
+
+	// Creating the helper pod to perform node restart
+	err = CreateHelperPod(experimentsDetails, clients)
+	if err != nil {
+		return errors.Errorf("Unable to create the helper pod, err: %v", err)
+	}
+
+	//Checking the status of helper pod
+	log.Info("[Status]: Checking the status of the helper pod")
+	err = status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, appLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	if err != nil {
+		return errors.Errorf("helper pod is not in running state, err: %v", err)
+	}
+
+	// Wait till the completion of helper pod
+	log.Infof("[Wait]: Waiting for %vs till the completion of the helper pod", strconv.Itoa(experimentsDetails.ChaosDuration+30))
+
+	podStatus, err := status.WaitForCompletion(experimentsDetails.ChaosNamespace, appLabel, clients, experimentsDetails.ChaosDuration+30, experimentsDetails.ExperimentName)
+	if err != nil || podStatus == "Failed" {
+		return errors.Errorf("helper pod failed due to, err: %v", err)
+	}
+
+	// Checking the status of application node
+	log.Info("[Status]: Getting the status of application node")
+	err = status.CheckNodeStatus(experimentsDetails.TargetNode, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	if err != nil {
+		log.Warn("Application node is not in the ready state, you may need to manually recover the node")
+	}
+
+	//Deleting the helper pod
+	log.Info("[Cleanup]: Deleting the helper pod")
+	err = common.DeletePod(experimentsDetails.ExperimentName+"-"+experimentsDetails.RunID, appLabel, experimentsDetails.ChaosNamespace, chaosDetails.Timeout, chaosDetails.Delay, clients)
+	if err != nil {
+		return errors.Errorf("Unable to delete the helper pod, err: %v", err)
+	}
+
+	//Waiting for the ramp time after chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", strconv.Itoa(experimentsDetails.RampTime))
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+	return nil
+}
+
+// CreateHelperPod derive the attributes for helper pod and create the helper pod
+func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets) error {
+	// This method is attaching emptyDir along with secret volume, and copy data from secret
+	// to the emptyDir, because secret is mounted as readonly and with 777 perms and it can't be changed
+	// because of: https://github.com/kubernetes/kubernetes/issues/57923
+
+	helperPod := &apiv1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      experimentsDetails.ExperimentName + "-" + experimentsDetails.RunID,
+			Namespace: experimentsDetails.ChaosNamespace,
+			Labels: map[string]string{
+				"app":      experimentsDetails.ExperimentName,
+				"name":     experimentsDetails.ExperimentName + "-" + experimentsDetails.RunID,
+				"chaosUID": string(experimentsDetails.ChaosUID),
+			},
+			Annotations: experimentsDetails.Annotations,
+		},
+		Spec: apiv1.PodSpec{
+			RestartPolicy: apiv1.RestartPolicyNever,
+			NodeName:      experimentsDetails.TargetNode,
+			Containers: []apiv1.Container{
+				{
+					Name:            experimentsDetails.ExperimentName,
+					Image:           experimentsDetails.LIBImage,
+					ImagePullPolicy: apiv1.PullIfNotPresent,
+					Command: []string{
+						"/bin/sh",
+					},
+					Args: []string{"-c", fmt.Sprintf("cp %[1]s %[2]s && chmod 400 %[2]s && ssh -o \"StrictHostKeyChecking=no\" -i %[2]s %[3]s@%[4]s %[5]s", privateKeyPath, emptyDirPath, experimentsDetails.SSHUser, experimentsDetails.TargetNodeIP, experimentsDetails.RebootCommand)},
+					VolumeMounts: []apiv1.VolumeMount{
+						{
+							Name:      privateKeySecret + experimentsDetails.RunID,
+							MountPath: privateKeyMount,
+						},
+						{
+							Name:      emptyDirVolume + experimentsDetails.RunID,
+							MountPath: emptyDirMount,
+						},
+					},
+				},
+			},
+			Volumes: []apiv1.Volume{
+				{
+					Name: privateKeySecret + experimentsDetails.RunID,
+					VolumeSource: apiv1.VolumeSource{
+						Secret: &apiv1.SecretVolumeSource{
+							SecretName: secretName,
+						},
+					},
+				},
+				{
+					Name: emptyDirVolume + experimentsDetails.RunID,
+					VolumeSource: apiv1.VolumeSource{
+						EmptyDir: &apiv1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.ChaosNamespace).Create(helperPod)
+	return err
+}
+
+//GetNode will select a random replica of application pod and return the node spec of that application pod
+func GetNode(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets) (*k8stypes.Pod, error) {
+	podList, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).List(v1.ListOptions{LabelSelector: experimentsDetails.AppLabel})
+	if err != nil || len(podList.Items) == 0 {
+		return nil, errors.Wrapf(err, "Fail to get the application pod in %v namespace, due to err: %v", experimentsDetails.AppNS, err)
+	}
+
+	rand.Seed(time.Now().Unix())
+	randomIndex := rand.Intn(len(podList.Items))
+	node := podList.Items[randomIndex]
+
+	return &node, nil
+}

--- a/experiments/generic/node-restart/README.md
+++ b/experiments/generic/node-restart/README.md
@@ -1,0 +1,14 @@
+## Experiment Metadata
+
+<table>
+<tr>
+<th> Name </th>
+<th> Description </th>
+<th> Documentation Link </th>
+</tr>
+<tr>
+ <td> Node Restart </td>
+ <td> This experiment restarts Kubernetes node. </td>
+ <td>  <a href="https://docs.litmuschaos.io/docs/node-restart/"> Here </a> </td>
+ </tr>
+ </table>

--- a/experiments/generic/node-restart/experiment/node-restart.go
+++ b/experiments/generic/node-restart/experiment/node-restart.go
@@ -1,0 +1,187 @@
+package experiment
+
+import (
+	litmusLIB "github.com/litmuschaos/litmus-go/chaoslib/litmus/node-restart/lib"
+	clients "github.com/litmuschaos/litmus-go/pkg/clients"
+	"github.com/litmuschaos/litmus-go/pkg/events"
+	experimentEnv "github.com/litmuschaos/litmus-go/pkg/generic/node-restart/environment"
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/generic/node-restart/types"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/probe"
+	"github.com/litmuschaos/litmus-go/pkg/result"
+	"github.com/litmuschaos/litmus-go/pkg/status"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
+)
+
+// NodeRestart inject the node-restart chaos
+func NodeRestart(clients clients.ClientSets) {
+
+	var err error
+	experimentsDetails := experimentTypes.ExperimentDetails{}
+	resultDetails := types.ResultDetails{}
+	eventsDetails := types.EventDetails{}
+	chaosDetails := types.ChaosDetails{}
+
+	//Fetching all the ENV passed from the runner pod
+	log.Infof("[PreReq]: Getting the ENV for the %v experiment", experimentsDetails.ExperimentName)
+	experimentEnv.GetENV(&experimentsDetails, "node-restart")
+
+	// Intialise the chaos attributes
+	experimentEnv.InitialiseChaosVariables(&chaosDetails, &experimentsDetails)
+
+	// Intialise Chaos Result Parameters
+	types.SetResultAttributes(&resultDetails, chaosDetails)
+
+	// Intialise the probe details
+	probe.InitializeProbesInChaosResultDetails(&chaosDetails, clients, &resultDetails)
+
+	//Updating the chaos result in the beginning of experiment
+	log.Infof("[PreReq]: Updating the chaos result of %v experiment (SOT)", experimentsDetails.ExperimentName)
+	err = result.ChaosResult(&chaosDetails, clients, &resultDetails, "SOT")
+	if err != nil {
+		log.Errorf("Unable to Create the Chaos Result due to %v", err)
+		failStep := "Updating the chaos result of node-restart experiment (SOT)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// Set the chaos result uid
+	result.SetResultUID(&resultDetails, clients, &chaosDetails)
+
+	//DISPLAY THE APP INFORMATION
+	log.InfoWithValues("The application information is as follows", logrus.Fields{
+		"Namespace":      experimentsDetails.AppNS,
+		"Label":          experimentsDetails.AppLabel,
+		"Chaos Duration": experimentsDetails.ChaosDuration,
+		"Ramp Time":      experimentsDetails.RampTime,
+	})
+
+	//PRE-CHAOS APPLICATION STATUS CHECK
+	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (pre-chaos)")
+	err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	if err != nil {
+		log.Errorf("Application status check failed due to %v\n", err)
+		failStep := "Verify that the AUT (Application Under Test) is running (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	//PRE-CHAOS AUXILIARY APPLICATION STATUS CHECK
+	if experimentsDetails.AuxiliaryAppInfo != "" {
+		log.Info("[Status]: Verify that the Auxiliary Applications are running (pre-chaos)")
+		err = status.CheckAuxiliaryApplicationStatus(experimentsDetails.AuxiliaryAppInfo, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+		if err != nil {
+			log.Errorf("Auxiliary Application status check failed due to %v", err)
+			failStep := "Verify that the Auxiliary Applications are running (pre-chaos)"
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+	}
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := "AUT: Running"
+
+		// run the probes in the pre-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+
+			err = probe.RunProbes(&chaosDetails, clients, &resultDetails, "PreChaos", &eventsDetails)
+			events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+			if err != nil {
+				log.Errorf("Probe failed, due to err: %v", err)
+				failStep := "Failed while adding probe"
+				msg := "AUT: Running, Probes: Unsuccessful"
+				types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = "AUT: Running, Probes: Successful"
+		}
+		// generating the events for the pre-chaos check
+		types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	// Including the litmus lib for node-restart
+	if experimentsDetails.ChaosLib == "litmus" {
+		err = litmusLIB.PrepareNodeRestart(&experimentsDetails, clients, &resultDetails, &eventsDetails, &chaosDetails)
+		if err != nil {
+			log.Errorf("[Error]: Node restart failed due to %v\n", err)
+			failStep := " Node restart Chaos injection failed"
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+		log.Info("[Confirmation]: Node restart has been done successfully")
+		resultDetails.Verdict = "Pass"
+	} else {
+		log.Error("[Invalid]: Please Provide the correct LIB")
+		failStep := "Including the litmus lib for node-restart"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	//POST-CHAOS APPLICATION STATUS CHECK
+	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (post-chaos)")
+	err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	if err != nil {
+		klog.V(0).Infof("Application status check failed due to %v\n", err)
+		failStep := "Verify that the AUT (Application Under Test) is running (post-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	//POST-CHAOS AUXILIARY APPLICATION STATUS CHECK
+	if experimentsDetails.AuxiliaryAppInfo != "" {
+		log.Info("[Status]: Verify that the Auxiliary Applications are running (post-chaos)")
+		err = status.CheckAuxiliaryApplicationStatus(experimentsDetails.AuxiliaryAppInfo, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+		if err != nil {
+			log.Errorf("Auxiliary Application status check failed due to %v", err)
+			failStep := "Verify that the Auxiliary Applications are running (post-chaos)"
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+	}
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := "AUT: Running"
+
+		// run the probes in the post-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+			err = probe.RunProbes(&chaosDetails, clients, &resultDetails, "PostChaos", &eventsDetails)
+			if err != nil {
+				log.Errorf("Unable to Add the probes, due to err: %v", err)
+				failStep := "Failed while adding probe"
+				msg := "AUT: Running, Probes: Unsuccessful"
+				types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = "AUT: Running, Probes: Successful"
+		}
+
+		// generating post chaos event
+		types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	//Updating the chaosResult in the end of experiment
+	log.Infof("[The End]: Updating the chaos result of %v experiment (EOT)", experimentsDetails.ExperimentName)
+	err = result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+	if err != nil {
+		log.Fatalf("Unable to Update the Chaos Result due to %v\n", err)
+	}
+	if experimentsDetails.EngineName != "" {
+		msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
+		types.SetEngineEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
+	types.SetResultEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &resultDetails)
+	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
+}

--- a/experiments/generic/node-restart/rbac.yaml
+++ b/experiments/generic/node-restart/rbac.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-restart-sa
+  namespace: default
+  labels:
+    name: node-restart-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: node-restart-sa
+  labels:
+    name: node-restart-sa
+rules:
+- apiGroups: ["","litmuschaos.io","batch","apps"]
+  resources: ["pods","jobs","secrets","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: node-restart-sa
+  labels:
+    name: node-restart-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-restart-sa
+subjects:
+- kind: ServiceAccount
+  name: node-restart-sa
+  namespace: default

--- a/experiments/generic/node-restart/test/test.yml
+++ b/experiments/generic/node-restart/test/test.yml
@@ -1,0 +1,75 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litmus-experiment
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      app: litmus-experiment
+  template:
+    metadata:
+      labels:
+        app: litmus-experiment
+    spec:
+      serviceAccountName: node-restart-sa
+      containers:
+      - name: gotest
+        image: busybox
+        command:
+          - sleep 
+          - "3600"
+        env:
+          - name: APP_NAMESPACE
+            value: 'default'
+
+          - name: APP_LABEL
+            value: 'run=nginx'
+
+          - name: APP_KIND
+            value: 'deployment'
+
+          - name: AUXILIARY_APPINFO
+            value: ''
+
+          - name: TOTAL_CHAOS_DURATION
+            value: '60'
+
+          - name: CHAOS_INTERVAL
+            value: '10'
+
+          - name: LIB
+            value: 'litmus'
+
+          - name: LIB_IMAGE
+            value: 'litmuschaos/go-runner:ci'
+
+          - name: CHAOS_NAMESPACE
+            value: 'default'
+
+          - name: RAMP_TIME
+            value: ''
+
+          - name: SSH_USER
+            value: 'core'
+
+          - name: REBOOT_COMMAND
+            value: 'sudo systemctl reboot'
+
+          - name: SECRET_NAME
+            value: 'id-rsa'
+          
+          - name: SECRET_VALUE
+            value: 'ssh-privatekey'
+
+          - name: TARGET_NODE
+            value: 'node01'
+
+          - name: TARGET_NODE_IP
+            value: '192.168.1.15'
+
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name

--- a/pkg/generic/node-restart/environment/environment.go
+++ b/pkg/generic/node-restart/environment/environment.go
@@ -1,0 +1,56 @@
+package environment
+
+import (
+	"os"
+	"strconv"
+
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/generic/node-restart/types"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	clientTypes "k8s.io/apimachinery/pkg/types"
+)
+
+//GetENV fetches all the env variables from the runner pod
+func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string) {
+	experimentDetails.ExperimentName = expName
+	experimentDetails.ChaosNamespace = Getenv("CHAOS_NAMESPACE", "litmus")
+	experimentDetails.EngineName = Getenv("CHAOSENGINE", "")
+	experimentDetails.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION", "30"))
+	experimentDetails.RampTime, _ = strconv.Atoi(Getenv("RAMP_TIME", "0"))
+	experimentDetails.ChaosLib = Getenv("LIB", "litmus")
+	experimentDetails.AppNS = Getenv("APP_NAMESPACE", "")
+	experimentDetails.AppLabel = Getenv("APP_LABEL", "")
+	experimentDetails.AppKind = Getenv("APP_KIND", "")
+	experimentDetails.ChaosUID = clientTypes.UID(Getenv("CHAOS_UID", ""))
+	experimentDetails.InstanceID = Getenv("INSTANCE_ID", "")
+	experimentDetails.ChaosPodName = Getenv("POD_NAME", "")
+	experimentDetails.LIBImage = Getenv("LIB_IMAGE", "litmuschaos/go-runner:latest")
+	experimentDetails.AuxiliaryAppInfo = Getenv("AUXILIARY_APPINFO", "")
+	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
+	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
+	experimentDetails.SSHUser = Getenv("SSH_USER", "root")
+	experimentDetails.RebootCommand = Getenv("REBOOT_COMMAND", "sudo systemctl reboot")
+	experimentDetails.TargetNode = Getenv("TARGET_NODE", "")
+	experimentDetails.TargetNodeIP = Getenv("TARGET_NODE_IP", "")
+}
+
+// Getenv fetch the env and set the default value, if any
+func Getenv(key string, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		value = defaultValue
+	}
+	return value
+}
+
+//InitialiseChaosVariables initialise all the global variables
+func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetails *experimentTypes.ExperimentDetails) {
+
+	chaosDetails.ChaosNamespace = experimentDetails.ChaosNamespace
+	chaosDetails.ChaosPodName = experimentDetails.ChaosPodName
+	chaosDetails.ChaosUID = experimentDetails.ChaosUID
+	chaosDetails.EngineName = experimentDetails.EngineName
+	chaosDetails.ExperimentName = experimentDetails.ExperimentName
+	chaosDetails.InstanceID = experimentDetails.InstanceID
+	chaosDetails.Timeout = experimentDetails.Timeout
+	chaosDetails.Delay = experimentDetails.Delay
+}

--- a/pkg/generic/node-restart/types/types.go
+++ b/pkg/generic/node-restart/types/types.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	clientTypes "k8s.io/apimachinery/pkg/types"
+)
+
+// ExperimentDetails is for collecting all the experiment-related details
+type ExperimentDetails struct {
+	ExperimentName   string
+	EngineName       string
+	ChaosDuration    int
+	Annotations      map[string]string
+	RampTime         int
+	ChaosLib         string
+	AppNS            string
+	AppLabel         string
+	AppKind          string
+	ChaosUID         clientTypes.UID
+	InstanceID       string
+	ChaosNamespace   string
+	ChaosPodName     string
+	RunID            string
+	LIBImage         string
+	AuxiliaryAppInfo string
+	Timeout          int
+	Delay            int
+	SSHUser          string
+	RebootCommand    string
+	TargetNode       string
+	TargetNodeIP     string
+}


### PR DESCRIPTION
This patch add experiment to restart host via the SSH.

So the example `ChaosEngine` would be:
```yaml
apiVersion: litmuschaos.io/v1alpha1
kind: ChaosEngine
metadata:
  name: nginx-chaos-restart
spec:
  auxiliaryAppInfo: ""
  appinfo:
    appns: 'kube-system'
    applabel: 'tier=control-plane'
    appkind: 'deployment'
  annotationCheck: 'false'
  engineState: 'active'
  chaosServiceAccount: chaos-admin
  monitoring: false
  jobCleanUpPolicy: 'retain'
  experiments:
    - name: node-restart
      spec:
        components:
          env:
            - name: SSH_USER
              value: 'docker'
```

Example `ChaosExperiment`:

```yaml
apiVersion: litmuschaos.io/v1alpha1
description:
  message: |
    Restart node
kind: ChaosExperiment
metadata:
  name: node-restart
  version: 0.1.21
spec:
  definition:
    scope: Cluster
    permissions:
      - apiGroups:
          - ""
          - "batch"
          - "apps"
          - "litmuschaos.io"
        resources:
          - "jobs"
          - "pods"
          - "pods/log"
          - "events"
          - "chaosengines"
          - "chaosexperiments"
          - "chaosresults"
        verbs:
          - "create"
          - "list"
          - "get"
          - "patch"
          - "update"
          - "delete"
      - apiGroups:
          - ""
        resources:
          - "nodes"
        verbs:
          - "get"
          - "list"
    image: "litmuschaos/go-runner:ci"
    imagePullPolicy: Never
    args:
    - -c
    - ./experiments -name node-restart
    command:
    - /bin/bash
    env:
    - name: SSH_USER
      value: ''

    # PROVIDE THE LIB HERE
    # ONLY LITMUS SUPPORTED
    - name: LIB
      value: 'litmus'

    # provide lib image
    - name: LIB_IMAGE
      value: 'litmuschaos/go-runner:ci'

    labels:
      name: node-restart
```

In order to run the test properly user need to create secret with private key as follows:
```bash
kubectl create secret generic id-rsa --from-file=ssh-privatekey=/path/to/id_rsa
```