### PR TITLE
chore(sequence): Adding both parallel/serial sequence in all pod-level experiments

### DIFF
--- a/chaoslib/litmus/container-kill/lib/container-kill.go
+++ b/chaoslib/litmus/container-kill/lib/container-kill.go
@@ -56,10 +56,68 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 		return errors.Errorf("Unable to get annotations, err: %v", err)
 	}
 
+	if experimentsDetails.Sequence == "serial" {
+		if err = InjectChaosInSerialMode(experimentsDetails, targetPodList, clients, chaosDetails); err != nil {
+			return err
+		}
+	} else {
+		if err = InjectChaosInParallelMode(experimentsDetails, targetPodList, clients, chaosDetails); err != nil {
+			return err
+		}
+	}
+
+	//Waiting for the ramp time after chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+	return nil
+}
+
+// InjectChaosInSerialMode kill the container of all target application serially (one by one)
+func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails) error {
+
 	// creating the helper pod to perform container kill chaos
 	for _, pod := range targetPodList.Items {
 		runID := common.GetRunID()
-		err = CreateHelperPod(experimentsDetails, clients, pod.Name, pod.Spec.NodeName, runID)
+		err := CreateHelperPod(experimentsDetails, clients, pod.Name, pod.Spec.NodeName, runID)
+		if err != nil {
+			return errors.Errorf("Unable to create the helper pod, err: %v", err)
+		}
+
+		//checking the status of the helper pods, wait till the pod comes to running state else fail the experiment
+		log.Info("[Status]: Checking the status of the helper pods")
+		err = status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("helper pods are not in running state, err: %v", err)
+		}
+
+		// Wait till the completion of the helper pod
+		// set an upper limit for the waiting time
+		log.Info("[Wait]: waiting till the completion of the helper pod")
+		podStatus, err := status.WaitForCompletion(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", clients, experimentsDetails.ChaosDuration+experimentsDetails.ChaosInterval+60, experimentsDetails.ExperimentName)
+		if err != nil || podStatus == "Failed" {
+			return errors.Errorf("helper pod failed, err: %v", err)
+		}
+
+		//Deleting all the helper pod for container-kill chaos
+		log.Info("[Cleanup]: Deleting all the helper pods")
+		err = common.DeletePod(experimentsDetails.ExperimentName+"-"+runID, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.ChaosNamespace, chaosDetails.Timeout, chaosDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("Unable to delete the helper pod, err: %v", err)
+		}
+	}
+	return nil
+
+}
+
+// InjectChaosInParallelMode kill the container of all target application in parallel mode (all at once)
+func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails) error {
+
+	// creating the helper pod to perform container kill chaos
+	for _, pod := range targetPodList.Items {
+		runID := common.GetRunID()
+		err := CreateHelperPod(experimentsDetails, clients, pod.Name, pod.Spec.NodeName, runID)
 		if err != nil {
 			return errors.Errorf("Unable to create the helper pod, err: %v", err)
 		}
@@ -67,7 +125,7 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 
 	//checking the status of the helper pods, wait till the pod comes to running state else fail the experiment
 	log.Info("[Status]: Checking the status of the helper pods")
-	err = status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	err := status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
 	if err != nil {
 		return errors.Errorf("helper pods are not in running state, err: %v", err)
 	}
@@ -87,12 +145,8 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 		return errors.Errorf("Unable to delete the helper pod, err: %v", err)
 	}
 
-	//Waiting for the ramp time after chaos injection
-	if experimentsDetails.RampTime != 0 {
-		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
-		common.WaitForDuration(experimentsDetails.RampTime)
-	}
 	return nil
+
 }
 
 //GetIterations derive the iterations value from given parameters

--- a/chaoslib/litmus/disk-fill/lib/disk-fill.go
+++ b/chaoslib/litmus/disk-fill/lib/disk-fill.go
@@ -52,10 +52,140 @@ func PrepareDiskFill(experimentsDetails *experimentTypes.ExperimentDetails, clie
 		events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
 	}
 
