### PR TITLE
fix(node-restart): Add node anti affinity and fix ssh known hosts file requirements

### DIFF
--- a/experiments/generic/node-restart/experiment/node-restart.go
+++ b/experiments/generic/node-restart/experiment/node-restart.go
@@ -26,7 +26,7 @@ func NodeRestart(clients clients.ClientSets) {
 
 	//Fetching all the ENV passed from the runner pod
 	log.Infof("[PreReq]: Getting the ENV for the %v experiment", experimentsDetails.ExperimentName)
-	experimentEnv.GetENV(&experimentsDetails, "node-restart")
+	experimentEnv.GetENV(&experimentsDetails)
 
 	// Intialise the chaos attributes
 	experimentEnv.InitialiseChaosVariables(&chaosDetails, &experimentsDetails)

--- a/pkg/generic/node-restart/environment/environment.go
+++ b/pkg/generic/node-restart/environment/environment.go
@@ -10,8 +10,8 @@ import (
 )
 
 //GetENV fetches all the env variables from the runner pod
-func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string) {
-	experimentDetails.ExperimentName = expName
+func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
+	experimentDetails.ExperimentName = Getenv("EXPERIMENT_NAME", "node-restart")
 	experimentDetails.ChaosNamespace = Getenv("CHAOS_NAMESPACE", "litmus")
 	experimentDetails.EngineName = Getenv("CHAOSENGINE", "")
 	experimentDetails.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION", "30"))


### PR DESCRIPTION
This PR aims to fix 2 problems I found while attempting to run the node-restart experiment:
* Running the ssh command in the pod will fail as it attempts to add the target host in the `$HOME/.ssh/known_hosts` file with this error:
`$>oc logs node-restart-fadufq`
`Could not create directory '/.ssh'.`
`Failed to add the host to the list of known hosts (/.ssh/known_hosts).`
 The fix consists in passing the flag `-o UserKnownHostsFile=/dev/null` to the ssh command to use `/dev/null` instead.
* Replaced `nodeName` field for a node selector of `anti-affinity` that will avoid scheduling the ephemeral pod that executes the ssh command, in the same target node where the restart will happen. Setting the `nodeName` field will bypass the scheduler and ignore any cordoning applied to the node.
* Enabled the ability to define the experiment name in the environment, following the other experiments. In this case it's harcoded to `node-restart`. This experiment logic can be applied to other scenarios, for instance node poweroff (I am working on it, I'll raise a PR next week once I've cleaned it up), and it would look better if the name of the running pods align with the experiment ;)
* Bit of cleanup in the go.mod and go.sum. Please confirm if these changes are valid, particularly the ones that mean removing libraries. I only added the kubernetes v1.16 required for the anti-affinity.