### PR TITLE
Add regex comparator to probes

### DIFF
--- a/pkg/probe/comparator.go
+++ b/pkg/probe/comparator.go
@@ -3,6 +3,7 @@ package probe
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -148,6 +149,22 @@ func (model Model) CompareString() error {
 		}
 	case "contains", "Contains":
 		if !strings.Contains(actualOutput, expectedOutput) {
+			return fmt.Errorf("The probe output didn't match with expected criteria")
+		}
+	case "matches", "Matches":
+		re, err := regexp.Compile(expectedOutput)
+		if err != nil {
+			return fmt.Errorf("The probe regex '%s' is not a valid expression", expectedOutput)
+		}
+		if !re.MatchString(actualOutput) {
+			return fmt.Errorf("The probe output didn't match with expected criteria")
+		}
+	case "notMatches", "NotMatches":
+		re, err := regexp.Compile(expectedOutput)
+		if err != nil {
+			return fmt.Errorf("The probe regex '%s' is not a valid expression", expectedOutput)
+		}
+		if re.MatchString(actualOutput) {
 			return fmt.Errorf("The probe output didn't match with expected criteria")
 		}
 	default:


### PR DESCRIPTION
By adding regex comparator to probe, we can evaluate additional expected
outputs which aren't covered by the existing comparators.

This can be useful in various scenarios, e.g when cmdProbe is used and
the output of the command might be several values that all can be
expected.

The `value` attribute of the `cmdProbe` element must follow the supported golang regex [1]

[1] https://github.com/google/re2/wiki/Syntax

Signed-off-by: Moti Asayag <masayag@redhat.com>