+	if experimentsDetails.Sequence == "serial" {
+		if err = InjectChaosInSerialMode(experimentsDetails, targetPodList, clients, chaosDetails, execCommandDetails); err != nil {
+			return err
+		}
+	} else {
+		if err = InjectChaosInParallelMode(experimentsDetails, targetPodList, clients, chaosDetails, execCommandDetails); err != nil {
+			return err
+		}
+	}
+
+	//Waiting for the ramp time after chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+	return nil
+}
+
+// InjectChaosInSerialMode fill the ephemeral storage of all target application serially (one by one)
+func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails, execCommandDetails exec.PodDetails) error {
+
 	// creating the helper pod to perform disk-fill chaos
 	for _, pod := range targetPodList.Items {
 		runID := common.GetRunID()
-		err = CreateHelperPod(experimentsDetails, clients, pod.Name, pod.Spec.NodeName, runID)
+		err := CreateHelperPod(experimentsDetails, clients, pod.Name, pod.Spec.NodeName, runID)
+		if err != nil {
+			return errors.Errorf("Unable to create the helper pod, err: %v", err)
+		}
+
+		//checking the status of the helper pods, wait till the pod comes to running state else fail the experiment
+		log.Info("[Status]: Checking the status of the helper pods")
+		err = status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("helper pods are not in running state, err: %v", err)
+		}
+
+		//Get the target container name of the application pod
+		if experimentsDetails.TargetContainer == "" {
+			experimentsDetails.TargetContainer, err = GetTargetContainer(experimentsDetails, pod.Name, clients)
+			if err != nil {
+				return errors.Errorf("Unable to get the target container name, err: %v", err)
+			}
+		}
+
+		// GetEphemeralStorageAttributes derive the ephemeral storage attributes from the target container
+		ephemeralStorageLimit, ephemeralStorageRequest, err := GetEphemeralStorageAttributes(experimentsDetails, clients, pod.Name)
+		if err != nil {
+			return err
+		}
+
+		// Derive the container id of the target container
+		containerID, err := GetContainerID(experimentsDetails, clients, pod.Name)
+		if err != nil {
+			return err
+		}
+
+		log.InfoWithValues("[Info]: Details of application under chaos injection", logrus.Fields{
+			"PodName":                 pod.Name,
+			"NodeName":                pod.Spec.NodeName,
+			"ContainerName":           experimentsDetails.TargetContainer,
+			"ephemeralStorageLimit":   ephemeralStorageLimit,
+			"ephemeralStorageRequest": ephemeralStorageRequest,
+			"ContainerID":             containerID,
+		})
+
+		// getting the helper pod name, scheduled on the target node
+		podName, err := GetHelperPodName(pod, clients, experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper")
+		if err != nil {
+			return err
+		}
+
+		// Derive the used ephemeral storage size from the target container
+		// It will exec inside disk-fill helper pod & derive the used ephemeral storage space
+		command := "du /diskfill/" + containerID
+		exec.SetExecCommandAttributes(&execCommandDetails, podName, "disk-fill", experimentsDetails.ChaosNamespace)
+		ephemeralStorageDetails, err := exec.Exec(&execCommandDetails, clients, strings.Fields(command))
+		if err != nil {
+			return errors.Errorf("Unable to get ephemeral storage details, err: %v", err)
+		}
+
+		// filtering out the used ephemeral storage from the output of du command
+		usedEphemeralStorageSize, err := FilterUsedEphemeralStorage(ephemeralStorageDetails)
+		if err != nil {
+			return errors.Errorf("Unable to filter used ephemeral storage size, err: %v", err)
+		}
+		log.Infof("used ephemeral storage space: %v", strconv.Itoa(usedEphemeralStorageSize))
+
+		// deriving the ephemeral storage size to be filled
+		sizeTobeFilled := GetSizeToBeFilled(experimentsDetails, usedEphemeralStorageSize, int(ephemeralStorageLimit))
+
+		log.Infof("ephemeral storage size to be filled: %v", strconv.Itoa(sizeTobeFilled))
+
+		if sizeTobeFilled > 0 {
+			// Creating files to fill the required ephemeral storage size of block size of 4K
+			command := "dd if=/dev/urandom of=/diskfill/" + containerID + "/diskfill bs=4K count=" + strconv.Itoa(sizeTobeFilled/4)
+			_, err = exec.Exec(&execCommandDetails, clients, strings.Fields(command))
+			if err != nil {
+				return errors.Errorf("Unable to fill the ephemeral storage, err: %v", err)
+			}
+		} else {
+			log.Warn("No required free space found!, It's Housefull")
+		}
+
+		// waiting for the chaos duration
+		log.Infof("[Wait]: Waiting for the %vs after injecting chaos", experimentsDetails.ChaosDuration)
+		common.WaitForDuration(experimentsDetails.ChaosDuration)
+
+		// It will delete the target pod if target pod is evicted
+		// if target pod is still running then it will delete all the files, which was created earlier during chaos execution
+		exec.SetExecCommandAttributes(&execCommandDetails, podName, "disk-fill", experimentsDetails.ChaosNamespace)
+		err = Remedy(experimentsDetails, clients, containerID, pod.Name, &execCommandDetails)
+		if err != nil {
+			return errors.Errorf("Unable to perform remedy operation due to %v", err)
+		}
+
+		//Deleting all the helper pod for disk-fill chaos
+		log.Info("[Cleanup]: Deleting the helper pod")
+		err = common.DeletePod(experimentsDetails.ExperimentName+"-"+runID, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.ChaosNamespace, chaosDetails.Timeout, chaosDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("Unable to delete the helper pod, %v", err)
+		}
+	}
+
+	return nil
+
+}
+
+// InjectChaosInParallelMode fill the ephemeral storage of of all target application in parallel mode (all at once)
+func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails, execCommandDetails exec.PodDetails) error {
+
+	// creating the helper pod to perform disk-fill chaos
+	for _, pod := range targetPodList.Items {
+		runID := common.GetRunID()
+		err := CreateHelperPod(experimentsDetails, clients, pod.Name, pod.Spec.NodeName, runID)
 		if err != nil {
 			return errors.Errorf("Unable to create the helper pod, err: %v", err)
 		}
@@ -63,7 +193,7 @@ func PrepareDiskFill(experimentsDetails *experimentTypes.ExperimentDetails, clie
 
 	//checking the status of the helper pods, wait till the pod comes to running state else fail the experiment
 	log.Info("[Status]: Checking the status of the helper pods")
-	err = status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	err := status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
 	if err != nil {
 		return errors.Errorf("helper pods are not in running state, err: %v", err)
 	}
@@ -172,12 +302,8 @@ func PrepareDiskFill(experimentsDetails *experimentTypes.ExperimentDetails, clie
 		return errors.Errorf("Unable to delete the helper pod, %v", err)
 	}
 
-	//Waiting for the ramp time after chaos injection
-	if experimentsDetails.RampTime != 0 {
-		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
-		common.WaitForDuration(experimentsDetails.RampTime)
-	}
 	return nil
+
 }
 
 //GetTargetContainer will fetch the container name from application pod

--- a/chaoslib/litmus/pod-delete/lib/pod-delete.go
+++ b/chaoslib/litmus/pod-delete/lib/pod-delete.go
@@ -11,7 +11,6 @@ import (
 	"github.com/litmuschaos/litmus-go/pkg/status"
 	"github.com/litmuschaos/litmus-go/pkg/types"
 	"github.com/litmuschaos/litmus-go/pkg/utils/common"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,9 +29,14 @@ func PreparePodDelete(experimentsDetails *experimentTypes.ExperimentDetails, cli
 		common.WaitForDuration(experimentsDetails.RampTime)
 	}
 
-	err = PodDeleteChaos(experimentsDetails, clients, eventsDetails, chaosDetails, resultDetails)
-	if err != nil {
-		return errors.Errorf("Unable to delete the application pods, err: %v", err)
+	if experimentsDetails.Sequence == "serial" {
+		if err = InjectChaosInSerialMode(experimentsDetails, clients, chaosDetails, eventsDetails); err != nil {
+			return err
+		}
+	} else {
+		if err = InjectChaosInParallelMode(experimentsDetails, clients, chaosDetails, eventsDetails); err != nil {
+			return err
+		}
 	}
 
 	//Waiting for the ramp time after chaos injection
@@ -40,6 +44,143 @@ func PreparePodDelete(experimentsDetails *experimentTypes.ExperimentDetails, cli
 		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
 		common.WaitForDuration(experimentsDetails.RampTime)
 	}
+	return nil
+}
+
+// InjectChaosInSerialMode kill the container of all target application serially (one by one)
+func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, chaosDetails *types.ChaosDetails, eventsDetails *types.EventDetails) error {
+
+	GracePeriod := int64(0)
+	//ChaosStartTimeStamp contains the start timestamp, when the chaos injection begin
+	ChaosStartTimeStamp := time.Now().Unix()
+
+	for count := 0; count < experimentsDetails.Iterations; count++ {
+
+		// Get the target pod details for the chaos execution
+		// if the target pod is not defined it will derive the random target pod list using pod affected percentage
+		targetPodList, err := common.GetPodList(experimentsDetails.AppNS, experimentsDetails.TargetPod, experimentsDetails.AppLabel, string(experimentsDetails.ChaosUID), experimentsDetails.PodsAffectedPerc, clients)
+		if err != nil {
+			return err
+		}
+
+		if experimentsDetails.EngineName != "" {
+			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
+			types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
+			events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+		}
+
+		//Deleting the application pod
+		for _, pod := range targetPodList.Items {
+
+			log.InfoWithValues("[Info]: Killing the following pods", logrus.Fields{
+				"PodName": pod.Name})
+
+			if experimentsDetails.Force == true {
+				err = clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Delete(pod.Name, &v1.DeleteOptions{GracePeriodSeconds: &GracePeriod})
+			} else {
+				err = clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Delete(pod.Name, &v1.DeleteOptions{})
+			}
+			if err != nil {
+				return err
+			}
+
+			//Waiting for the chaos interval after chaos injection
+			if experimentsDetails.ChaosInterval != 0 {
+				log.Infof("[Wait]: Wait for the chaos interval %vs", experimentsDetails.ChaosInterval)
+				common.WaitForDuration(experimentsDetails.ChaosInterval)
+			}
+
+			//Verify the status of pod after the chaos injection
+			log.Info("[Status]: Verification for the recreation of application pod")
+			if err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
+				return err
+			}
+
+			//ChaosCurrentTimeStamp contains the current timestamp
+			ChaosCurrentTimeStamp := time.Now().Unix()
+
+			//ChaosDiffTimeStamp contains the difference of current timestamp and start timestamp
+			//It will helpful to track the total chaos duration
+			chaosDiffTimeStamp := ChaosCurrentTimeStamp - ChaosStartTimeStamp
+
+			if int(chaosDiffTimeStamp) >= experimentsDetails.ChaosDuration {
+				log.Infof("[Chaos]: Time is up for experiment: %v", experimentsDetails.ExperimentName)
+				break
+			}
+		}
+
+	}
+	log.Infof("[Completion]: %v chaos is done", experimentsDetails.ExperimentName)
+
+	return nil
+
+}
+
+// InjectChaosInParallelMode kill the container of all target application in parallel mode (all at once)
+func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, chaosDetails *types.ChaosDetails, eventsDetails *types.EventDetails) error {
+
+	GracePeriod := int64(0)
+	//ChaosStartTimeStamp contains the start timestamp, when the chaos injection begin
+	ChaosStartTimeStamp := time.Now().Unix()
+
+	for count := 0; count < experimentsDetails.Iterations; count++ {
+
+		// Get the target pod details for the chaos execution
+		// if the target pod is not defined it will derive the random target pod list using pod affected percentage
+		targetPodList, err := common.GetPodList(experimentsDetails.AppNS, experimentsDetails.TargetPod, experimentsDetails.AppLabel, string(experimentsDetails.ChaosUID), experimentsDetails.PodsAffectedPerc, clients)
+		if err != nil {
+			return err
+		}
+
+		if experimentsDetails.EngineName != "" {
+			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
+			types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
+			events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+		}
+
+		//Deleting the application pod
+		for _, pod := range targetPodList.Items {
+
+			log.InfoWithValues("[Info]: Killing the following pods", logrus.Fields{
+				"PodName": pod.Name})
+
+			if experimentsDetails.Force == true {
+				err = clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Delete(pod.Name, &v1.DeleteOptions{GracePeriodSeconds: &GracePeriod})
+			} else {
+				err = clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Delete(pod.Name, &v1.DeleteOptions{})
+			}
+			if err != nil {
+				return err
+			}
+		}
+
+		//Waiting for the chaos interval after chaos injection
+		if experimentsDetails.ChaosInterval != 0 {
+			log.Infof("[Wait]: Wait for the chaos interval %vs", experimentsDetails.ChaosInterval)
+			common.WaitForDuration(experimentsDetails.ChaosInterval)
+		}
+
+		//Verify the status of pod after the chaos injection
+		log.Info("[Status]: Verification for the recreation of application pod")
+		if err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
+			return err
+		}
+
+		//ChaosCurrentTimeStamp contains the current timestamp
+		ChaosCurrentTimeStamp := time.Now().Unix()
+
+		//ChaosDiffTimeStamp contains the difference of current timestamp and start timestamp
+		//It will helpful to track the total chaos duration
+		chaosDiffTimeStamp := ChaosCurrentTimeStamp - ChaosStartTimeStamp
+
+		if int(chaosDiffTimeStamp) >= experimentsDetails.ChaosDuration {
+			log.Infof("[Chaos]: Time is up for experiment: %v", experimentsDetails.ExperimentName)
+			break
+		}
+	}
+
+	log.Infof("[Completion]: %v chaos is done", experimentsDetails.ExperimentName)
+
 	return nil
 }
 

