### PR TITLE
[WIP] Add experiment that simulates AWS Az being down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/_output
 .stignore
+.idea

--- a/bin/go-runner.go
+++ b/bin/go-runner.go
@@ -32,6 +32,7 @@ import (
 	podNetworkLatency "github.com/litmuschaos/litmus-go/experiments/generic/pod-network-latency/experiment"
 	podNetworkLoss "github.com/litmuschaos/litmus-go/experiments/generic/pod-network-loss/experiment"
 	kafkaBrokerPodFailure "github.com/litmuschaos/litmus-go/experiments/kafka/kafka-broker-pod-failure/experiment"
+	azDown "github.com/litmuschaos/litmus-go/experiments/kube-aws/az-down/experiment"
 	ebsLoss "github.com/litmuschaos/litmus-go/experiments/kube-aws/ebs-loss/experiment"
 	ec2terminate "github.com/litmuschaos/litmus-go/experiments/kube-aws/ec2-terminate/experiment"
 
@@ -109,6 +110,8 @@ func main() {
 		ebsLoss.EBSLoss(clients)
 	case "node-restart":
 		nodeRestart.NodeRestart(clients)
+	case "az-down":
+		azDown.AZDown(clients)
 	default:
 		log.Fatalf("Unsupported -name %v, please provide the correct value of -name args", *experimentName)
 	}

--- a/chaoslib/litmus/az-down/lib/az-down.go
+++ b/chaoslib/litmus/az-down/lib/az-down.go
@@ -1,0 +1,13 @@
+package lib
+
+import "github.com/litmuschaos/litmus-go/pkg/log"
+
+func AZDown() error {
+	log.Info("YES")
+
+	return nil
+	// IF YOU WANT TO USE AN EXISTING CHAOSLIB THEN DELETE THIS FILE AND USE THE SAME
+	// ELSE
+	// ADD THE BUSINESS LOGIC OF THE ACTUAL CHAOS HERE
+	// CALL THIS FUNCTION FROM <experiment-name.go>
+}

--- a/ec2-instances
+++ b/ec2-instances
@@ -1,0 +1,862 @@
+{
+    "Reservations": [
+        {
+            "Groups": [],
+            "Instances": [
+                {
+                    "AmiLaunchIndex": 0,
+                    "ImageId": "ami-060b61707685d896c",
+                    "InstanceId": "i-003020769b8d753ab",
+                    "InstanceType": "m5.xlarge",
+                    "LaunchTime": "2020-10-29T17:09:53+00:00",
+                    "Monitoring": {
+                        "State": "disabled"
+                    },
+                    "Placement": {
+                        "AvailabilityZone": "eu-west-1a",
+                        "GroupName": "",
+                        "Tenancy": "default"
+                    },
+                    "PrivateDnsName": "ip-10-0-172-107.eu-west-1.compute.internal",
+                    "PrivateIpAddress": "10.0.172.107",
+                    "ProductCodes": [],
+                    "PublicDnsName": "",
+                    "State": {
+                        "Code": 16,
+                        "Name": "running"
+                    },
+                    "StateTransitionReason": "",
+                    "SubnetId": "subnet-07b26f59781e3cb37",
+                    "VpcId": "vpc-07462a3825c1b116c",
+                    "Architecture": "x86_64",
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/xvda",
+                            "Ebs": {
+                                "AttachTime": "2020-10-29T17:09:54+00:00",
+                                "DeleteOnTermination": true,
+                                "Status": "attached",
+                                "VolumeId": "vol-0d66810a6b5b4d02a"
+                            }
+                        }
+                    ],
+                    "ClientToken": "3A245EEC-6970-4AE0-B0CA-2F2D3F0B89A9",
+                    "EbsOptimized": false,
+                    "EnaSupport": true,
+                    "Hypervisor": "xen",
+                    "IamInstanceProfile": {
+                        "Arn": "arn:aws:iam::622761864308:instance-profile/pbraun-observatorium-4cnp4-master-profile",
+                        "Id": "AIPAZB7375R2FPFLRYH53"
+                    },
+                    "NetworkInterfaces": [
+                        {
+                            "Attachment": {
+                                "AttachTime": "2020-10-29T17:09:53+00:00",
+                                "AttachmentId": "eni-attach-0763b1edf5efff031",
+                                "DeleteOnTermination": false,
+                                "DeviceIndex": 0,
+                                "Status": "attached"
+                            },
+                            "Description": "",
+                            "Groups": [
+                                {
+                                    "GroupName": "terraform-20201029170931346800000003",
+                                    "GroupId": "sg-02f3a1e1a6947c5dd"
+                                }
+                            ],
+                            "Ipv6Addresses": [],
+                            "MacAddress": "0a:64:30:e5:27:45",
+                            "NetworkInterfaceId": "eni-0269164e597101773",
+                            "OwnerId": "622761864308",
+                            "PrivateDnsName": "ip-10-0-172-107.eu-west-1.compute.internal",
+                            "PrivateIpAddress": "10.0.172.107",
+                            "PrivateIpAddresses": [
+                                {
+                                    "Primary": true,
+                                    "PrivateDnsName": "ip-10-0-172-107.eu-west-1.compute.internal",
+                                    "PrivateIpAddress": "10.0.172.107"
+                                }
+                            ],
+                            "SourceDestCheck": true,
+                            "Status": "in-use",
+                            "SubnetId": "subnet-07b26f59781e3cb37",
+                            "VpcId": "vpc-07462a3825c1b116c",
+                            "InterfaceType": "interface"
+                        }
+                    ],
+                    "RootDeviceName": "/dev/xvda",
+                    "RootDeviceType": "ebs",
+                    "SecurityGroups": [
+                        {
+                            "GroupName": "terraform-20201029170931346800000003",
+                            "GroupId": "sg-02f3a1e1a6947c5dd"
+                        }
+                    ],
+                    "SourceDestCheck": true,
+                    "Tags": [
+                        {
+                            "Key": "Name",
+                            "Value": "pbraun-observatorium-4cnp4-master-1"
+                        },
+                        {
+                            "Key": "kubernetes.io/cluster/pbraun-observatorium-4cnp4",
+                            "Value": "owned"
+                        }
+                    ],
+                    "VirtualizationType": "hvm",
+                    "CpuOptions": {
+                        "CoreCount": 2,
+                        "ThreadsPerCore": 2
+                    },
+                    "CapacityReservationSpecification": {
+                        "CapacityReservationPreference": "open"
+                    },
+                    "HibernationOptions": {
+                        "Configured": false
+                    },
+                    "MetadataOptions": {
+                        "State": "applied",
+                        "HttpTokens": "optional",
+                        "HttpPutResponseHopLimit": 1,
+                        "HttpEndpoint": "enabled"
+                    }
+                }
+            ],
+            "OwnerId": "622761864308",
+            "ReservationId": "r-0ee738c1285f869ee"
+        },
+        {
+            "Groups": [],
+            "Instances": [
+                {
+                    "AmiLaunchIndex": 0,
+                    "ImageId": "ami-060b61707685d896c",
+                    "InstanceId": "i-0ab806d1bbdafe277",
+                    "InstanceType": "m5.xlarge",
+                    "LaunchTime": "2020-10-29T17:09:53+00:00",
+                    "Monitoring": {
+                        "State": "disabled"
+                    },
+                    "Placement": {
+                        "AvailabilityZone": "eu-west-1a",
+                        "GroupName": "",
+                        "Tenancy": "default"
+                    },
+                    "PrivateDnsName": "ip-10-0-207-192.eu-west-1.compute.internal",
+                    "PrivateIpAddress": "10.0.207.192",
+                    "ProductCodes": [],
+                    "PublicDnsName": "",
+                    "State": {
+                        "Code": 16,
+                        "Name": "running"
+                    },
+                    "StateTransitionReason": "",
+                    "SubnetId": "subnet-07b26f59781e3cb37",
+                    "VpcId": "vpc-07462a3825c1b116c",
+                    "Architecture": "x86_64",
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/xvda",
+                            "Ebs": {
+                                "AttachTime": "2020-10-29T17:09:54+00:00",
+                                "DeleteOnTermination": true,
+                                "Status": "attached",
+                                "VolumeId": "vol-04e7a971203afa0eb"
+                            }
+                        }
+                    ],
+                    "ClientToken": "C24BBCC9-91FA-4FD6-8D02-664EDE01A37A",
+                    "EbsOptimized": false,
+                    "EnaSupport": true,
+                    "Hypervisor": "xen",
+                    "IamInstanceProfile": {
+                        "Arn": "arn:aws:iam::622761864308:instance-profile/pbraun-observatorium-4cnp4-master-profile",
+                        "Id": "AIPAZB7375R2FPFLRYH53"
+                    },
+                    "NetworkInterfaces": [
+                        {
+                            "Attachment": {
+                                "AttachTime": "2020-10-29T17:09:53+00:00",
+                                "AttachmentId": "eni-attach-0bdd2dac56b670505",
+                                "DeleteOnTermination": false,
+                                "DeviceIndex": 0,
+                                "Status": "attached"
+                            },
+                            "Description": "",
+                            "Groups": [
+                                {
+                                    "GroupName": "terraform-20201029170931346800000003",
+                                    "GroupId": "sg-02f3a1e1a6947c5dd"
+                                }
+                            ],
+                            "Ipv6Addresses": [],
+                            "MacAddress": "0a:57:f7:35:f9:f1",
+                            "NetworkInterfaceId": "eni-093d5d817b953de99",
+                            "OwnerId": "622761864308",
+                            "PrivateDnsName": "ip-10-0-207-192.eu-west-1.compute.internal",
+                            "PrivateIpAddress": "10.0.207.192",
+                            "PrivateIpAddresses": [
+                                {
+                                    "Primary": true,
+                                    "PrivateDnsName": "ip-10-0-207-192.eu-west-1.compute.internal",
+                                    "PrivateIpAddress": "10.0.207.192"
+                                }
+                            ],
+                            "SourceDestCheck": true,
+                            "Status": "in-use",
+                            "SubnetId": "subnet-07b26f59781e3cb37",
+                            "VpcId": "vpc-07462a3825c1b116c",
+                            "InterfaceType": "interface"
+                        }
+                    ],
+                    "RootDeviceName": "/dev/xvda",
+                    "RootDeviceType": "ebs",
+                    "SecurityGroups": [
+                        {
+                            "GroupName": "terraform-20201029170931346800000003",
+                            "GroupId": "sg-02f3a1e1a6947c5dd"
+                        }
+                    ],
+                    "SourceDestCheck": true,
+                    "Tags": [
+                        {
+                            "Key": "Name",
+                            "Value": "pbraun-observatorium-4cnp4-master-0"
+                        },
+                        {
+                            "Key": "kubernetes.io/cluster/pbraun-observatorium-4cnp4",
+                            "Value": "owned"
+                        }
+                    ],
+                    "VirtualizationType": "hvm",
+                    "CpuOptions": {
+                        "CoreCount": 2,
+                        "ThreadsPerCore": 2
+                    },
+                    "CapacityReservationSpecification": {
+                        "CapacityReservationPreference": "open"
+                    },
+                    "HibernationOptions": {
+                        "Configured": false
+                    },
+                    "MetadataOptions": {
+                        "State": "applied",
+                        "HttpTokens": "optional",
+                        "HttpPutResponseHopLimit": 1,
+                        "HttpEndpoint": "enabled"
+                    }
+                }
+            ],
+            "OwnerId": "622761864308",
+            "ReservationId": "r-0569b1eb8b270d282"
+        },
+        {
+            "Groups": [],
+            "Instances": [
+                {
+                    "AmiLaunchIndex": 0,
+                    "ImageId": "ami-060b61707685d896c",
+                    "InstanceId": "i-0c17df375ee86b227",
+                    "InstanceType": "m5.xlarge",
+                    "LaunchTime": "2020-10-29T17:09:53+00:00",
+                    "Monitoring": {
+                        "State": "disabled"
+                    },
+                    "Placement": {
+                        "AvailabilityZone": "eu-west-1a",
+                        "GroupName": "",
+                        "Tenancy": "default"
+                    },
+                    "PrivateDnsName": "ip-10-0-208-29.eu-west-1.compute.internal",
+                    "PrivateIpAddress": "10.0.208.29",
+                    "ProductCodes": [],
+                    "PublicDnsName": "",
+                    "State": {
+                        "Code": 16,
+                        "Name": "running"
+                    },
+                    "StateTransitionReason": "",
+                    "SubnetId": "subnet-07b26f59781e3cb37",
+                    "VpcId": "vpc-07462a3825c1b116c",
+                    "Architecture": "x86_64",
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/xvda",
+                            "Ebs": {
+                                "AttachTime": "2020-10-29T17:09:54+00:00",
+                                "DeleteOnTermination": true,
+                                "Status": "attached",
+                                "VolumeId": "vol-09342496e3511934b"
+                            }
+                        }
+                    ],
+                    "ClientToken": "17E7EC13-540A-42D7-A22F-7B9B28A76E4B",
+                    "EbsOptimized": false,
+                    "EnaSupport": true,
+                    "Hypervisor": "xen",
+                    "IamInstanceProfile": {
+                        "Arn": "arn:aws:iam::622761864308:instance-profile/pbraun-observatorium-4cnp4-master-profile",
+                        "Id": "AIPAZB7375R2FPFLRYH53"
+                    },
+                    "NetworkInterfaces": [
+                        {
+                            "Attachment": {
+                                "AttachTime": "2020-10-29T17:09:53+00:00",
+                                "AttachmentId": "eni-attach-0c51b2b40c466b9f5",
+                                "DeleteOnTermination": false,
+                                "DeviceIndex": 0,
+                                "Status": "attached"
+                            },
+                            "Description": "",
+                            "Groups": [
+                                {
+                                    "GroupName": "terraform-20201029170931346800000003",
+                                    "GroupId": "sg-02f3a1e1a6947c5dd"
+                                }
+                            ],
+                            "Ipv6Addresses": [],
+                            "MacAddress": "0a:8c:cc:70:6e:c1",
+                            "NetworkInterfaceId": "eni-042d7556dc104912b",
+                            "OwnerId": "622761864308",
+                            "PrivateDnsName": "ip-10-0-208-29.eu-west-1.compute.internal",
+                            "PrivateIpAddress": "10.0.208.29",
+                            "PrivateIpAddresses": [
+                                {
+                                    "Primary": true,
+                                    "PrivateDnsName": "ip-10-0-208-29.eu-west-1.compute.internal",
+                                    "PrivateIpAddress": "10.0.208.29"
+                                }
+                            ],
+                            "SourceDestCheck": true,
+                            "Status": "in-use",
+                            "SubnetId": "subnet-07b26f59781e3cb37",
+                            "VpcId": "vpc-07462a3825c1b116c",
+                            "InterfaceType": "interface"
+                        }
+                    ],
+                    "RootDeviceName": "/dev/xvda",
+                    "RootDeviceType": "ebs",
+                    "SecurityGroups": [
+                        {
+                            "GroupName": "terraform-20201029170931346800000003",
+                            "GroupId": "sg-02f3a1e1a6947c5dd"
+                        }
+                    ],
+                    "SourceDestCheck": true,
+                    "Tags": [
+                        {
+                            "Key": "Name",
+                            "Value": "pbraun-observatorium-4cnp4-master-2"
+                        },
+                        {
+                            "Key": "kubernetes.io/cluster/pbraun-observatorium-4cnp4",
+                            "Value": "owned"
+                        }
+                    ],
+                    "VirtualizationType": "hvm",
+                    "CpuOptions": {
+                        "CoreCount": 2,
+                        "ThreadsPerCore": 2
+                    },
+                    "CapacityReservationSpecification": {
+                        "CapacityReservationPreference": "open"
+                    },
+                    "HibernationOptions": {
+                        "Configured": false
+                    },
+                    "MetadataOptions": {
+                        "State": "applied",
+                        "HttpTokens": "optional",
+                        "HttpPutResponseHopLimit": 1,
+                        "HttpEndpoint": "enabled"
+                    }
+                }
+            ],
+            "OwnerId": "622761864308",
+            "ReservationId": "r-07107c94fdf5d52c1"
+        },
+        {
+            "Groups": [],
+            "Instances": [
+                {
+                    "AmiLaunchIndex": 0,
+                    "ImageId": "ami-060b61707685d896c",
+                    "InstanceId": "i-02335f2bbec9b938d",
+                    "InstanceType": "m5.xlarge",
+                    "LaunchTime": "2020-10-29T17:23:59+00:00",
+                    "Monitoring": {
+                        "State": "disabled"
+                    },
+                    "Placement": {
+                        "AvailabilityZone": "eu-west-1a",
+                        "GroupName": "",
+                        "Tenancy": "default"
+                    },
+                    "PrivateDnsName": "ip-10-0-212-242.eu-west-1.compute.internal",
+                    "PrivateIpAddress": "10.0.212.242",
+                    "ProductCodes": [],
+                    "PublicDnsName": "",
+                    "State": {
+                        "Code": 16,
+                        "Name": "running"
+                    },
+                    "StateTransitionReason": "",
+                    "SubnetId": "subnet-07b26f59781e3cb37",
+                    "VpcId": "vpc-07462a3825c1b116c",
+                    "Architecture": "x86_64",
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/xvda",
+                            "Ebs": {
+                                "AttachTime": "2020-10-29T17:24:00+00:00",
+                                "DeleteOnTermination": true,
+                                "Status": "attached",
+                                "VolumeId": "vol-0da1d03dddddc4279"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdcs",
+                            "Ebs": {
+                                "AttachTime": "2020-10-30T09:18:35+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-0a8f10a9f6e84ac07"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdcg",
+                            "Ebs": {
+                                "AttachTime": "2020-10-30T09:18:35+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-06ca00aae22d67988"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdbs",
+                            "Ebs": {
+                                "AttachTime": "2020-11-06T17:40:56+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-05e9463ce36a54b4f"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdbf",
+                            "Ebs": {
+                                "AttachTime": "2020-11-06T17:51:42+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-0a77056acc4ed584c"
+                            }
+                        }
+                    ],
+                    "ClientToken": "",
+                    "EbsOptimized": false,
+                    "EnaSupport": true,
+                    "Hypervisor": "xen",
+                    "IamInstanceProfile": {
+                        "Arn": "arn:aws:iam::622761864308:instance-profile/pbraun-observatorium-4cnp4-worker-profile",
+                        "Id": "AIPAZB7375R2BQQAMD36Y"
+                    },
+                    "NetworkInterfaces": [
+                        {
+                            "Attachment": {
+                                "AttachTime": "2020-10-29T17:23:59+00:00",
+                                "AttachmentId": "eni-attach-09029d920375d7b13",
+                                "DeleteOnTermination": true,
+                                "DeviceIndex": 0,
+                                "Status": "attached"
+                            },
+                            "Description": "",
+                            "Groups": [
+                                {
+                                    "GroupName": "terraform-20201029170931346100000002",
+                                    "GroupId": "sg-0456fb1d6d3be496a"
+                                }
+                            ],
+                            "Ipv6Addresses": [],
+                            "MacAddress": "0a:5d:0f:bf:a7:a3",
+                            "NetworkInterfaceId": "eni-0311f5e81e18ef329",
+                            "OwnerId": "622761864308",
+                            "PrivateDnsName": "ip-10-0-212-242.eu-west-1.compute.internal",
+                            "PrivateIpAddress": "10.0.212.242",
+                            "PrivateIpAddresses": [
+                                {
+                                    "Primary": true,
+                                    "PrivateDnsName": "ip-10-0-212-242.eu-west-1.compute.internal",
+                                    "PrivateIpAddress": "10.0.212.242"
+                                }
+                            ],
+                            "SourceDestCheck": true,
+                            "Status": "in-use",
+                            "SubnetId": "subnet-07b26f59781e3cb37",
+                            "VpcId": "vpc-07462a3825c1b116c",
+                            "InterfaceType": "interface"
+                        }
+                    ],
+                    "RootDeviceName": "/dev/xvda",
+                    "RootDeviceType": "ebs",
+                    "SecurityGroups": [
+                        {
+                            "GroupName": "terraform-20201029170931346100000002",
+                            "GroupId": "sg-0456fb1d6d3be496a"
+                        }
+                    ],
+                    "SourceDestCheck": true,
+                    "Tags": [
+                        {
+                            "Key": "Name",
+                            "Value": "pbraun-observatorium-4cnp4-worker-eu-west-1a-bwvcj"
+                        },
+                        {
+                            "Key": "kubernetes.io/cluster/pbraun-observatorium-4cnp4",
+                            "Value": "owned"
+                        }
+                    ],
+                    "VirtualizationType": "hvm",
+                    "CpuOptions": {
+                        "CoreCount": 2,
+                        "ThreadsPerCore": 2
+                    },
+                    "CapacityReservationSpecification": {
+                        "CapacityReservationPreference": "open"
+                    },
+                    "HibernationOptions": {
+                        "Configured": false
+                    },
+                    "MetadataOptions": {
+                        "State": "applied",
+                        "HttpTokens": "optional",
+                        "HttpPutResponseHopLimit": 1,
+                        "HttpEndpoint": "enabled"
+                    }
+                }
+            ],
+            "OwnerId": "622761864308",
+            "ReservationId": "r-02472a19998904845"
+        },
+        {
+            "Groups": [],
+            "Instances": [
+                {
+                    "AmiLaunchIndex": 0,
+                    "ImageId": "ami-060b61707685d896c",
+                    "InstanceId": "i-0a78ff91e45615718",
+                    "InstanceType": "m5.xlarge",
+                    "LaunchTime": "2020-10-29T17:24:01+00:00",
+                    "Monitoring": {
+                        "State": "disabled"
+                    },
+                    "Placement": {
+                        "AvailabilityZone": "eu-west-1a",
+                        "GroupName": "",
+                        "Tenancy": "default"
+                    },
+                    "PrivateDnsName": "ip-10-0-240-193.eu-west-1.compute.internal",
+                    "PrivateIpAddress": "10.0.240.193",
+                    "ProductCodes": [],
+                    "PublicDnsName": "",
+                    "State": {
+                        "Code": 16,
+                        "Name": "running"
+                    },
+                    "StateTransitionReason": "",
+                    "SubnetId": "subnet-07b26f59781e3cb37",
+                    "VpcId": "vpc-07462a3825c1b116c",
+                    "Architecture": "x86_64",
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/xvda",
+                            "Ebs": {
+                                "AttachTime": "2020-10-29T17:24:01+00:00",
+                                "DeleteOnTermination": true,
+                                "Status": "attached",
+                                "VolumeId": "vol-0169dee4549d93b9b"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdct",
+                            "Ebs": {
+                                "AttachTime": "2020-10-30T09:18:35+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-0a0f55262cb62f783"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdba",
+                            "Ebs": {
+                                "AttachTime": "2020-10-30T10:27:45+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-032e3606125877ac3"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdca",
+                            "Ebs": {
+                                "AttachTime": "2020-11-06T17:41:51+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-0d896e8f13ff33822"
+                            }
+                        }
+                    ],
+                    "ClientToken": "",
+                    "EbsOptimized": false,
+                    "EnaSupport": true,
+                    "Hypervisor": "xen",
+                    "IamInstanceProfile": {
+                        "Arn": "arn:aws:iam::622761864308:instance-profile/pbraun-observatorium-4cnp4-worker-profile",
+                        "Id": "AIPAZB7375R2BQQAMD36Y"
+                    },
+                    "NetworkInterfaces": [
+                        {
+                            "Attachment": {
+                                "AttachTime": "2020-10-29T17:24:01+00:00",
+                                "AttachmentId": "eni-attach-04e5a2c6c024b999e",
+                                "DeleteOnTermination": true,
+                                "DeviceIndex": 0,
+                                "Status": "attached"
+                            },
+                            "Description": "",
+                            "Groups": [
+                                {
+                                    "GroupName": "terraform-20201029170931346100000002",
+                                    "GroupId": "sg-0456fb1d6d3be496a"
+                                }
+                            ],
+                            "Ipv6Addresses": [],
+                            "MacAddress": "0a:68:b6:92:43:ad",
+                            "NetworkInterfaceId": "eni-0b750886d755e11d3",
+                            "OwnerId": "622761864308",
+                            "PrivateDnsName": "ip-10-0-240-193.eu-west-1.compute.internal",
+                            "PrivateIpAddress": "10.0.240.193",
+                            "PrivateIpAddresses": [
+                                {
+                                    "Primary": true,
+                                    "PrivateDnsName": "ip-10-0-240-193.eu-west-1.compute.internal",
+                                    "PrivateIpAddress": "10.0.240.193"
+                                }
+                            ],
+                            "SourceDestCheck": true,
+                            "Status": "in-use",
+                            "SubnetId": "subnet-07b26f59781e3cb37",
+                            "VpcId": "vpc-07462a3825c1b116c",
+                            "InterfaceType": "interface"
+                        }
+                    ],
+                    "RootDeviceName": "/dev/xvda",
+                    "RootDeviceType": "ebs",
+                    "SecurityGroups": [
+                        {
+                            "GroupName": "terraform-20201029170931346100000002",
+                            "GroupId": "sg-0456fb1d6d3be496a"
+                        }
+                    ],
+                    "SourceDestCheck": true,
+                    "Tags": [
+                        {
+                            "Key": "kubernetes.io/cluster/pbraun-observatorium-4cnp4",
+                            "Value": "owned"
+                        },
+                        {
+                            "Key": "Name",
+                            "Value": "pbraun-observatorium-4cnp4-worker-eu-west-1a-dk8bf"
+                        }
+                    ],
+                    "VirtualizationType": "hvm",
+                    "CpuOptions": {
+                        "CoreCount": 2,
+                        "ThreadsPerCore": 2
+                    },
+                    "CapacityReservationSpecification": {
+                        "CapacityReservationPreference": "open"
+                    },
+                    "HibernationOptions": {
+                        "Configured": false
+                    },
+                    "MetadataOptions": {
+                        "State": "applied",
+                        "HttpTokens": "optional",
+                        "HttpPutResponseHopLimit": 1,
+                        "HttpEndpoint": "enabled"
+                    }
+                }
+            ],
+            "OwnerId": "622761864308",
+            "ReservationId": "r-037835368142d9029"
+        },
+        {
+            "Groups": [],
+            "Instances": [
+                {
+                    "AmiLaunchIndex": 0,
+                    "ImageId": "ami-060b61707685d896c",
+                    "InstanceId": "i-0a7a9154b652f4b65",
+                    "InstanceType": "m5.xlarge",
+                    "LaunchTime": "2020-10-29T17:24:02+00:00",
+                    "Monitoring": {
+                        "State": "disabled"
+                    },
+                    "Placement": {
+                        "AvailabilityZone": "eu-west-1a",
+                        "GroupName": "",
+                        "Tenancy": "default"
+                    },
+                    "PrivateDnsName": "ip-10-0-199-116.eu-west-1.compute.internal",
+                    "PrivateIpAddress": "10.0.199.116",
+                    "ProductCodes": [],
+                    "PublicDnsName": "",
+                    "State": {
+                        "Code": 16,
+                        "Name": "running"
+                    },
+                    "StateTransitionReason": "",
+                    "SubnetId": "subnet-07b26f59781e3cb37",
+                    "VpcId": "vpc-07462a3825c1b116c",
+                    "Architecture": "x86_64",
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/xvda",
+                            "Ebs": {
+                                "AttachTime": "2020-10-29T17:24:03+00:00",
+                                "DeleteOnTermination": true,
+                                "Status": "attached",
+                                "VolumeId": "vol-02befb85f690a352f"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdci",
+                            "Ebs": {
+                                "AttachTime": "2020-10-30T09:18:12+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-0b304e72d161bfc8b"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdcn",
+                            "Ebs": {
+                                "AttachTime": "2020-10-30T09:18:35+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-0d35ca48a5e6ea9e4"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdbd",
+                            "Ebs": {
+                                "AttachTime": "2020-10-30T10:25:45+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-0b6b73c3e531e8534"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdba",
+                            "Ebs": {
+                                "AttachTime": "2020-11-06T17:40:06+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-0e4fd666b90c3718d"
+                            }
+                        },
+                        {
+                            "DeviceName": "/dev/xvdcy",
+                            "Ebs": {
+                                "AttachTime": "2020-11-06T17:49:43+00:00",
+                                "DeleteOnTermination": false,
+                                "Status": "attached",
+                                "VolumeId": "vol-03f748bb84857f3ea"
+                            }
+                        }
+                    ],
+                    "ClientToken": "",
+                    "EbsOptimized": false,
+                    "EnaSupport": true,
+                    "Hypervisor": "xen",
+                    "IamInstanceProfile": {
+                        "Arn": "arn:aws:iam::622761864308:instance-profile/pbraun-observatorium-4cnp4-worker-profile",
+                        "Id": "AIPAZB7375R2BQQAMD36Y"
+                    },
+                    "NetworkInterfaces": [
+                        {
+                            "Attachment": {
+                                "AttachTime": "2020-10-29T17:24:02+00:00",
+                                "AttachmentId": "eni-attach-06e2a73c5899145fd",
+                                "DeleteOnTermination": true,
+                                "DeviceIndex": 0,
+                                "Status": "attached"
+                            },
+                            "Description": "",
+                            "Groups": [
+                                {
+                                    "GroupName": "terraform-20201029170931346100000002",
+                                    "GroupId": "sg-0456fb1d6d3be496a"
+                                }
+                            ],
+                            "Ipv6Addresses": [],
+                            "MacAddress": "0a:24:1b:33:8a:f7",
+                            "NetworkInterfaceId": "eni-0c610f1f004d50d4d",
+                            "OwnerId": "622761864308",
+                            "PrivateDnsName": "ip-10-0-199-116.eu-west-1.compute.internal",
+                            "PrivateIpAddress": "10.0.199.116",
+                            "PrivateIpAddresses": [
+                                {
+                                    "Primary": true,
+                                    "PrivateDnsName": "ip-10-0-199-116.eu-west-1.compute.internal",
+                                    "PrivateIpAddress": "10.0.199.116"
+                                }
+                            ],
+                            "SourceDestCheck": true,
+                            "Status": "in-use",
+                            "SubnetId": "subnet-07b26f59781e3cb37",
+                            "VpcId": "vpc-07462a3825c1b116c",
+                            "InterfaceType": "interface"
+                        }
+                    ],
+                    "RootDeviceName": "/dev/xvda",
+                    "RootDeviceType": "ebs",
+                    "SecurityGroups": [
+                        {
+                            "GroupName": "terraform-20201029170931346100000002",
+                            "GroupId": "sg-0456fb1d6d3be496a"
+                        }
+                    ],
+                    "SourceDestCheck": true,
+                    "Tags": [
+                        {
+                            "Key": "kubernetes.io/cluster/pbraun-observatorium-4cnp4",
+                            "Value": "owned"
+                        },
+                        {
+                            "Key": "Name",
+                            "Value": "pbraun-observatorium-4cnp4-worker-eu-west-1a-h55nh"
+                        }
+                    ],
+                    "VirtualizationType": "hvm",
+                    "CpuOptions": {
+                        "CoreCount": 2,
+                        "ThreadsPerCore": 2
+                    },
+                    "CapacityReservationSpecification": {
+                        "CapacityReservationPreference": "open"
+                    },
+                    "HibernationOptions": {
+                        "Configured": false
+                    },
+                    "MetadataOptions": {
+                        "State": "applied",
+                        "HttpTokens": "optional",
+                        "HttpPutResponseHopLimit": 1,
+                        "HttpEndpoint": "enabled"
+                    }
+                }
+            ],
+            "OwnerId": "622761864308",
+            "ReservationId": "r-0095564e03b169e5a"
+        }
+    ]
+}

--- a/experiments/kube-aws/az-down/az-down.chartserviceversion.yaml
+++ b/experiments/kube-aws/az-down/az-down.chartserviceversion.yaml
@@ -1,0 +1,29 @@
+apiVersion: litmuchaos.io/v1alpha1
+kind: ChartServiceVersion
+metadata:
+  name: az-down 
+  version: 0.1.0
+  annotations:
+    categories: kube-aws
+    repository: https://github.com/litmuschaos/litmus-go/tree/master/experiments/kube-aws/az-down
+    support: https://kubernetes.slack.com/messages/CNXNB0ZTN
+spec:
+  displayName: az-down 
+  categoryDescription: >
+    simulating AZ to be down 
+  keywords: 
+    - "kubernetes" 
+    - "kube-aws"
+  maturity: alpha 
+  minKubeVersion: 1.12.0 
+  provider: 
+    name: redhat
+  maintainers: 
+    - name: jhellar 
+      email: jhellar@redhat.com
+  links: 
+    - name: Documentation 
+      url: https://docs.litmuschaos.io/docs/getstarted/ 
+  icon:
+    - url: 
+      mediatype: ""

--- a/experiments/kube-aws/az-down/engine.yaml
+++ b/experiments/kube-aws/az-down/engine.yaml
@@ -1,0 +1,32 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+spec:
+  appinfo:
+    appns: 'kafka-cluster'
+    applabel: 'app.kubernetes.io/name=kafka'
+    appkind: 'statefulset'
+  # It can be true/false
+  annotationCheck: 'true'
+  # It can be active/stop
+  engineState: 'active'
+  #ex. values: ns1:name=percona,ns2:run=nginx
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: az-down-sa
+  monitoring: false
+  # It can be delete/retain
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: az-down
+      spec:
+        components:
+          env:
+            # set chaos duration (in sec) as desired
+            - name: TOTAL_CHAOS_DURATION
+              value: '30'
+
+            # set chaos interval (in sec) as desired
+            - name: CHAOS_INTERVAL
+              value: '10'
+              

--- a/experiments/kube-aws/az-down/engine.yaml
+++ b/experiments/kube-aws/az-down/engine.yaml
@@ -1,14 +1,14 @@
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
-  name: nginx-chaos
+  name: az-down-chaos
 spec:
   appinfo:
     appns: 'kafka-cluster'
     applabel: 'app.kubernetes.io/name=kafka'
     appkind: 'statefulset'
   # It can be true/false
-  annotationCheck: 'true'
+  annotationCheck: 'false'
   # It can be active/stop
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx
@@ -29,4 +29,25 @@ spec:
             # set chaos interval (in sec) as desired
             - name: CHAOS_INTERVAL
               value: '10'
+
+            # set aws region where az is located
+            - name: AWS_REGION
+              value: ''
+
+            # set key id for IAM user to be used
+            - name: AWS_IAM_KEY_ID
+              value: '10'
+
+            # set secret for IAM user to be used
+            - name: AWS_IAM_SECRET
+              value: '10'
+
+            # number of nodes to simulate failure of
+            - name: NODE_FAILURES
+              value: ''
+
+            # number of nodes to simulate failure of
+            - name: NODE_NAMES_TO_TARGET
+              value: ''
+
               

--- a/experiments/kube-aws/az-down/experiment.yaml
+++ b/experiments/kube-aws/az-down/experiment.yaml
@@ -1,0 +1,56 @@
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    simulating AZ to be down
+kind: ChaosExperiment
+metadata:
+  name: az-down
+  version: 0.1.0 
+spec:
+  definition:
+    scope: Cluster
+    permissions:
+      - apiGroups: 
+          - "" 
+          - "batch" 
+          - "litmuschaos.io"
+        resources: 
+          - "jobs" 
+          - "pods" 
+          - "events" 
+          - "pods/log" 
+          - "secrets" 
+          - "chaosengines" 
+          - "chaosexperiments" 
+          - "chaosresults"
+        verbs: 
+          - "create" 
+          - "list" 
+          - "get" 
+          - "update" 
+          - "patch" 
+          - "delete"
+    image: "litmuschaos/litmus-go:latest"
+    args:
+    - -c
+    - ./experiments/az-down
+    command:
+    - /bin/bash
+    env:
+    - name: ANSIBLE_STDOUT_CALLBACK
+      value: 'default'
+
+    - name: TOTAL_CHAOS_DURATION
+      value: '' 
+
+    - name: CHAOS_INTERVAL
+      value: ''
+
+    - name: LIB
+      value: ''
+
+    - name: RAMP_TIME
+      value: ''
+      
+    labels:
+      experiment: az-down 

--- a/experiments/kube-aws/az-down/experiment/az-down.go
+++ b/experiments/kube-aws/az-down/experiment/az-down.go
@@ -1,0 +1,178 @@
+package experiment
+
+import (
+	litmusLIB "github.com/litmuschaos/litmus-go/chaoslib/litmus/az-down/lib"
+	clients "github.com/litmuschaos/litmus-go/pkg/clients"
+	"github.com/litmuschaos/litmus-go/pkg/events"
+	experimentEnv "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/environment"
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/types"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/probe"
+	"github.com/litmuschaos/litmus-go/pkg/result"
+	"github.com/litmuschaos/litmus-go/pkg/status"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/sirupsen/logrus"
+)
+
+func AZDown(clients clients.ClientSets) {
+
+	var err error
+	experimentsDetails := experimentTypes.ExperimentDetails{}
+	resultDetails := types.ResultDetails{}
+	eventsDetails := types.EventDetails{}
+	chaosDetails := types.ChaosDetails{}
+
+	//Fetching all the ENV passed from the runner pod
+	log.Infof("[PreReq]: Getting the ENV for the %v experiment", experimentsDetails.ExperimentName)
+	experimentEnv.GetENV(&experimentsDetails)
+
+	// Intialise the chaos attributes
+	experimentEnv.InitialiseChaosVariables(&chaosDetails, &experimentsDetails)
+
+	// Intialise Chaos Result Parameters
+	types.SetResultAttributes(&resultDetails, chaosDetails)
+
+	// Intialise the probe details. Bail out upon error, as we haven't entered exp business logic yet
+	if err := probe.InitializeProbesInChaosResultDetails(&chaosDetails, clients, &resultDetails); err != nil {
+		log.Fatalf("Unable to initialise probes details from chaosengine, err: %v", err)
+	}
+
+	//Updating the chaos result in the beginning of experiment
+	log.Infof("[PreReq]: Updating the chaos result of %v experiment (SOT)", experimentsDetails.ExperimentName)
+	err = result.ChaosResult(&chaosDetails, clients, &resultDetails, "SOT")
+	if err != nil {
+		log.Errorf("Unable to Create the Chaos Result, err: %v", err)
+		failStep := "Updating the chaos result of az-down experiment (SOT)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// Set the chaos result uid
+	result.SetResultUID(&resultDetails, clients, &chaosDetails)
+
+	// generating the event in chaosresult to marked the verdict as awaited
+	msg := "experiment: " + experimentsDetails.ExperimentName + ", Result: Awaited"
+	types.SetResultEventAttributes(&eventsDetails, types.AwaitedVerdict, msg, "Normal", &resultDetails)
+	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
+
+	//DISPLAY THE APP INFORMATION
+	log.InfoWithValues("The application information is as follows", logrus.Fields{
+		"Namespace": experimentsDetails.AppNS,
+		"Label":     experimentsDetails.AppLabel,
+		"Ramp Time": experimentsDetails.RampTime,
+	})
+
+	//PRE-CHAOS APPLICATION STATUS CHECK
+	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (pre-chaos)")
+	err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	if err != nil {
+		log.Errorf("Application status check failed, err: %v", err)
+		failStep := "Verify that the AUT (Application Under Test) is running (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := "AUT: Running"
+
+		// run the probes in the pre-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+
+			err = probe.RunProbes(&chaosDetails, clients, &resultDetails, "PreChaos", &eventsDetails)
+			if err != nil {
+				log.Errorf("Probe Failed, err: %v", err)
+				failStep := "Failed while running probes"
+				msg := "AUT: Running, Probes: Unsuccessful"
+				types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = "AUT: Running, Probes: Successful"
+		}
+		// generating the events for the pre-chaos check
+		types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	// INVOKE THE CHAOSLIB OF YOUR CHOICE HERE, WHICH WILL CONTAIN
+	// THE BUSINESS LOGIC OF THE ACTUAL CHAOS
+	// IT CAN BE A NEW CHAOSLIB YOU HAVE CREATED SPECIALLY FOR THIS EXPERIMENT OR ANY EXISTING ONE
+
+	// Including the litmus lib
+	if experimentsDetails.ChaosLib == "litmus" {
+		err = litmusLIB.AZDown()
+		if err != nil {
+			log.Errorf("Chaos injection failed, err: %v", err)
+			failStep := "failed in chaos injection phase"
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+		log.Info("[Confirmation]: chaos has been injected successfully")
+		resultDetails.Verdict = "Pass"
+	} else {
+		log.Error("[Invalid]: Please Provide the correct LIB")
+		failStep := "no match found for specified lib"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	//POST-CHAOS APPLICATION STATUS CHECK
+	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (post-chaos)")
+	err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	if err != nil {
+		log.Errorf("Application status check failed, err: %v", err)
+		failStep := "Verify that the AUT (Application Under Test) is running (post-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := "AUT: Running"
+
+		// run the probes in the post-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+			err = probe.RunProbes(&chaosDetails, clients, &resultDetails, "PostChaos", &eventsDetails)
+			if err != nil {
+				log.Errorf("Probes Failed, err: %v", err)
+				failStep := "Failed while running probes"
+				msg := "AUT: Running, Probes: Unsuccessful"
+				types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = "AUT: Running, Probes: Successful"
+		}
+
+		// generating post chaos event
+		types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	//Updating the chaosResult in the end of experiment
+	log.Infof("[The End]: Updating the chaos result of %v experiment (EOT)", experimentsDetails.ExperimentName)
+	err = result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+	if err != nil {
+		log.Fatalf("Unable to Update the Chaos Result, err: %v", err)
+	}
+
+	// generating the event in chaosresult to marked the verdict as pass/fail
+	msg = "experiment: " + experimentsDetails.ExperimentName + ", Result: " + resultDetails.Verdict
+	reason := types.PassVerdict
+	eventType := "Normal"
+	if resultDetails.Verdict != "Pass" {
+		reason = types.FailVerdict
+		eventType = "Warning"
+	}
+	types.SetResultEventAttributes(&eventsDetails, reason, msg, eventType, &resultDetails)
+	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
+
+	if experimentsDetails.EngineName != "" {
+		msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
+		types.SetEngineEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+}

--- a/experiments/kube-aws/az-down/experiment/az-down.go
+++ b/experiments/kube-aws/az-down/experiment/az-down.go
@@ -16,7 +16,6 @@ import (
 	"github.com/litmuschaos/litmus-go/pkg/types"
 	"github.com/sirupsen/logrus"
 	"math/rand"
-	"strings"
 )
 
 // returns all AZ's instances are located in
@@ -30,17 +29,7 @@ func selectRandomAz(azlist []string) (string) {
 	return azlist[rand.Intn(len(azlist))]
 }
 
-// check if instance name matches what we want to target
-func isTargetableInstance(instanceName string, identifiers []string) (bool) {
-	for _, identifier := range identifiers {
-		if strings.Contains(instanceName, identifier) {
-			return true
-		}
-	}
-	return false
-}
-
-//
+// chooses an az at random to target
 func getAzToTarget(instances []*experimentTypes.InstanceDetails) (string) {
 
 	availableAzsToTarget := getAzRangeOfInstances(instances) // look at targeting more than 1 az if possible
@@ -49,69 +38,12 @@ func getAzToTarget(instances []*experimentTypes.InstanceDetails) (string) {
 	return selectRandomAz(availableAzsToTarget)
 }
 
-//
-func getVpcOfAzInstances(instances []*experimentTypes.InstanceDetails, az string) ([]*experimentTypes.InstanceDetails, error) {
-
-	azToTarget := getAzToTarget(instances)
-
-	// return vpc that corresponds to instances
-	vpcOfinstancesInTargetAz := getInstancesInAz(instances, azToTarget)
-
-
-}
-
 func getNetworkAclAssociationIdForSubnet(subnetId string) (string, error) {
 	return "", nil //TODO implement
 }
 
 func getNetworkAclIdForSubnet (subnetId string) (string, error) {
 	return "", nil //TODO implement
-}
-
-func getInstanceSecurityGroupIds(instances []*experimentTypes.InstanceDetails) ([]*string) {
-
-	allInstanceSecurityGroups := []string{}
-	for _, instance := range instances {
-		allInstanceSecurityGroups = append(allInstanceSecurityGroups, instance.SecGroupIds...)
-	}
-
-	// remove duplicates
-	uniqueSecurityGroupMap := map[string]string{}
-	for _, group := range allInstanceSecurityGroups {
-		_, ok := uniqueSecurityGroupMap[group]
-		if (!ok) {
-			uniqueSecurityGroupMap[group] = "exists"
-		}
-	}
-
-	// return just security group ids
-	instanceSecurityGroupIds := make([]*string, 0, len(uniqueSecurityGroupMap))
-	for key := range uniqueSecurityGroupMap {
-		instanceSecurityGroupIds = append(instanceSecurityGroupIds, &key)
-	}
-	return instanceSecurityGroupIds
-}
-
-func GetSecurityGroupDefinitions(ec2Svc *ec2.EC2, instances []*experimentTypes.InstanceDetails) (*ec2.DescribeSecurityGroupsOutput, error) {
-	uniqueSecurityGroupNames := getInstanceSecurityGroupIds(instances)
-	securityGroupDefinitions, err := aws.GetSecurityGroupsByIds(ec2Svc, uniqueSecurityGroupNames)
-	if err != nil {
-		return nil, err
-	}
-	return securityGroupDefinitions, nil
-}
-
-func createEmptySecurityGroup(ec2Svc *ec2.EC2) (*ec2.CreateSecurityGroupOutput, error) {
-	// TODO implement
-	return nil, nil
-}
-
-func assignNewSecurityGroup(ec2Svc *ec2.EC2, instances []*types.InstanceDetails, securityGroup *ec2.CreateSecurityGroupOutput) (error) {
-	return nil // TODO implement
-}
-
-func removePreChaosSecurityGroups(ec2Svc *ec2.EC2, instances []*types.InstanceDetails) (error) {
-	return nil // TODO implement
 }
 
 func AZDown(clients clients.ClientSets) {

--- a/experiments/kube-aws/az-down/experiment/az-down.go
+++ b/experiments/kube-aws/az-down/experiment/az-down.go
@@ -1,8 +1,10 @@
 package experiment
 
 import (
+	"github.com/aws/aws-sdk-go/service/ec2"
 	litmusLIB "github.com/litmuschaos/litmus-go/chaoslib/litmus/az-down/lib"
-	clients "github.com/litmuschaos/litmus-go/pkg/clients"
+	"github.com/litmuschaos/litmus-go/pkg/clients"
+	"github.com/litmuschaos/litmus-go/pkg/cloud/aws"
 	"github.com/litmuschaos/litmus-go/pkg/events"
 	experimentEnv "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/environment"
 	experimentTypes "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/types"
@@ -12,10 +14,125 @@ import (
 	"github.com/litmuschaos/litmus-go/pkg/status"
 	"github.com/litmuschaos/litmus-go/pkg/types"
 	"github.com/sirupsen/logrus"
+	"math/rand"
+	"strings"
 )
+
+// return all instances that are in the az specified
+func getInstancesInAz(instances []*experimentTypes.InstanceDetails, az string) ([]*experimentTypes.InstanceDetails) {
+	instancesInAz := []*experimentTypes.InstanceDetails{}
+	for _, instance := range instances {
+		// for each name element to target check if in instance name string
+		// if no name elements return all instances
+		if instance.AZ == az { //TODO make sure default az value is set
+			instancesInAz = append(instancesInAz, instance)
+		}
+	}
+	return instancesInAz
+}
+
+// returns all AZ's instances are located in
+func getAllAvailableZones([]*experimentTypes.InstanceDetails) ([]string) {
+	// TODO check all instances and return list of zones instances are located in
+	return []string{}
+}
+
+// return random valid az to target
+func getAzToTarget(azs []string) (string) {
+	return azs[rand.Intn(len(azs))]
+}
+
+// check if instance name matches what we want to target
+func isTargetableInstance(instanceName string, identifiers []string) (bool) {
+	for _, identifier := range identifiers {
+		if strings.Contains(instanceName, identifier) {
+			return true
+		}
+	}
+	return false
+}
+
+// returns instances to target in experiment
+func getInstancesToTarget(allInstances []*experimentTypes.InstanceDetails, experimentsDetails *experimentTypes.ExperimentDetails) ([]*experimentTypes.InstanceDetails, error) {
+
+	availableAzsToTarget := getAllAvailableZones(allInstances) // look at targeting more than 1 az if possible
+
+	// az will be targeted randomly - should this be configurable?
+	azToTarget := getAzToTarget(availableAzsToTarget) // will this affect where litmus chaos is scheduled?
+	instancesInTargetAz := getInstancesInAz(allInstances, azToTarget)
+
+	// get instances that match node identifiers
+	instancesToTarget := []*experimentTypes.InstanceDetails{}
+	nodeIdentifiers := strings.Split(experimentsDetails.NodeIdentifiers, ",")
+	for _, instance := range instancesInTargetAz {
+		if isTargetableInstance(instance.Name, nodeIdentifiers) {
+			instancesToTarget = append(instancesToTarget, instance)
+		}
+	}
+
+	// TODO - return all instances in az if no labels match?
+	if len(instancesToTarget) == 0 {
+		instancesToTarget = instancesInTargetAz
+	}
+
+	// TODO - return number of instances specified by env var
+	numberOfNodesToTarget := experimentsDetails.NumberNodesToTarget
+	if numberOfNodesToTarget > len(instancesToTarget) {
+		return instancesToTarget, nil
+	}
+
+	return instancesToTarget[:numberOfNodesToTarget], nil // TODO - update to return random instances
+}
+
+func getInstanceSecurityGroupIds(instances []*experimentTypes.InstanceDetails) ([]*string) {
+
+	allInstanceSecurityGroups := []string{}
+	for _, instance := range instances {
+		allInstanceSecurityGroups = append(allInstanceSecurityGroups, instance.SecGroupIds...)
+	}
+
+	// remove duplicates
+	uniqueSecurityGroupMap := map[string]string{}
+	for _, group := range allInstanceSecurityGroups {
+		_, ok := uniqueSecurityGroupMap[group]
+		if (!ok) {
+			uniqueSecurityGroupMap[group] = "exists"
+		}
+	}
+
+	// return just security group ids
+	instanceSecurityGroupIds := make([]*string, 0, len(uniqueSecurityGroupMap))
+	for key := range uniqueSecurityGroupMap {
+		instanceSecurityGroupIds = append(instanceSecurityGroupIds, &key)
+	}
+	return instanceSecurityGroupIds
+}
+
+func GetSecurityGroupDefinitions(ec2Svc *ec2.EC2, instances []*experimentTypes.InstanceDetails) (*ec2.DescribeSecurityGroupsOutput, error) {
+	uniqueSecurityGroupNames := getInstanceSecurityGroupIds(instances)
+	securityGroupDefinitions, err := aws.GetSecurityGroupsByIds(ec2Svc, uniqueSecurityGroupNames)
+	if err != nil {
+		return nil, err
+	}
+	return securityGroupDefinitions, nil
+}
+
+func createEmptySecurityGroup(ec2Svc *ec2.EC2) (*ec2.CreateSecurityGroupOutput, error) {
+	// TODO implement
+	return nil, nil
+}
+
+func assignNewSecurityGroup(ec2Svc *ec2.EC2, instances []*types.InstanceDetails, securityGroup *ec2.CreateSecurityGroupOutput) (error) {
+	return nil // TODO implement
+}
+
+func removePreChaosSecurityGroups(ec2Svc *ec2.EC2, instances []*types.InstanceDetails) (error) {
+	return nil // TODO implement
+}
 
 func AZDown(clients clients.ClientSets) {
 
+	// TODO refactor this monster method into smaller methods to make more readable
 	var err error
 	experimentsDetails := experimentTypes.ExperimentDetails{}
 	resultDetails := types.ResultDetails{}
@@ -26,13 +143,13 @@ func AZDown(clients clients.ClientSets) {
 	log.Infof("[PreReq]: Getting the ENV for the %v experiment", experimentsDetails.ExperimentName)
 	experimentEnv.GetENV(&experimentsDetails)
 
-	// Intialise the chaos attributes
+	// Initialise the chaos attributes
 	experimentEnv.InitialiseChaosVariables(&chaosDetails, &experimentsDetails)
 
-	// Intialise Chaos Result Parameters
+	// Initialise Chaos Result Parameters
 	types.SetResultAttributes(&resultDetails, chaosDetails)
 
-	// Intialise the probe details. Bail out upon error, as we haven't entered exp business logic yet
+	// Initialise the probe details. Bail out upon error, as we haven't entered exp business logic yet
 	if err := probe.InitializeProbesInChaosResultDetails(&chaosDetails, clients, &resultDetails); err != nil {
 		log.Fatalf("Unable to initialise probes details from chaosengine, err: %v", err)
 	}
@@ -99,6 +216,67 @@ func AZDown(clients clients.ClientSets) {
 	// INVOKE THE CHAOSLIB OF YOUR CHOICE HERE, WHICH WILL CONTAIN
 	// THE BUSINESS LOGIC OF THE ACTUAL CHAOS
 	// IT CAN BE A NEW CHAOSLIB YOU HAVE CREATED SPECIALLY FOR THIS EXPERIMENT OR ANY EXISTING ONE
+
+	// TODO create replicated topic in kafka
+
+	// Configure AWS Credentials
+	if err = aws.ConfigureAWS(); err != nil {
+		log.Errorf("AWS authentication failed, err: %v", err)
+		failStep := "Configure AWS configuration (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// create ec2 client
+	ec2Svc := aws.GetNewEC2Client(&experimentsDetails)
+
+	// Get all instances in region that belong to our cluster under test
+	//Verify the aws ec2 instance is running (pre chaos)
+	clusterInstances, err := aws.GetClusterInstancesInRegion(&ec2Svc, experimentsDetails.ClusterIdentifier)
+	if err != nil {
+		log.Errorf("failed to get the ec2 instance instances in region, err: %v", err)
+		failStep := "Getting all instances in region (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// Get instances to target
+	instancesToTarget, err := getInstancesToTarget(clusterInstances, &experimentsDetails)
+	if (err != nil) || len(instancesToTarget) == 0 {
+		log.Errorf("failed to get the ec2 instances to target with experiment, err: %v", err)
+		failStep := "Getting the instances to target with experiment (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// fetch a copy of security group definitions before alerting security groups of instances
+	preChaosSecGroups, err := GetSecurityGroupDefinitions(&ec2Svc, instancesToTarget)
+
+	// TODO create new security group with no inbound or outbound rules
+	emptySecurityGroup, err := createEmptySecurityGroup(&ec2Svc)
+	if err != nil {
+		log.Errorf("failed to create new empty security group, err: %v", err)
+		failStep := "Creating an empty security group to assign to instances in az (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	err = assignNewSecurityGroup(&ec2Svc, instancesToTarget, emptySecurityGroup)
+	if err != nil {
+		log.Errorf("failed assign new empty security group to instances in az, err: %v", err)
+		failStep := "Failed to assign empty security group to instances in az (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// TODO remove old security group
+	err = removePreChaosSecurityGroups(&ec2Svc, instancesToTarget)
+	if err != nil {
+		log.Errorf("failed to remove pre-chaos security group(s) from instances in az targeted, err: %v", err)
+		failStep := "Failed to remove pre-chaos security group(s) from instances in az targeted (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
 
 	// Including the litmus lib
 	if experimentsDetails.ChaosLib == "litmus" {
@@ -176,3 +354,4 @@ func AZDown(clients clients.ClientSets) {
 		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
 	}
 }
+

--- a/experiments/kube-aws/az-down/rbac.yaml
+++ b/experiments/kube-aws/az-down/rbac.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: az-down-sa
+  namespace: default
+  labels:
+    name: az-down-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: az-down-sa
+  labels:
+    name: az-down-sa
+rules:
+- apiGroups: ["","apps","litmuschaos.io","batch"]
+  resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete","deletecollection"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: az-down-sa
+  labels:
+    name: az-down-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: az-down-sa
+subjects:
+- kind: ServiceAccount
+  name: az-down-sa
+  namespace: default

--- a/experiments/kube-aws/az-down/test/test.yml
+++ b/experiments/kube-aws/az-down/test/test.yml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litmus-experiment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: litmus-experiment
+  template:
+    metadata:
+      labels: 
+        app: litmus-experiment
+    spec:
+      serviceAccountName: "az-down-sa" 
+      containers:
+      - name: gotest
+        image: busybox 
+        command: 
+          - sleep
+          - "3600"
+        env:
+          # provide application namespace
+          - name: APP_NAMESPACE
+            value: ''
+
+          # provide application labels
+          - name: APP_LABEL
+            value: ''
+ 
+          # provide application kind
+          - name: APP_KIND
+            value: '' 
+
+          - name: TOTAL_CHAOS_DURATION
+            value: ''
+
+          # provide auxiliary application details - namespace and labels of the applications
+          # sample input is - "ns1:app=percona,ns2:name=nginx"
+          - name: AUXILIARY_APPINFO
+            value: ''
+          
+          ## Period to wait before injection of chaos in sec
+          - name: RAMP_TIME
+            value: ''
+
+          ## env var that describes the library used to execute the chaos
+          ## default: litmus. Supported values: litmus, powerfulseal, chaoskube
+          - name: LIB
+            value: ''
+
+          # provide the chaos namespace
+          - name: CHAOS_NAMESPACE
+            value: ''
+        
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
+          - name: CHAOS_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+

--- a/experiments/kube-aws/ec2-terminate/experiment/ec2-terminate.go
+++ b/experiments/kube-aws/ec2-terminate/experiment/ec2-terminate.go
@@ -62,6 +62,8 @@ func EC2Terminate(clients clients.ClientSets) {
 
 	//PRE-CHAOS APPLICATION STATUS CHECK
 	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (pre-chaos)")
+	// TODO - look at expanding this out to check multiple kafka clusters, not just one
+	// TODO - look at expanding this out to kafka-specific checks, or else using an external probe
 	err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
 	if err != nil {
 		log.Errorf("Application status check failed, err: %v", err)
@@ -73,6 +75,7 @@ func EC2Terminate(clients clients.ClientSets) {
 	//PRE-CHAOS AUXILIARY APPLICATION STATUS CHECK
 	if experimentsDetails.AuxiliaryAppInfo != "" {
 		log.Info("[Status]: Verify that the Auxiliary Applications are running (pre-chaos)")
+		// TODO - check if there is a way to specify auxiliary applications, ie zookeepers/ kafka exporters?
 		err = status.CheckAuxiliaryApplicationStatus(experimentsDetails.AuxiliaryAppInfo, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
 		if err != nil {
 			log.Errorf("Auxiliary Application status check failed, err: %v", err)
@@ -93,7 +96,7 @@ func EC2Terminate(clients clients.ClientSets) {
 
 		// run the probes in the pre-chaos check
 		if len(resultDetails.ProbeDetails) != 0 {
-
+			// TODO - check what probes these are
 			err = probe.RunProbes(&chaosDetails, clients, &resultDetails, "PreChaos", &eventsDetails)
 			if err != nil {
 				log.Errorf("Probe Failed, err: %v", err)

--- a/pkg/cloud/aws/client.go
+++ b/pkg/cloud/aws/client.go
@@ -1,0 +1,23 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/types"
+)
+
+func GetNewEC2Client(experimentsDetails *experimentTypes.ExperimentDetails) (ec2.EC2) {
+
+	// Load session from shared config
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		Config:            aws.Config{Region: aws.String(experimentsDetails.AwsRegion)},
+	}))
+
+	// Create new EC2 client
+	ec2Svc := ec2.New(sess)
+
+	// TODO add error handling
+	return *ec2Svc
+}

--- a/pkg/cloud/aws/instances.go
+++ b/pkg/cloud/aws/instances.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	azDown "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/types"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"strings"
+)
+
+func isInstanceInCluster() (bool) {
+	// TODO check if instance is part of OSD cluster under test
+	return false
+}
+
+// returns all instances by name, id and az for region that cluster identifier
+func GetAllInstancesInRegion(ec2Svc *ec2.EC2) ([]*azDown.InstanceDetails, error){
+
+	instanceData, err := ec2Svc.DescribeInstances(nil)
+
+	if err != nil {
+		log.Error(fmt.Sprintf("Could not list instances in region %s", err.Error()))
+	}
+
+	reservations := instanceData.Reservations
+
+	instances := make([]*azDown.InstanceDetails, len(reservations))
+	for i, res := range reservations {
+		instance := azDown.InstanceDetails{
+			Name: *res.Instances[0].InstanceId,
+			ID: *res.Instances[0].Placement.AvailabilityZone,
+			AZ: *res.Instances[0].Placement.AvailabilityZone,
+		}
+		instances[i] = &instance
+	}
+
+	return instances, nil
+}
+
+// returns a list of all instances whose name contains a specified cluster name identifier
+func GetClusterInstancesInRegion(ec2Svc *ec2.EC2, clusterIdentifier string) ([]*azDown.InstanceDetails, error) {
+	allInstances, err := GetAllInstancesInRegion(ec2Svc)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterInstances := []*azDown.InstanceDetails{}
+	for _, instance := range allInstances {
+		name := instance.Name
+		if strings.Contains(name, clusterIdentifier) {
+			clusterInstances = append(clusterInstances, instance)
+		}
+	}
+	return clusterInstances, nil
+}
+
+

--- a/pkg/cloud/aws/security-groups.go
+++ b/pkg/cloud/aws/security-groups.go
@@ -1,0 +1,26 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func GetSecurityGroupsByIds(ec2Svc *ec2.EC2, secGroupIds []*string) (*ec2.DescribeSecurityGroupsOutput, error) {
+	input := ec2.DescribeSecurityGroupsInput{GroupIds: secGroupIds}
+	return ec2Svc.DescribeSecurityGroups(&input)
+}
+
+func CreateNewSecurityGroup(ec2Svc *ec2.EC2, input *ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
+	return ec2Svc.CreateSecurityGroup(input)
+}
+
+func AssignSecurityGroupToInstance(ec2Svc *ec2.EC2) {
+	// TODO use aws client to assign security group to instance
+}
+
+func RemoveSecurityGroupFromInstance(ec2Svc *ec2.EC2) {
+	// TODO use aws client to remove security group from instance
+}
+
+func RemoveSecurityGroupFromInstances(ec2Svc *ec2.EC2) {
+	// TODO use aws client to remove security group from instance
+}

--- a/pkg/kafka/kafka-topic-mgt.go
+++ b/pkg/kafka/kafka-topic-mgt.go
@@ -1,0 +1,5 @@
+package kafka
+
+// TODO implement function to create replicated topic in cluster
+
+

--- a/pkg/kube-aws/az-down/environment/environment.go
+++ b/pkg/kube-aws/az-down/environment/environment.go
@@ -13,6 +13,8 @@ import (
 // STEPS TO GETENV OF YOUR CHOICE HERE
 // ADDED FOR FEW MANDATORY FIELD
 
+// TODO update as necessary as types change
+
 //GetENV fetches all the env variables from the runner pod
 func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.ExperimentName = Getenv("EXPERIMENT_NAME", "az-down")

--- a/pkg/kube-aws/az-down/environment/environment.go
+++ b/pkg/kube-aws/az-down/environment/environment.go
@@ -1,0 +1,55 @@
+package environment
+
+import (
+	"os"
+	"strconv"
+
+	clientTypes "k8s.io/apimachinery/pkg/types"
+
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/types"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+)
+
+// STEPS TO GETENV OF YOUR CHOICE HERE
+// ADDED FOR FEW MANDATORY FIELD
+
+//GetENV fetches all the env variables from the runner pod
+func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
+	experimentDetails.ExperimentName = Getenv("EXPERIMENT_NAME", "az-down")
+	experimentDetails.ChaosNamespace = Getenv("CHAOS_NAMESPACE", "litmus")
+	experimentDetails.EngineName = Getenv("CHAOSENGINE", "")
+	experimentDetails.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION", "30"))
+	experimentDetails.ChaosInterval, _ = strconv.Atoi(Getenv("CHAOS_INTERVAL", "10"))
+	experimentDetails.RampTime, _ = strconv.Atoi(Getenv("RAMP_TIME", "0"))
+	experimentDetails.ChaosLib = Getenv("LIB", "litmus")
+	experimentDetails.AppNS = Getenv("APP_NAMESPACE", "")
+	experimentDetails.AppLabel = Getenv("APP_LABEL", "")
+	experimentDetails.AppKind = Getenv("APP_KIND", "")
+	experimentDetails.ChaosUID = clientTypes.UID(Getenv("CHAOS_UID", ""))
+	experimentDetails.InstanceID = Getenv("INSTANCE_ID", "")
+	experimentDetails.ChaosPodName = Getenv("POD_NAME", "")
+	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
+	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
+}
+
+// Getenv fetch the env and set the default value, if any
+func Getenv(key string, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		value = defaultValue
+	}
+	return value
+}
+
+//InitialiseChaosVariables initialise all the global variables
+func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetails *experimentTypes.ExperimentDetails) {
+
+	chaosDetails.ChaosNamespace = experimentDetails.ChaosNamespace
+	chaosDetails.ChaosPodName = experimentDetails.ChaosPodName
+	chaosDetails.ChaosUID = experimentDetails.ChaosUID
+	chaosDetails.EngineName = experimentDetails.EngineName
+	chaosDetails.ExperimentName = experimentDetails.ExperimentName
+	chaosDetails.InstanceID = experimentDetails.InstanceID
+	chaosDetails.Timeout = experimentDetails.Timeout
+	chaosDetails.Delay = experimentDetails.Delay
+}

--- a/pkg/kube-aws/az-down/types/types.go
+++ b/pkg/kube-aws/az-down/types/types.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	clientTypes "k8s.io/apimachinery/pkg/types"
+)
+
+// ADD THE ATTRIBUTES OF YOUR CHOICE HERE
+// FEW MENDATORY ATTRIBUTES ARE ADDED BY DEFAULT 
+
+// ExperimentDetails is for collecting all the experiment-related details
+type ExperimentDetails struct {
+	ExperimentName      string
+	EngineName          string
+	ChaosDuration       int
+	ChaosInterval       int
+	RampTime            int
+	ChaosLib            string
+	AppNS               string
+	AppLabel            string
+	AppKind             string
+	ChaosUID            clientTypes.UID
+	InstanceID          string
+	ChaosNamespace      string
+	ChaosPodName        string
+	Timeout             int
+	Delay               int
+}

--- a/pkg/kube-aws/az-down/types/types.go
+++ b/pkg/kube-aws/az-down/types/types.go
@@ -28,8 +28,6 @@ type ExperimentDetails struct {
 	AwsRegion           string
 	NumberOfAZs         int
 	ClusterIdentifier   string
-	NodeIdentifiers     string
-	NumberNodesToTarget int
 }
 
 type InstanceDetails struct {

--- a/pkg/kube-aws/az-down/types/types.go
+++ b/pkg/kube-aws/az-down/types/types.go
@@ -8,6 +8,7 @@ import (
 // FEW MENDATORY ATTRIBUTES ARE ADDED BY DEFAULT 
 
 // ExperimentDetails is for collecting all the experiment-related details
+// TODO make sure these are all relevant
 type ExperimentDetails struct {
 	ExperimentName      string
 	EngineName          string
@@ -24,4 +25,16 @@ type ExperimentDetails struct {
 	ChaosPodName        string
 	Timeout             int
 	Delay               int
+	AwsRegion           string
+	NumberOfAZs         int
+	ClusterIdentifier   string
+	NodeIdentifiers     string
+	NumberNodesToTarget int
+}
+
+type InstanceDetails struct {
+	Name        string
+	ID          string
+	AZ          string
+	SecGroupIds []string
 }

--- a/pkg/kube-aws/az-down/types/types.go
+++ b/pkg/kube-aws/az-down/types/types.go
@@ -26,7 +26,6 @@ type ExperimentDetails struct {
 	Timeout             int
 	Delay               int
 	AwsRegion           string
-	NumberOfAZs         int
 	ClusterIdentifier   string
 }
 

--- a/subnets-output
+++ b/subnets-output
@@ -1,0 +1,276 @@
+{
+    "Subnets": [
+        {
+            "AvailabilityZone": "eu-west-1b",
+            "AvailabilityZoneId": "euw1-az1",
+            "AvailableIpAddressCount": 4091,
+            "CidrBlock": "172.31.0.0/20",
+            "DefaultForAz": true,
+            "MapPublicIpOnLaunch": true,
+            "MapCustomerOwnedIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-ba0e3ddc",
+            "VpcId": "vpc-ac8041d5",
+            "OwnerId": "622761864308",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "SubnetArn": "arn:aws:ec2:eu-west-1:622761864308:subnet/subnet-ba0e3ddc"
+        },
+        {
+            "AvailabilityZone": "eu-west-1a",
+            "AvailabilityZoneId": "euw1-az3",
+            "AvailableIpAddressCount": 32759,
+            "CidrBlock": "10.0.0.0/17",
+            "DefaultForAz": false,
+            "MapPublicIpOnLaunch": false,
+            "MapCustomerOwnedIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-05bec41653abc00e5",
+            "VpcId": "vpc-07462a3825c1b116c",
+            "OwnerId": "622761864308",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "pbraun-observatorium-4cnp4-public-eu-west-1a"
+                },
+                {
+                    "Key": "kubernetes.io/cluster/pbraun-observatorium-4cnp4",
+                    "Value": "owned"
+                }
+            ],
+            "SubnetArn": "arn:aws:ec2:eu-west-1:622761864308:subnet/subnet-05bec41653abc00e5"
+        },
+        {
+            "AvailabilityZone": "eu-west-1b",
+            "AvailabilityZoneId": "euw1-az1",
+            "AvailableIpAddressCount": 8182,
+            "CidrBlock": "10.0.32.0/19",
+            "DefaultForAz": false,
+            "MapPublicIpOnLaunch": false,
+            "MapCustomerOwnedIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-0427d0df9bf6488e5",
+            "VpcId": "vpc-0cb3748abafcc54a5",
+            "OwnerId": "622761864308",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "Tags": [
+                {
+                    "Key": "kubernetes.io/cluster/damurphy-6wndz",
+                    "Value": "owned"
+                },
+                {
+                    "Key": "Name",
+                    "Value": "damurphy-6wndz-public-eu-west-1b"
+                }
+            ],
+            "SubnetArn": "arn:aws:ec2:eu-west-1:622761864308:subnet/subnet-0427d0df9bf6488e5"
+        },
+        {
+            "AvailabilityZone": "eu-west-1a",
+            "AvailabilityZoneId": "euw1-az3",
+            "AvailableIpAddressCount": 8182,
+            "CidrBlock": "10.0.0.0/19",
+            "DefaultForAz": false,
+            "MapPublicIpOnLaunch": false,
+            "MapCustomerOwnedIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-0006edf0fa7eba4f6",
+            "VpcId": "vpc-0cb3748abafcc54a5",
+            "OwnerId": "622761864308",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "damurphy-6wndz-public-eu-west-1a"
+                },
+                {
+                    "Key": "kubernetes.io/cluster/damurphy-6wndz",
+                    "Value": "owned"
+                }
+            ],
+            "SubnetArn": "arn:aws:ec2:eu-west-1:622761864308:subnet/subnet-0006edf0fa7eba4f6"
+        },
+        {
+            "AvailabilityZone": "eu-west-1b",
+            "AvailabilityZoneId": "euw1-az1",
+            "AvailableIpAddressCount": 8183,
+            "CidrBlock": "10.0.160.0/19",
+            "DefaultForAz": false,
+            "MapPublicIpOnLaunch": false,
+            "MapCustomerOwnedIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-0e487870c6acf597c",
+            "VpcId": "vpc-0cb3748abafcc54a5",
+            "OwnerId": "622761864308",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "Tags": [
+                {
+                    "Key": "kubernetes.io/role/internal-elb",
+                    "Value": ""
+                },
+                {
+                    "Key": "Name",
+                    "Value": "damurphy-6wndz-private-eu-west-1b"
+                },
+                {
+                    "Key": "kubernetes.io/cluster/damurphy-6wndz",
+                    "Value": "owned"
+                }
+            ],
+            "SubnetArn": "arn:aws:ec2:eu-west-1:622761864308:subnet/subnet-0e487870c6acf597c"
+        },
+        {
+            "AvailabilityZone": "eu-west-1c",
+            "AvailabilityZoneId": "euw1-az2",
+            "AvailableIpAddressCount": 4091,
+            "CidrBlock": "172.31.16.0/20",
+            "DefaultForAz": true,
+            "MapPublicIpOnLaunch": true,
+            "MapCustomerOwnedIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-b01715f8",
+            "VpcId": "vpc-ac8041d5",
+            "OwnerId": "622761864308",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "SubnetArn": "arn:aws:ec2:eu-west-1:622761864308:subnet/subnet-b01715f8"
+        },
+        {
+            "AvailabilityZone": "eu-west-1a",
+            "AvailabilityZoneId": "euw1-az3",
+            "AvailableIpAddressCount": 8183,
+            "CidrBlock": "10.0.128.0/19",
+            "DefaultForAz": false,
+            "MapPublicIpOnLaunch": false,
+            "MapCustomerOwnedIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-09d159ec6c9e2a0c3",
+            "VpcId": "vpc-0cb3748abafcc54a5",
+            "OwnerId": "622761864308",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "Tags": [
+                {
+                    "Key": "kubernetes.io/role/internal-elb",
+                    "Value": ""
+                },
+                {
+                    "Key": "Name",
+                    "Value": "damurphy-6wndz-private-eu-west-1a"
+                },
+                {
+                    "Key": "kubernetes.io/cluster/damurphy-6wndz",
+                    "Value": "owned"
+                }
+            ],
+            "SubnetArn": "arn:aws:ec2:eu-west-1:622761864308:subnet/subnet-09d159ec6c9e2a0c3"
+        },
+        {
+            "AvailabilityZone": "eu-west-1c",
+            "AvailabilityZoneId": "euw1-az2",
+            "AvailableIpAddressCount": 8182,
+            "CidrBlock": "10.0.64.0/19",
+            "DefaultForAz": false,
+            "MapPublicIpOnLaunch": false,
+            "MapCustomerOwnedIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-0d56d85f4541b1a84",
+            "VpcId": "vpc-0cb3748abafcc54a5",
+            "OwnerId": "622761864308",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "damurphy-6wndz-public-eu-west-1c"
+                },
+                {
+                    "Key": "kubernetes.io/cluster/damurphy-6wndz",
+                    "Value": "owned"
+                }
+            ],
+            "SubnetArn": "arn:aws:ec2:eu-west-1:622761864308:subnet/subnet-0d56d85f4541b1a84"
+        },
+        {
+            "AvailabilityZone": "eu-west-1a",
+            "AvailabilityZoneId": "euw1-az3",
+            "AvailableIpAddressCount": 4091,
+            "CidrBlock": "172.31.32.0/20",
+            "DefaultForAz": true,
+            "MapPublicIpOnLaunch": true,
+            "MapCustomerOwnedIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-ae720ef4",
+            "VpcId": "vpc-ac8041d5",
+            "OwnerId": "622761864308",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "SubnetArn": "arn:aws:ec2:eu-west-1:622761864308:subnet/subnet-ae720ef4"
+        },
+        {
+            "AvailabilityZone": "eu-west-1a",
+            "AvailabilityZoneId": "euw1-az3",
+            "AvailableIpAddressCount": 32756,
+            "CidrBlock": "10.0.128.0/17",
+            "DefaultForAz": false,
+            "MapPublicIpOnLaunch": false,
+            "MapCustomerOwnedIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-07b26f59781e3cb37",
+            "VpcId": "vpc-07462a3825c1b116c",
+            "OwnerId": "622761864308",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "Tags": [
+                {
+                    "Key": "kubernetes.io/role/internal-elb",
+                    "Value": ""
+                },
+                {
+                    "Key": "Name",
+                    "Value": "pbraun-observatorium-4cnp4-private-eu-west-1a"
+                },
+                {
+                    "Key": "kubernetes.io/cluster/pbraun-observatorium-4cnp4",
+                    "Value": "owned"
+                }
+            ],
+            "SubnetArn": "arn:aws:ec2:eu-west-1:622761864308:subnet/subnet-07b26f59781e3cb37"
+        },
+        {
+            "AvailabilityZone": "eu-west-1c",
+            "AvailabilityZoneId": "euw1-az2",
+            "AvailableIpAddressCount": 8183,
+            "CidrBlock": "10.0.192.0/19",
+            "DefaultForAz": false,
+            "MapPublicIpOnLaunch": false,
+            "MapCustomerOwnedIpOnLaunch": false,
+            "State": "available",
+            "SubnetId": "subnet-0a41372d317d83b35",
+            "VpcId": "vpc-0cb3748abafcc54a5",
+            "OwnerId": "622761864308",
+            "AssignIpv6AddressOnCreation": false,
+            "Ipv6CidrBlockAssociationSet": [],
+            "Tags": [
+                {
+                    "Key": "kubernetes.io/cluster/damurphy-6wndz",
+                    "Value": "owned"
+                },
+                {
+                    "Key": "Name",
+                    "Value": "damurphy-6wndz-private-eu-west-1c"
+                },
+                {
+                    "Key": "kubernetes.io/role/internal-elb",
+                    "Value": ""
+                }
+            ],
+            "SubnetArn": "arn:aws:ec2:eu-west-1:622761864308:subnet/subnet-0a41372d317d83b35"
+        }
+    ]
+}


### PR DESCRIPTION
## What

https://issues.redhat.com/browse/MGDSTRM-579 - add chaos experiment that simulates az being down

## Why

To ensure resiliency of our service we need to evaluate what impact that an availability zone being down will have.

## How

- Add new litmus-go experiment for az-down
- create dummy ACLs with deny all traffic policies
- assign ACLs to subnets of az under test
- revert ACL changes after experiment concludes


