### PR TITLE
chore(blob/cassandra-pod-delete): Adding an ability to generate detailed chaos result

### DIFF
--- a/pkg/result/chaosresult.go
+++ b/pkg/result/chaosresult.go
@@ -143,6 +143,10 @@ func PatchChaosResult(result *v1alpha1.ChaosResult, clients clients.ClientSets, 
 			result.Status.ExperimentStatus.ProbeSuccessPercentage = strconv.Itoa((resultDetails.PassedProbeCount * 100) / len(resultDetails.ProbeDetails))
 		}
 
+		if resultDetails.Data != nil {
+			result.Status.Data = resultDetails.Data
+		}
+
 	} else if len(resultDetails.ProbeDetails) != 0 {
 		result.Status.ExperimentStatus.ProbeSuccessPercentage = "Awaited"
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -32,6 +32,7 @@ type ResultDetails struct {
 	ResultUID        clientTypes.UID
 	ProbeDetails     []ProbeDetails
 	PassedProbeCount int
+	Data             map[string]string
 }
 
 // ProbeDetails is for collecting all the probe details


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding output of nodetool status command at `.status.data` inside chaos result

- Data field expect data in the form of map[string]string. If the value has different data types. It needs to be type-cast/encoded to a string value before adding it.