--- a/chaoslib/pumba/container-kill/lib/container-kill.go
+++ b/chaoslib/pumba/container-kill/lib/container-kill.go
@@ -53,8 +53,79 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 		events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
 	}
 
+	if experimentsDetails.Sequence == "serial" {
+		if err = InjectChaosInSerialMode(experimentsDetails, targetPodList, clients, chaosDetails); err != nil {
+			return err
+		}
+	} else {
+		if err = InjectChaosInParallelMode(experimentsDetails, targetPodList, clients, chaosDetails); err != nil {
+			return err
+		}
+	}
+
+	//Waiting for the ramp time after chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+	return nil
+}
+
+// InjectChaosInSerialMode kill the container of all target application serially (one by one)
+func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails) error {
+
+	// creating the helper pod to perform container kill chaos
+	for _, pod := range targetPodList.Items {
+
+		//GetRestartCount return the restart count of target container
+		restartCountBefore := GetRestartCount(pod, experimentsDetails.TargetContainer)
+		log.Infof("restartCount of target container before chaos injection: %v", restartCountBefore)
+
+		runID := common.GetRunID()
+
+		log.InfoWithValues("[Info]: Details of application under chaos injection", logrus.Fields{
+			"PodName":       pod.Name,
+			"NodeName":      pod.Spec.NodeName,
+			"ContainerName": experimentsDetails.TargetContainer,
+		})
+
+		err := CreateHelperPod(experimentsDetails, clients, pod.Name, pod.Spec.NodeName, runID)
+		if err != nil {
+			return errors.Errorf("Unable to create the helper pod, err: %v", err)
+		}
+
+		//checking the status of the helper pod, wait till the pod comes to running state else fail the experiment
+		log.Info("[Status]: Checking the status of the helper pod")
+		err = status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("helper pod is not in running state, err: %v", err)
+		}
+
+		log.Infof("[Wait]: Waiting for the %vs chaos duration", experimentsDetails.ChaosDuration)
+		common.WaitForDuration(experimentsDetails.ChaosDuration)
+
+		// It will verify that the restart count of container should increase after chaos injection
+		err = VerifyRestartCount(experimentsDetails, pod, clients, restartCountBefore)
+		if err != nil {
+			return errors.Errorf("Target container is not restarted, err: %v", err)
+		}
+
+		//Deleting the helper pod
+		log.Info("[Cleanup]: Deleting the helper pod")
+		err = common.DeletePod(experimentsDetails.ExperimentName+"-"+runID, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.ChaosNamespace, chaosDetails.Timeout, chaosDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("Unable to delete the helper pod, err: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// InjectChaosInParallelMode kill the container of all target application in parallel mode (all at once)
+func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails) error {
+
 	//GetRestartCount return the restart count of target container
-	restartCountBefore := GetRestartCount(targetPodList, experimentsDetails.TargetContainer)
+	restartCountBefore := GetRestartCountAll(targetPodList, experimentsDetails.TargetContainer)
 	log.Infof("restartCount of target containers before chaos injection: %v", restartCountBefore)
 
 	// creating the helper pod to perform container kill chaos
@@ -68,7 +139,7 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 			"ContainerName": experimentsDetails.TargetContainer,
 		})
 
-		err = CreateHelperPod(experimentsDetails, clients, pod.Name, pod.Spec.NodeName, runID)
+		err := CreateHelperPod(experimentsDetails, clients, pod.Name, pod.Spec.NodeName, runID)
 		if err != nil {
 			return errors.Errorf("Unable to create the helper pod, err: %v", err)
 		}
@@ -76,7 +147,7 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 
 	//checking the status of the helper pod, wait till the pod comes to running state else fail the experiment
 	log.Info("[Status]: Checking the status of the helper pod")
-	err = status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	err := status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
 	if err != nil {
 		return errors.Errorf("helper pod is not in running state, err: %v", err)
 	}
@@ -85,7 +156,7 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 	common.WaitForDuration(experimentsDetails.ChaosDuration)
 
 	// It will verify that the restart count of container should increase after chaos injection
-	err = VerifyRestartCount(experimentsDetails, targetPodList, clients, restartCountBefore)
+	err = VerifyRestartCountAll(experimentsDetails, targetPodList, clients, restartCountBefore)
 	if err != nil {
 		return errors.Errorf("Target container is not restarted , err: %v", err)
 	}
@@ -97,11 +168,6 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 		return errors.Errorf("Unable to delete the helper pod, err: %v", err)
 	}
 
