### PR TITLE
chore(fix): Update /run-e2e CI with latest chaos action and GitHub actions

### DIFF
--- a/.github/workflows/guide.md
+++ b/.github/workflows/guide.md
@@ -129,13 +129,3 @@ _Experiments Available for custom bot:_
 
 
 ***Note:*** *All the tests are performed on a KinD cluster with containerd runtime.*
-
-## Merge a Pull Request
-
-- For auto merging, we need to comment `/merge` in the PR which will add a label  `merge` in the PR and then finally merge the PR according to the ENVs provided.
-
-_Minimum Number of Approvals:_
-
-- The action will automatically check if the required number of review approvals has been reached. If the number is not reached, it will not merge the PR.
-
-- It will work according to the role of the commenter and branch protection Rule on the repository.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,11 @@ jobs:
           
       - name: Generating Go binary and Building docker image
         run: |
-          make build
+          make build-amd64
 
       #Install and configure a kind cluster
       - name: Installing Prerequisites (KinD Cluster)
-        uses: engineerd/setup-kind@v0.4.0
+        uses: engineerd/setup-kind@v0.5.0
         with:
             version: "v0.7.0"
 
@@ -63,22 +63,28 @@ jobs:
 
       - name: Deploy a sample application for chaos injection
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/mayadata-io/chaos-ci-lib/master/app/nginx.yml
+          kubectl apply -f https://raw.githubusercontent.com/litmuschaos/chaos-ci-lib/master/app/nginx.yml
           sleep 30
           
       - name: Setting up kubeconfig ENV for Github Chaos Action
         run: echo ::set-env name=KUBE_CONFIG_DATA::$(base64 -w 0 ~/.kube/config)
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
+      - name: Setup Litmus
+        uses: mayadata-io/github-chaos-actions@v0.3.0
+        env:
+          INSTALL_LITMUS: true
 
       - name: Running Litmus pod delete chaos experiment
         if: startsWith(github.event.comment.body, '/run-e2e-pod-delete') || startsWith(github.event.comment.body, '/run-e2e-all')
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: pod-delete
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           IMAGE_PULL_POLICY: IfNotPresent
-          LITMUS_CLEANUP: true
+          JOB_CLEANUP_POLICY: delete 
 
       - name: Update pod delete result
         if: startsWith(github.event.comment.body, '/run-e2e-pod-delete') || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -90,15 +96,14 @@ jobs:
 
       - name: Running container kill chaos experiment
         if: startsWith(github.event.comment.body, '/run-e2e-container-kill') || startsWith(github.event.comment.body, '/run-e2e-all')
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: container-kill
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           IMAGE_PULL_POLICY: IfNotPresent
+          JOB_CLEANUP_POLICY: delete 
           CONTAINER_RUNTIME: containerd
-          LITMUS_CLEANUP: true
 
       - name: Update container-kill result
         if: startsWith(github.event.comment.body, '/run-e2e-container-kill') || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -110,14 +115,13 @@ jobs:
 
       - name: Running node-cpu-hog chaos experiment
         if: startsWith(github.event.comment.body, '/run-e2e-node-cpu-hog') || startsWith(github.event.comment.body, '/run-e2e-resource-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: node-cpu-hog
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           IMAGE_PULL_POLICY: IfNotPresent
-          LITMUS_CLEANUP: true
+          JOB_CLEANUP_POLICY: delete 
 
       - name: Update node-cpu-hog result
         if: startsWith(github.event.comment.body, '/run-e2e-node-cpu-hog') || startsWith(github.event.comment.body, '/run-e2e-resource-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -129,14 +133,13 @@ jobs:
 
       - name: Running node-memory-hog chaos experiment
         if: startsWith(github.event.comment.body, '/run-e2e-node-memory-hog') || startsWith(github.event.comment.body, '/run-e2e-resource-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: node-memory-hog
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
           IMAGE_PULL_POLICY: IfNotPresent
-          LITMUS_CLEANUP: true
+          JOB_CLEANUP_POLICY: delete 
 
       - name: Update node-memory-hog result
         if: startsWith(github.event.comment.body, '/run-e2e-node-memory-hog') || startsWith(github.event.comment.body, '/run-e2e-resource-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -148,17 +151,16 @@ jobs:
           
       - name: Running pod-cpu-hog chaos experiment
         if: startsWith(github.event.comment.body, '/run-e2e-pod-cpu-hog') || startsWith(github.event.comment.body, '/run-e2e-resource-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: pod-cpu-hog
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
-          IMAGE_PULL_POLICY: IfNotPresent      
+          IMAGE_PULL_POLICY: IfNotPresent
+          JOB_CLEANUP_POLICY: delete       
           TARGET_CONTAINER: nginx
           TOTAL_CHAOS_DURATION: 60
           CPU_CORES: 1
-          LITMUS_CLEANUP: true
 
       - name: Update pod-cpu-hog result
         if: startsWith(github.event.comment.body, '/run-e2e-pod-cpu-hog') || startsWith(github.event.comment.body, '/run-e2e-resource-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -170,17 +172,16 @@ jobs:
           
       - name: Running pod-memory-hog chaos experiment
         if: startsWith(github.event.comment.body, '/run-e2e-pod-memory-hog') || startsWith(github.event.comment.body, '/run-e2e-resource-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: pod-cpu-hog
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
-          IMAGE_PULL_POLICY: IfNotPresent      
+          IMAGE_PULL_POLICY: IfNotPresent
+          JOB_CLEANUP_POLICY: delete       
           TARGET_CONTAINER: nginx
           TOTAL_CHAOS_DURATION: 60
           MEMORY_CONSUMPTION: 500
-          LITMUS_CLEANUP: true
 
       - name: Update pod-memory-hog result
         if: startsWith(github.event.comment.body, '/run-e2e-pod-memory-hog') || startsWith(github.event.comment.body, '/run-e2e-resource-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -192,18 +193,17 @@ jobs:
           
       - name: Running pod network corruption chaos experiment
         if: startsWith(github.event.comment.body, '/run-e2e-pod-network-corruption') || startsWith(github.event.comment.body, '/run-e2e-network-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: pod-network-corruption
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
-          IMAGE_PULL_POLICY: IfNotPresent      
+          IMAGE_PULL_POLICY: IfNotPresent
+          JOB_CLEANUP_POLICY: delete       
           TARGET_CONTAINER: nginx
           TOTAL_CHAOS_DURATION: 60
           NETWORK_INTERFACE: eth0
-          CONTAINER_RUNTIME: containerd
-          LITMUS_CLEANUP: true 
+          CONTAINER_RUNTIME: containerd 
           
       - name: Update pod-network-corruption result
         if: startsWith(github.event.comment.body, '/run-e2e-pod-network-corruption') || startsWith(github.event.comment.body, '/run-e2e-network-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -215,18 +215,17 @@ jobs:
 
       - name: Running pod network duplication chaos experiment
         if: startsWith(github.event.comment.body, '/run-e2e-pod-network-duplication') || startsWith(github.event.comment.body, '/run-e2e-network-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: pod-network-duplication
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
-          IMAGE_PULL_POLICY: IfNotPresent      
+          IMAGE_PULL_POLICY: IfNotPresent
+          JOB_CLEANUP_POLICY: delete       
           TARGET_CONTAINER: nginx
           TOTAL_CHAOS_DURATION: 60
           NETWORK_INTERFACE: eth0
-          CONTAINER_RUNTIME: containerd
-          LITMUS_CLEANUP: true  
+          CONTAINER_RUNTIME: containerd  
           
       - name: Update pod-network-duplication result
         if: startsWith(github.event.comment.body, '/run-e2e-pod-network-duplication') || startsWith(github.event.comment.body, '/run-e2e-network-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -238,19 +237,18 @@ jobs:
         
       - name: Running pod-network-latency chaos experiment
         if: startsWith(github.event.comment.body, '/run-e2e-pod-network-latency') || startsWith(github.event.comment.body, '/run-e2e-network-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: pod-network-latency
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
-          IMAGE_PULL_POLICY: IfNotPresent        
+          IMAGE_PULL_POLICY: IfNotPresent
+          JOB_CLEANUP_POLICY: delete         
           TARGET_CONTAINER: nginx
           TOTAL_CHAOS_DURATION: 60
           NETWORK_INTERFACE: eth0
           NETWORK_LATENCY: 60000
           CONTAINER_RUNTIME: containerd
-          LITMUS_CLEANUP: true
 
       - name: Update pod-network-latency result
         if: startsWith(github.event.comment.body, '/run-e2e-pod-network-latency') || startsWith(github.event.comment.body, '/run-e2e-network-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -261,19 +259,19 @@ jobs:
             | Pod Network Latency | Pass | containerd |                  
 
       - name: Running pod-network-loss chaos experiment
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        if: startsWith(github.event.comment.body, '/run-e2e-pod-network-loss') || startsWith(github.event.comment.body, '/run-e2e-network-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: pod-network-loss
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
-          IMAGE_PULL_POLICY: IfNotPresent      
+          IMAGE_PULL_POLICY: IfNotPresent
+          JOB_CLEANUP_POLICY: delete       
           TARGET_CONTAINER: nginx
           TOTAL_CHAOS_DURATION: 60
           NETWORK_INTERFACE: eth0
           NETWORK_PACKET_LOSS_PERCENTAGE: 100
           CONTAINER_RUNTIME: containerd
-          LITMUS_CLEANUP: true
 
       - name: Update pod-network-loss result
         if: startsWith(github.event.comment.body, '/run-e2e-pod-network-loss') || startsWith(github.event.comment.body, '/run-e2e-network-chaos')  || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -285,15 +283,14 @@ jobs:
         
       - name: Running pod autoscaler chaos experiment
         if: startsWith(github.event.comment.body, '/run-e2e-pod-autoscaler') || startsWith(github.event.comment.body, '/run-e2e-all')
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: pod-autoscaler
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
-          IMAGE_PULL_POLICY: IfNotPresent     
+          IMAGE_PULL_POLICY: IfNotPresent
+          JOB_CLEANUP_POLICY: delete      
           TOTAL_CHAOS_DURATION: 60
-          LITMUS_CLEANUP: true
 
       - name: Update pod-autoscaler result
         if: startsWith(github.event.comment.body, '/run-e2e-pod-autoscaler') || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -305,16 +302,15 @@ jobs:
         
       - name: Running node-io-stress chaos experiment
         if: startsWith(github.event.comment.body, '/run-e2e-node-io-stress') || startsWith(github.event.comment.body, '/run-e2e-io-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
-        uses: mayadata-io/github-chaos-actions@v0.2.0
+        uses: mayadata-io/github-chaos-actions@v0.3.0
         env:
-          INSTALL_LITMUS: true
           EXPERIMENT_NAME: node-io-stress
           EXPERIMENT_IMAGE: litmuschaos/go-runner
           EXPERIMENT_IMAGE_TAG: ci
-          IMAGE_PULL_POLICY: IfNotPresent      
+          IMAGE_PULL_POLICY: IfNotPresent
+          JOB_CLEANUP_POLICY: delete       
           TOTAL_CHAOS_DURATION: 120
           FILESYSTEM_UTILIZATION_PERCENTAGE: 10
-          LITMUS_CLEANUP: true
           
       - name: Update node-io-stress result
         if: startsWith(github.event.comment.body, '/run-e2e-node-io-stress') || startsWith(github.event.comment.body, '/run-e2e-io-chaos') || startsWith(github.event.comment.body, '/run-e2e-all')
@@ -336,6 +332,8 @@ jobs:
          startsWith(github.event.comment.body, '/run-e2e-io-chaos')  || startsWith(github.event.comment.body, '/run-e2e-all')
         run: |
           echo ::set-env name=TEST_RUN::true
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true        
 
       - name: Check for all the jobs are succeeded
         if: ${{ success() && env.TEST_RUN == 'true' }}
@@ -363,6 +361,11 @@ jobs:
         env: 
           RUN_ID: ${{ github.run_id }}
 
+      - name: Uninstall Litmus
+        uses: mayadata-io/github-chaos-actions@v0.3.0
+        env:          
+          LITMUS_CLEANUP: true
+
       - name: Deleting KinD cluster
         if: ${{ always() }}
         run: kind delete cluster
@@ -379,29 +382,3 @@ jobs:
           reactions: eyes
         env: 
           RUN_ID: ${{ github.run_id }}
-
-  # This job will merge an equipped PR in two steps:
-  # Firstly it will add a merge label on the target PR and then it will merge the PR according to the envs provided.
-  merge:  
-    if: contains(github.event.comment.html_url, '/pull/') && startsWith(github.event.comment.body, '/merge')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Add a merge label 
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          labels: merge
-
-      # The action will automatically check if the required number of review approvals has been reached.   
-      - name: automerge      
-        uses: "pascalgn/automerge-action@f81beb99aef41bb55ad072857d43073fba833a98"
-        env:          
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: "merge,!WIP,!DO NOT MERGE"
-          MERGE_METHOD: "squash"
-          MERGE_FORKS: "true"
-          MERGE_RETRIES: "6"
-          MERGE_RETRY_SLEEP: "10000"
-          UPDATE_LABELS: ""
-          UPDATE_METHOD: "merge"
-          MERGE_DELETE_BRANCH: true


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

This PR includes: 

- Update commands like `set-env` and `add-path` which are deprecated from GitHub actions.
- Update Kind cluster creation action
- Update Chaos Action to the latest version that is `v0.3.0`.
- Make Install and Uninstall as pre & post task in the workflow rather than running for every experiment.
- Set job cleanup policy to `delete`. To save cluster resources. 
- Remove `/merge` command from GitHub actions due to security reasons. 

tested run - https://github.com/uditgaurav/test-litmus-go/runs/1449902688?check_suite_focus=true