-	//Waiting for the ramp time after chaos injection
-	if experimentsDetails.RampTime != 0 {
-		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
-		common.WaitForDuration(experimentsDetails.RampTime)
-	}
 	return nil
 }
 
@@ -117,38 +183,46 @@ func GetTargetContainer(experimentsDetails *experimentTypes.ExperimentDetails, a
 }
 
 //GetRestartCount return the restart count of target container
-func GetRestartCount(targetPodList apiv1.PodList, containerName string) []int {
-	restartCount := []int{}
-	for _, pod := range targetPodList.Items {
-		for _, container := range pod.Status.ContainerStatuses {
-			if container.Name == containerName {
-				restartCount = append(restartCount, int(container.RestartCount))
-				break
-			}
+func GetRestartCount(targetPod apiv1.Pod, containerName string) int {
+	restartCount := 0
+	for _, container := range targetPod.Status.ContainerStatuses {
+		if container.Name == containerName {
+			restartCount = int(container.RestartCount)
+			break
 		}
 	}
 	return restartCount
 }
 
+//GetRestartCountAll return the restart count of all target container
+func GetRestartCountAll(targetPodList apiv1.PodList, containerName string) []int {
+	restartCount := []int{}
+	for _, pod := range targetPodList.Items {
+
+		restartCount = append(restartCount, GetRestartCount(pod, containerName))
+
+	}
+
+	return restartCount
+}
+
 //VerifyRestartCount verify the restart count of target container that it is restarted or not after chaos injection
 // the restart count of container should increase after chaos injection
-func VerifyRestartCount(experimentsDetails *experimentTypes.ExperimentDetails, podList apiv1.PodList, clients clients.ClientSets, restartCountBefore []int) error {
+func VerifyRestartCount(experimentsDetails *experimentTypes.ExperimentDetails, pod apiv1.Pod, clients clients.ClientSets, restartCountBefore int) error {
 
-	restartCountAfter := []int{}
+	restartCountAfter := 0
 	err := retry.
 		Times(90).
 		Wait(1 * time.Second).
 		Try(func(attempt uint) error {
-			for index := range podList.Items {
-				pod, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Get(podList.Items[index].Name, v1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				for _, container := range pod.Status.ContainerStatuses {
-					if container.Name == experimentsDetails.TargetContainer {
-						restartCountAfter = append(restartCountAfter, int(container.RestartCount))
-						break
-					}
+			pod, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Get(pod.Name, v1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			for _, container := range pod.Status.ContainerStatuses {
+				if container.Name == experimentsDetails.TargetContainer {
+					restartCountAfter = int(container.RestartCount)
+					break
 				}
 			}
 			return nil
@@ -158,17 +232,28 @@ func VerifyRestartCount(experimentsDetails *experimentTypes.ExperimentDetails, p
 		return err
 	}
 
-	for index := range restartCountBefore {
-		// it will fail if restart count won't increase
-		if restartCountAfter[index] <= restartCountBefore[index] {
-			return errors.Errorf("Target container is not restarted")
-		}
+	// it will fail if restart count won't increase
+	if restartCountAfter <= restartCountBefore {
+		return errors.Errorf("Target container is not restarted")
 	}
 
 	log.Infof("restartCount of target container after chaos injection: %v", restartCountAfter)
 
 	return nil
 
+}
+
+//VerifyRestartCountAll verify the restart count of all the target container that it is restarted or not after chaos injection
+// the restart count of container should increase after chaos injection
+func VerifyRestartCountAll(experimentsDetails *experimentTypes.ExperimentDetails, podList apiv1.PodList, clients clients.ClientSets, restartCountBefore []int) error {
+
+	for index, pod := range podList.Items {
+
+		if err := VerifyRestartCount(experimentsDetails, pod, clients, restartCountBefore[index]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // CreateHelperPod derive the attributes for helper pod and create the helper pod

--- a/chaoslib/pumba/cpu-chaos/lib/cpu-chaos.go
+++ b/chaoslib/pumba/cpu-chaos/lib/cpu-chaos.go
@@ -44,6 +44,71 @@ func PreparePodCPUHog(experimentsDetails *experimentTypes.ExperimentDetails, cli
 		return errors.Errorf("unable to get annotations, err: %v", err)
 	}
 
+	if experimentsDetails.Sequence == "serial" {
+		if err = InjectChaosInSerialMode(experimentsDetails, targetPodList, clients, chaosDetails); err != nil {
+			return err
+		}
+	} else {
+		if err = InjectChaosInParallelMode(experimentsDetails, targetPodList, clients, chaosDetails); err != nil {
+			return err
+		}
+	}
+
+	//Waiting for the ramp time after chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+	return nil
+}
+
+// InjectChaosInSerialMode stress the cpu of all target application serially (one by one)
+func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails) error {
+
+	// creating the helper pod to perform cpu chaos
+	for _, pod := range targetPodList.Items {
+
+		runID := common.GetRunID()
+
+		log.InfoWithValues("[Info]: Details of application under chaos injection", logrus.Fields{
+			"PodName":  pod.Name,
+			"NodeName": pod.Spec.NodeName,
+			"CPUcores": experimentsDetails.CPUcores,
+		})
+
+		err = CreateHelperPod(experimentsDetails, clients, pod.Name, pod.Spec.NodeName, runID)
+		if err != nil {
+			return errors.Errorf("Unable to create the helper pod, err: %v", err)
+		}
+
+		//checking the status of the helper pod, wait till the pod comes to running state else fail the experiment
+		log.Info("[Status]: Checking the status of the helper pod")
+		err = status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("helper pod is not in running state, err: %v", err)
+		}
+
+		// Wait till the completion of helper pod
+		log.Infof("[Wait]: Waiting for %vs till the completion of the helper pod", strconv.Itoa(experimentsDetails.ChaosDuration+30))
+		podStatus, err := status.WaitForCompletion(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", clients, experimentsDetails.ChaosDuration+30, "pumba-stress")
+		if err != nil || podStatus == "Failed" {
+			return errors.Errorf("helper pod failed due to, err: %v", err)
+		}
+
+		//Deleting the helper pod
+		log.Info("[Cleanup]: Deleting the helper pod")
+		err = common.DeletePod(experimentsDetails.ExperimentName+"-"+runID, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.ChaosNamespace, chaosDetails.Timeout, chaosDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("Unable to delete the helper pod, err: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// InjectChaosInParallelMode kill the container of all target application in parallel mode (all at once)
+func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails) error {
+
 	// creating the helper pod to perform cpu chaos
 	for _, pod := range targetPodList.Items {
 
@@ -82,11 +147,6 @@ func PreparePodCPUHog(experimentsDetails *experimentTypes.ExperimentDetails, cli
 		return errors.Errorf("Unable to delete the helper pod, err: %v", err)
 	}
 
-	//Waiting for the ramp time after chaos injection
-	if experimentsDetails.RampTime != 0 {
-		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
-		common.WaitForDuration(experimentsDetails.RampTime)
-	}
 	return nil
 }
 

--- a/chaoslib/pumba/network-chaos/lib/network-chaos.go
+++ b/chaoslib/pumba/network-chaos/lib/network-chaos.go
@@ -47,6 +47,74 @@ func PrepareAndInjectChaos(experimentsDetails *experimentTypes.ExperimentDetails
 		events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
 	}
 
+	if experimentsDetails.Sequence == "serial" {
+		if err = InjectChaosInSerialMode(experimentsDetails, targetPodList, clients, chaosDetails, args); err != nil {
+			return err
+		}
+	} else {
+		if err = InjectChaosInParallelMode(experimentsDetails, targetPodList, clients, chaosDetails, args); err != nil {
+			return err
+		}
+	}
+
+	//Waiting for the ramp time after chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+	return nil
+}
+
+// InjectChaosInSerialMode stress the cpu of all target application serially (one by one)
+func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails, args []string) error {
+
+	// creating the helper pod to perform network chaos
+	for _, pod := range targetPodList.Items {
+
+		runID := common.GetRunID()
+
+		log.InfoWithValues("[Info]: Details of application under chaos injection", logrus.Fields{
+			"PodName":  pod.Name,
+			"NodeName": pod.Spec.NodeName,
+		})
+		// args contains details of the specific chaos injection
+		// constructing `argsWithRegex` based on updated regex with a diff pod name
+		// without extending/concatenating the args var itself
+		argsWithRegex := append(args, "re2:k8s_POD_"+pod.Name+"_"+experimentsDetails.AppNS)
+		log.Infof("Arguments for running %v are %v", experimentsDetails.ExperimentName, argsWithRegex)
+		err = CreateHelperPod(experimentsDetails, clients, pod.Spec.NodeName, runID, argsWithRegex)
+		if err != nil {
+			return errors.Errorf("Unable to create the helper pod, err: %v", err)
+		}
+
+		//checking the status of the helper pod, wait till the pod comes to running state else fail the experiment
+		log.Info("[Status]: Checking the status of the helper pod")
+		err = status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("helper pod is not in running state, err: %v", err)
+		}
+
+		// Wait till the completion of helper pod
+		log.Infof("[Wait]: Waiting for %vs till the completion of the helper pod", experimentsDetails.ChaosDuration)
+		podStatus, err := status.WaitForCompletion(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", clients, experimentsDetails.ChaosDuration+30, chaosDetails.ExperimentName)
+		if err != nil || podStatus == "Failed" {
+			return errors.Errorf("helper pod failed, err: %v", err)
+		}
+
+		//Deleting the helper pod
+		log.Info("[Cleanup]: Deleting the helper pod")
+		err = common.DeletePod(experimentsDetails.ExperimentName+"-"+runID, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.ChaosNamespace, chaosDetails.Timeout, chaosDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("Unable to delete the helper pod, err: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// InjectChaosInParallelMode kill the container of all target application in parallel mode (all at once)
+func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails, args []string) error {
+
 	// creating the helper pod to perform network chaos
 	for _, pod := range targetPodList.Items {
 
@@ -88,11 +156,6 @@ func PrepareAndInjectChaos(experimentsDetails *experimentTypes.ExperimentDetails
 		return errors.Errorf("Unable to delete the helper pod, err: %v", err)
 	}
 
-	//Waiting for the ramp time after chaos injection
-	if experimentsDetails.RampTime != 0 {
-		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
-		common.WaitForDuration(experimentsDetails.RampTime)
-	}
 	return nil
 }
 

--- a/chaoslib/pumba/pod-io-stress/lib/pod-io-stress.go
+++ b/chaoslib/pumba/pod-io-stress/lib/pod-io-stress.go
@@ -44,6 +44,72 @@ func PreparePodIOStress(experimentsDetails *experimentTypes.ExperimentDetails, c
 		return errors.Errorf("unable to get annotations, err: %v", err)
 	}
 
+	if experimentsDetails.Sequence == "serial" {
+		if err = InjectChaosInSerialMode(experimentsDetails, targetPodList, clients, chaosDetails); err != nil {
+			return err
+		}
+	} else {
+		if err = InjectChaosInParallelMode(experimentsDetails, targetPodList, clients, chaosDetails); err != nil {
+			return err
+		}
+	}
+
+	//Waiting for the ramp time after chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+	return nil
+}
+
+// InjectChaosInSerialMode stress the cpu of all target application serially (one by one)
+func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails) error {
+
+	// creating the helper pod to perform network chaos
+	for _, pod := range targetPodList.Items {
+
+		runID := common.GetRunID()
+
+		log.InfoWithValues("[Info]: Details of application under chaos injection", logrus.Fields{
+			"PodName":                         pod.Name,
+			"NodeName":                        pod.Spec.NodeName,
+			"FilesystemUtilizationPercentage": experimentsDetails.FilesystemUtilizationPercentage,
+			"FilesystemUtilizationBytes":      experimentsDetails.FilesystemUtilizationBytes,
+		})
+
+		err = CreateHelperPod(experimentsDetails, clients, pod.Name, pod.Spec.NodeName, runID)
+		if err != nil {
+			return errors.Errorf("Unable to create the helper pod, err: %v", err)
+		}
+
+		//checking the status of the helper pod, wait till the pod comes to running state else fail the experiment
+		log.Info("[Status]: Checking the status of the helper pod")
+		err = status.CheckApplicationStatus(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("helper pod is not in running state, err: %v", err)
+		}
+
+		// Wait till the completion of helper pod
+		log.Infof("[Wait]: Waiting for %vs till the completion of the helper pod", strconv.Itoa(experimentsDetails.ChaosDuration+30))
+		podStatus, err := status.WaitForCompletion(experimentsDetails.ChaosNamespace, "app="+experimentsDetails.ExperimentName+"-helper", clients, experimentsDetails.ChaosDuration+30, "pumba-stress")
+		if err != nil || podStatus == "Failed" {
+			return errors.Errorf("helper pod failed due to, err: %v", err)
+		}
+
+		//Deleting the helper pod
+		log.Info("[Cleanup]: Deleting the helper pod")
+		err = common.DeletePod(experimentsDetails.ExperimentName+"-"+runID, "app="+experimentsDetails.ExperimentName+"-helper", experimentsDetails.ChaosNamespace, chaosDetails.Timeout, chaosDetails.Delay, clients)
+		if err != nil {
+			return errors.Errorf("Unable to delete the helper pod, err: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// InjectChaosInParallelMode kill the container of all target application in parallel mode (all at once)
+func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList apiv1.PodList, clients clients.ClientSets, chaosDetails *types.ChaosDetails) error {
+
 	// creating the helper pod to perform network chaos
 	for _, pod := range targetPodList.Items {
 
@@ -83,11 +149,6 @@ func PreparePodIOStress(experimentsDetails *experimentTypes.ExperimentDetails, c
 		return errors.Errorf("Unable to delete the helper pod, err: %v", err)
 	}
 
-	//Waiting for the ramp time after chaos injection
-	if experimentsDetails.RampTime != 0 {
-		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
-		common.WaitForDuration(experimentsDetails.RampTime)
-	}
 	return nil
 }
 

--- a/pkg/generic/container-kill/environment/environment.go
+++ b/pkg/generic/container-kill/environment/environment.go
@@ -34,6 +34,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
 	experimentDetails.ContainerRuntime = Getenv("CONTAINER_RUNTIME", "docker")
 	experimentDetails.PodsAffectedPerc, _ = strconv.Atoi(Getenv("PODS_AFFECTED_PERC", "0"))
+	experimentDetails.Sequence = Getenv("SEQUENCE", "parallel")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/container-kill/types/types.go
+++ b/pkg/generic/container-kill/types/types.go
@@ -31,4 +31,5 @@ type ExperimentDetails struct {
 	ContainerRuntime    string
 	PodsAffectedPerc    int
 	Annotations         map[string]string
+	Sequence            string
 }

--- a/pkg/generic/disk-fill/environment/environment.go
+++ b/pkg/generic/disk-fill/environment/environment.go
@@ -33,6 +33,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.LIBImage = Getenv("LIB_IMAGE", "litmuschaos/go-runner:latest")
 	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
 	experimentDetails.PodsAffectedPerc, _ = strconv.Atoi(Getenv("PODS_AFFECTED_PERC", "0"))
+	experimentDetails.Sequence = Getenv("SEQUENCE", "parallel")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/disk-fill/types/types.go
+++ b/pkg/generic/disk-fill/types/types.go
@@ -29,4 +29,5 @@ type ExperimentDetails struct {
 	TargetPod        string
 	PodsAffectedPerc int
 	Annotations      map[string]string
+	Sequence         string
 }

--- a/pkg/generic/network-chaos/environment/environment.go
+++ b/pkg/generic/network-chaos/environment/environment.go
@@ -40,6 +40,8 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.ContainerRuntime = Getenv("CONTAINER_RUNTIME", "docker")
 	experimentDetails.ChaosServiceAccount = Getenv("CHAOS_SERVICE_ACCOUNT", "")
 	experimentDetails.SocketPath = Getenv("SOCKET_PATH", "/run/containerd/containerd.sock")
+	experimentDetails.Sequence = Getenv("SEQUENCE", "parallel")
+
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/network-chaos/types/types.go
+++ b/pkg/generic/network-chaos/types/types.go
@@ -37,4 +37,5 @@ type ExperimentDetails struct {
 	ContainerRuntime                   string
 	ChaosServiceAccount                string
 	SocketPath                         string
+	Sequence                           string
 }

--- a/pkg/generic/pod-delete/environment/environment.go
+++ b/pkg/generic/pod-delete/environment/environment.go
@@ -31,6 +31,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
 	experimentDetails.TargetPod = Getenv("TARGET_POD", "")
 	experimentDetails.PodsAffectedPerc, _ = strconv.Atoi(Getenv("PODS_AFFECTED_PERC", "0"))
+	experimentDetails.Sequence = Getenv("SEQUENCE", "parallel")
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/pod-delete/types/types.go
+++ b/pkg/generic/pod-delete/types/types.go
@@ -26,4 +26,5 @@ type ExperimentDetails struct {
 	Delay               int
 	TargetPod           string
 	PodsAffectedPerc    int
+	Sequence            string
 }

--- a/pkg/generic/pod-io-stress/environment/environment.go
+++ b/pkg/generic/pod-io-stress/environment/environment.go
@@ -31,6 +31,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.NumberOfWorkers, _ = strconv.Atoi(Getenv("NUMBER_OF_WORKERS", "4"))
 	experimentDetails.LIBImage = Getenv("LIB_IMAGE", "gaiaadm/pumba")
 	experimentDetails.PodsAffectedPerc, _ = strconv.Atoi(Getenv("PODS_AFFECTED_PERC", "0"))
+	experimentDetails.Sequence = Getenv("SEQUENCE", "parallel")
 
 }
 

--- a/pkg/generic/pod-io-stress/types/types.go
+++ b/pkg/generic/pod-io-stress/types/types.go
@@ -27,4 +27,5 @@ type ExperimentDetails struct {
 	Annotations                     map[string]string
 	LIBImage                        string
 	PodsAffectedPerc                int
+	Sequence                        string
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- container-kill in docker :heavy_check_mark: 
- container-kill in containerd :heavy_check_mark: 
- disk-fill :heavy_check_mark: 
- network-chaos docker :heavy_check_mark: 
- network chaos containerd :heavy_check_mark: 
- pod-delete :heavy_check_mark: 
- cpu pumba :heavy_check_mark: 
- mm pumba :heavy_check_mark: 
- pod-io-stress :heavy_check_mark: 