### PR TITLE
Aws az down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/_output
 .stignore
+.idea

--- a/bin/go-runner.go
+++ b/bin/go-runner.go
@@ -32,6 +32,7 @@ import (
 	podNetworkLatency "github.com/litmuschaos/litmus-go/experiments/generic/pod-network-latency/experiment"
 	podNetworkLoss "github.com/litmuschaos/litmus-go/experiments/generic/pod-network-loss/experiment"
 	kafkaBrokerPodFailure "github.com/litmuschaos/litmus-go/experiments/kafka/kafka-broker-pod-failure/experiment"
+	azDown "github.com/litmuschaos/litmus-go/experiments/kube-aws/az-down/experiment"
 	ebsLoss "github.com/litmuschaos/litmus-go/experiments/kube-aws/ebs-loss/experiment"
 	ec2terminate "github.com/litmuschaos/litmus-go/experiments/kube-aws/ec2-terminate/experiment"
 
@@ -109,6 +110,8 @@ func main() {
 		ebsLoss.EBSLoss(clients)
 	case "node-restart":
 		nodeRestart.NodeRestart(clients)
+	case "az-down":
+		azDown.AZDown(clients)
 	default:
 		log.Fatalf("Unsupported -name %v, please provide the correct value of -name args", *experimentName)
 	}

--- a/chaoslib/litmus/az-down/lib/az-down.go
+++ b/chaoslib/litmus/az-down/lib/az-down.go
@@ -1,0 +1,13 @@
+package lib
+
+import "github.com/litmuschaos/litmus-go/pkg/log"
+
+func AZDown() error {
+	log.Info("YES")
+
+	return nil
+	// IF YOU WANT TO USE AN EXISTING CHAOSLIB THEN DELETE THIS FILE AND USE THE SAME
+	// ELSE
+	// ADD THE BUSINESS LOGIC OF THE ACTUAL CHAOS HERE
+	// CALL THIS FUNCTION FROM <experiment-name.go>
+}

--- a/experiments/kube-aws/az-down/README.md
+++ b/experiments/kube-aws/az-down/README.md
@@ -1,0 +1,14 @@
+## Experiment Metadata
+
+<table>
+<tr>
+<th> Name </th>
+<th> Description </th>
+<th> Documentation Link </th>
+</tr>
+<tr>
+ <td> AZ Down </td>
+ <td> This experiment simulates an az failure. ACL policies that deny all inbound and outbound traffic are associated with the target az subnets for the specified chaos duration. These ACL policies are removed and the original ACL policies restored post-chaos.</td>
+ <td>  <a href=""> Coming Soon </a> </td>
+ </tr>
+ </table>

--- a/experiments/kube-aws/az-down/az-down.chartserviceversion.yaml
+++ b/experiments/kube-aws/az-down/az-down.chartserviceversion.yaml
@@ -1,0 +1,29 @@
+apiVersion: litmuchaos.io/v1alpha1
+kind: ChartServiceVersion
+metadata:
+  name: az-down
+  version: 0.1.0
+  annotations:
+    categories: kube-aws
+    repository: https://github.com/litmuschaos/litmus-go/tree/master/experiments/kube-aws/az-down
+    support: https://kubernetes.slack.com/messages/CNXNB0ZTN
+spec:
+  displayName: az-down
+  categoryDescription: >
+    simulating AZ to be down
+  keywords:
+    - 'kubernetes'
+    - 'kube-aws'
+  maturity: alpha
+  minKubeVersion: 1.12.0
+  provider:
+    name: redhat
+  maintainers:
+    - name: damurphy
+      email: damurphy@redhat.com
+  links:
+    - name: Documentation
+      url: https://docs.litmuschaos.io/docs/getstarted/
+  icon:
+    - url:
+      mediatype: ''

--- a/experiments/kube-aws/az-down/engine.yaml
+++ b/experiments/kube-aws/az-down/engine.yaml
@@ -1,0 +1,43 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: az-down-chaos
+spec:
+  appinfo:
+    appns: 'kafka-cluster'
+    applabel: 'app.kubernetes.io/name=kafka'
+    appkind: 'statefulset'
+  # It can be true/false
+  annotationCheck: 'false'
+  # It can be active/stop
+  engineState: 'active'
+  #ex. values: ns1:name=percona,ns2:run=nginx
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: az-down-sa
+  monitoring: false
+  # It can be delete/retain
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: az-down
+      spec:
+        components:
+          env:
+            # set chaos duration (in sec) as desired
+            - name: TOTAL_CHAOS_DURATION
+              value: ''
+
+            # set chaos interval (in sec) as desired
+            - name: CHAOS_INTERVAL
+              value: ''
+
+            # set aws region where az is located
+            - name: AWS_REGION
+              value: ''
+
+            # only az's with instance names containing this substring will be targetable
+            - name: CLUSTER_IDENTIFIER
+              value: ''
+
+            # setting to true will not create or alter any ACLs/ ACL associations
+            - name: DRY_RUN
+              value: ''

--- a/experiments/kube-aws/az-down/experiment.yaml
+++ b/experiments/kube-aws/az-down/experiment.yaml
@@ -1,0 +1,66 @@
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    simulating AZ to be down
+kind: ChaosExperiment
+metadata:
+  name: az-down
+  version: 0.1.0 
+spec:
+  definition:
+    scope: Cluster
+    permissions:
+      - apiGroups: 
+          - "" 
+          - "batch" 
+          - "litmuschaos.io"
+        resources: 
+          - "jobs" 
+          - "pods" 
+          - "events" 
+          - "pods/log" 
+          - "secrets" 
+          - "chaosengines" 
+          - "chaosexperiments" 
+          - "chaosresults"
+        verbs: 
+          - "create" 
+          - "list" 
+          - "get" 
+          - "update" 
+          - "patch" 
+          - "delete"
+    image: "quay.io/damurphy/go-runner:latest"
+    args:
+    - -c
+    - ./experiments/az-down
+    command:
+    - /bin/bash
+    env:
+    # should not be needed
+    - name: ANSIBLE_STDOUT_CALLBACK
+      value: 'default'
+
+    - name: TOTAL_CHAOS_DURATION
+      value: ''
+
+    - name: CHAOS_INTERVAL
+      value: ''
+
+    - name: LIB
+      value: ''
+
+    - name: RAMP_TIME
+      value: ''
+
+    # region to target
+    - name: AWS_REGION
+      value: ''
+
+    # only az's with instance names containing this substring will be targetable
+    - name: CLUSTER_IDENTIFIER
+      value: ''
+
+    # setting to true will not create or alter any ACLs/ ACL associations
+    - name: DRY_RUN
+      value: ''

--- a/experiments/kube-aws/az-down/experiment/az-down.go
+++ b/experiments/kube-aws/az-down/experiment/az-down.go
@@ -1,0 +1,388 @@
+package experiment
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	litmusLIB "github.com/litmuschaos/litmus-go/chaoslib/litmus/az-down/lib"
+	"github.com/litmuschaos/litmus-go/pkg/clients"
+	"github.com/litmuschaos/litmus-go/pkg/cloud/aws"
+	"github.com/litmuschaos/litmus-go/pkg/events"
+	experimentEnv "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/environment"
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/types"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/probe"
+	"github.com/litmuschaos/litmus-go/pkg/result"
+	"github.com/litmuschaos/litmus-go/pkg/status"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/sirupsen/logrus"
+	"math/rand"
+)
+
+// returns all AZs instances are located in
+func getAzRangeOfInstances(instances []*experimentTypes.InstanceDetails) []string {
+
+	// filter unique az values
+	uniqueAzs := make(map[string]string)
+	for _, instance := range instances {
+		uniqueAzs[instance.AZ] = ""
+	}
+
+	azNames := make([]string, 0, len(uniqueAzs))
+	for azName, _ := range uniqueAzs {
+		azNames = append(azNames, azName)
+	}
+
+	return azNames
+}
+
+// return random valid az to target
+func selectRandomAz(azlist []string) string {
+	return azlist[rand.Intn(len(azlist))]
+}
+
+// chooses an az at random to target
+func getAzToTarget(instances []*experimentTypes.InstanceDetails) string {
+
+	availableAzsToTarget := getAzRangeOfInstances(instances) // look at targeting more than 1 az if possible
+
+	// we want to randomly target an AZ
+	return selectRandomAz(availableAzsToTarget)
+}
+
+// returns NetworkAclId and NetworkAclAssociationId of an ACL for a given subnet id
+func getNetworkAclDetails(ec2Svc *ec2.EC2, subnetId string) (experimentTypes.Subnet, error) {
+
+	filterName := "association.subnet-id"
+	subnetFilter := ec2.Filter{
+		Name:   &filterName,
+		Values: []*string{&subnetId},
+	}
+	filters := []*ec2.Filter{&subnetFilter}
+
+	aclOutput, err := ec2Svc.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{Filters: filters})
+
+	if err != nil {
+		return experimentTypes.Subnet{}, err
+	}
+
+	subnetAclDetails := experimentTypes.Subnet{
+		NetworkAclId:            *aclOutput.NetworkAcls[0].Associations[0].NetworkAclId,
+		NetworkAclAssociationId: *aclOutput.NetworkAcls[0].Associations[0].NetworkAclAssociationId,
+	}
+
+	return subnetAclDetails, nil
+}
+
+func AZDown(clients clients.ClientSets) {
+
+	var err error
+	experimentsDetails := experimentTypes.ExperimentDetails{}
+	resultDetails := types.ResultDetails{}
+	eventsDetails := types.EventDetails{}
+	chaosDetails := types.ChaosDetails{}
+
+	//Fetching all the ENV passed from the runner pod
+	log.Infof("[PreReq]: Getting the ENV for the %v experiment", experimentsDetails.ExperimentName)
+	experimentEnv.GetENV(&experimentsDetails)
+
+	// Initialise the chaos attributes
+	experimentEnv.InitialiseChaosVariables(&chaosDetails, &experimentsDetails)
+
+	// Initialise Chaos Result Parameters
+	types.SetResultAttributes(&resultDetails, chaosDetails)
+
+	if experimentsDetails.EngineName != "" {
+		// Initialise the probe details. Bail out upon error, as we haven't entered exp business logic yet
+		if err := probe.InitializeProbesInChaosResultDetails(&chaosDetails, clients, &resultDetails); err != nil {
+			log.Fatalf("Unable to initialise probes details from chaosengine, err: %v", err)
+		}
+	}
+
+
+	//Updating the chaos result in the beginning of experiment
+	log.Infof("[PreReq]: Updating the chaos result of %v experiment (SOT)", experimentsDetails.ExperimentName)
+	err = result.ChaosResult(&chaosDetails, clients, &resultDetails, "SOT")
+	if err != nil {
+		log.Errorf("Unable to Create the Chaos Result, err: %v", err)
+		failStep := "Updating the chaos result of az-down experiment (SOT)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// Set the chaos result uid
+	result.SetResultUID(&resultDetails, clients, &chaosDetails)
+
+	// generating the event in chaosresult to marked the verdict as awaited
+	msg := "experiment: " + experimentsDetails.ExperimentName + ", Result: Awaited"
+	types.SetResultEventAttributes(&eventsDetails, types.AwaitedVerdict, msg, "Normal", &resultDetails)
+	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
+
+	//DISPLAY THE APP INFORMATION
+	log.InfoWithValues("The application information is as follows", logrus.Fields{
+		"Namespace": experimentsDetails.AppNS,
+		"Label":     experimentsDetails.AppLabel,
+		"Ramp Time": experimentsDetails.RampTime,
+	})
+
+	//PRE-CHAOS APPLICATION STATUS CHECK
+	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (pre-chaos)")
+	err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	if err != nil {
+		log.Errorf("Application status check failed, err: %v", err)
+		failStep := "Verify that the AUT (Application Under Test) is running (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := "AUT: Running"
+
+		// run the probes in the pre-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+
+			err = probe.RunProbes(&chaosDetails, clients, &resultDetails, "PreChaos", &eventsDetails)
+			if err != nil {
+				log.Errorf("Probe Failed, err: %v", err)
+				failStep := "Failed while running probes"
+				msg := "AUT: Running, Probes: Unsuccessful"
+				types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = "AUT: Running, Probes: Successful"
+		}
+		// generating the events for the pre-chaos check
+		types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	// start of experiment logic
+
+	// Configure AWS Credentials
+	if err = aws.ConfigureAWS(); err != nil {
+		log.Errorf("AWS authentication failed, err: %v", err)
+		failStep := "Configure AWS configuration (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// create ec2 client
+	ec2Svc := aws.GetNewEC2Client(&experimentsDetails)
+
+	// Get all instances in region that belong to our cluster under test
+	clusterInstances, err := aws.GetClusterInstancesInRegion(&ec2Svc, &experimentsDetails)
+	if err != nil {
+		log.Errorf("failed to get the ec2 instances in region, err: %v", err)
+		failStep := "Getting all instances in region (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+	log.Info(fmt.Sprintf("Instances that match cluster-identifier %s: %s", experimentsDetails.ClusterIdentifier, clusterInstances))
+
+	// return early if no instances match cluster identifier
+	if len(clusterInstances) < 1 {
+		log.Errorf("Unable to find any ec2 instances in region that match cluster identifier, err: %v", err)
+		failStep := "Unable to find any ec2 instances in region that match cluster identifier (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// select az to be targeted
+	azToTarget := getAzToTarget(clusterInstances)
+	log.Info(fmt.Sprintf("Targeting cluster instances in az %s", azToTarget))
+
+	// get subnets for target az
+	filterName := "availabilityZone"
+	azNameFilter := ec2.Filter{
+		Name:   &filterName,
+		Values: []*string{&azToTarget},
+	}
+	filters := []*ec2.Filter{&azNameFilter}
+
+	subnetsDescription, err := ec2Svc.DescribeSubnets(&ec2.DescribeSubnetsInput{Filters: filters})
+
+	// gather details of subnets in target az
+	azDetails := experimentTypes.AzDetails{
+		AzName: azToTarget,
+	}
+	subnetDetails := []*experimentTypes.Subnet{}
+	for _, subnet := range subnetsDescription.Subnets {
+		subnetDetail := experimentTypes.Subnet{
+			Id:    *subnet.SubnetId,
+			VpcId: *subnet.VpcId,
+		}
+		subnetDetails = append(subnetDetails, &subnetDetail)
+		log.Info(fmt.Sprintf("Identified subnet in target az %s: SubnetId:%s VpcId:%s", azToTarget, subnet.SubnetId, subnet.VpcId))
+	}
+	azDetails.Subnets = subnetDetails
+	log.Info(fmt.Sprintf("Details of instances in az %s being taken down: %s", azToTarget, azDetails))
+
+	// create and assign dummy acl to each subnet vpc
+	vpcDummyAcls := make(map[string]string)
+	for i, subnet := range azDetails.Subnets {
+		// create only if required, otherwise associate vpc with pre-existing dummy ACL
+		_, ok := vpcDummyAcls[subnet.VpcId]
+		if !ok {
+			output, err := ec2Svc.CreateNetworkAcl(&ec2.CreateNetworkAclInput{DryRun: &experimentsDetails.DryRun, VpcId: &subnet.VpcId})
+			if err != nil {
+				log.Errorf("Failed to assign dummy ACM to vpc of az being targeted, err: %v", err)
+				failStep := "Failed to assign dummy ACL to vpc of az being targeted"
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			dummyAclId := fmt.Sprint(*output.NetworkAcl.NetworkAclId)
+			subnet.DummyAclId = dummyAclId
+			vpcDummyAcls[subnet.VpcId] = dummyAclId
+			log.Info(fmt.Sprintf("Dummy ACL id:%s created for vpc id: %s.", dummyAclId, subnet.VpcId))
+		}
+
+		subnet.DummyAclId = vpcDummyAcls[subnet.VpcId]
+		azDetails.Subnets[i] = subnet
+		log.Info(fmt.Sprintf("Dummy ACL id:%s associated with vpc id: %s.", subnet.DummyAclId, subnet.VpcId))
+	}
+
+	// get NetworkAclAssociationId and NetworkAclId of subnets in az
+	for _, subnet := range azDetails.Subnets {
+		networkAclDetails, err := getNetworkAclDetails(&ec2Svc, subnet.Id)
+		if err != nil {
+			log.Errorf("Failed to get NetworkAclAssociationId for subnet %s, err: %v", subnet.Id, err)
+			failStep := fmt.Sprintf("Failed to get NetworkAclAssociationId for subnet %s in az being targeted", subnet.Id)
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+		subnet.NetworkAclAssociationId = networkAclDetails.NetworkAclAssociationId
+		subnet.NetworkAclId = networkAclDetails.NetworkAclId
+		log.Info(fmt.Sprintf("ACL details of subnet %s pre-chaos. NetworkAclAssociationId: %s, NetworkAclId:%s", subnet.Id, subnet.NetworkAclId, subnet.NetworkAclId))
+	}
+
+	// replace old acl with new acl to take nodes in az out of circulation
+	aclAssociations := make(map[string]string)
+	for _, subnet := range azDetails.Subnets {
+		_, ok := aclAssociations[subnet.NetworkAclId]
+		// replace association with dummy acl if not replaced already
+		if !ok {
+			_, err := ec2Svc.ReplaceNetworkAclAssociation(&ec2.ReplaceNetworkAclAssociationInput{
+				DryRun: &experimentsDetails.DryRun,
+				AssociationId: &subnet.NetworkAclAssociationId,
+				NetworkAclId:  &subnet.DummyAclId,
+			})
+			if err != nil {
+				log.Errorf("Failed to replace association-id:%s ACL:%s with dummy ACL:%s, err: %v", subnet.NetworkAclAssociationId, subnet.NetworkAclId, subnet.DummyAclId, err)
+				failStep := fmt.Sprintf("Failed to replace association-id:%s ACL:%s with dummy ACL:%s", subnet.NetworkAclAssociationId, subnet.NetworkAclId, subnet.DummyAclId)
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			aclAssociations[subnet.NetworkAclId] = subnet.NetworkAclAssociationId
+			log.Info(fmt.Sprintf("Replaced NetworkAclAssociationId:%s NetworkAclId:%s with dummy DummyAclId:%s", subnet.NetworkAclAssociationId, subnet.NetworkAclId, subnet.DummyAclId))
+		}
+	}
+
+	// Including the litmus lib
+	if experimentsDetails.ChaosLib == "litmus" {
+		err = litmusLIB.AZDown()
+		if err != nil {
+			log.Errorf("Chaos injection failed, err: %v", err)
+			failStep := "failed in chaos injection phase"
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+		log.Info("[Confirmation]: chaos has been injected successfully")
+		resultDetails.Verdict = "Pass"
+	} else {
+		log.Error("[Invalid]: Please Provide the correct LIB")
+		failStep := "no match found for specified lib"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	//POST-CHAOS APPLICATION STATUS CHECK
+	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (post-chaos)")
+	err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+	if err != nil {
+		log.Errorf("Application status check failed, err: %v", err)
+		failStep := "Verify that the AUT (Application Under Test) is running (post-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := "AUT: Running"
+
+		// run the probes in the post-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+			err = probe.RunProbes(&chaosDetails, clients, &resultDetails, "PostChaos", &eventsDetails)
+			if err != nil {
+				log.Errorf("Probes Failed, err: %v", err)
+				failStep := "Failed while running probes"
+				msg := "AUT: Running, Probes: Unsuccessful"
+				types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = "AUT: Running, Probes: Successful"
+		}
+
+		// generating post chaos event
+		types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	//Updating the chaosResult in the end of experiment
+	log.Infof("[The End]: Updating the chaos result of %v experiment (EOT)", experimentsDetails.ExperimentName)
+	err = result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+	if err != nil {
+		log.Fatalf("Unable to Update the Chaos Result, err: %v", err)
+	}
+
+	// generating the event in chaosresult to marked the verdict as pass/fail
+	msg = "experiment: " + experimentsDetails.ExperimentName + ", Result: " + resultDetails.Verdict
+	reason := types.PassVerdict
+	eventType := "Normal"
+	if resultDetails.Verdict != "Pass" {
+		reason = types.FailVerdict
+		eventType = "Warning"
+	}
+	types.SetResultEventAttributes(&eventsDetails, reason, msg, eventType, &resultDetails)
+	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
+
+	if experimentsDetails.EngineName != "" {
+		msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
+		types.SetEngineEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	// cleanup: re-associate pre-chaos ACL to bring nodes in target az back into circulation
+	for _, subnet := range azDetails.Subnets {
+		_, err := ec2Svc.ReplaceNetworkAclAssociation(&ec2.ReplaceNetworkAclAssociationInput{
+			DryRun: &experimentsDetails.DryRun,
+			AssociationId: &subnet.NetworkAclAssociationId,
+			NetworkAclId:  &subnet.NetworkAclId,
+		})
+		if err != nil {
+			log.Errorf("Failed to revert association-id:%s dummy-ACL:%s to original ACL:%s, err: %v", subnet.NetworkAclAssociationId, subnet.DummyAclId, subnet.NetworkAclId, err)
+			failStep := fmt.Sprintf("Failed to revert association-id:%s dummy-ACL:%s to original ACL:%s", subnet.NetworkAclAssociationId, subnet.DummyAclId, subnet.NetworkAclId)
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+		log.Info(fmt.Sprintf("Reverted NetworkAclAssociationId:%s DummyAclId:%s to original NetworkAclId:%s", subnet.NetworkAclAssociationId, subnet.DummyAclId, subnet.NetworkAclId))
+	}
+
+	// cleanup: remove dummy ACLs no longer needed
+	for _, subnet := range azDetails.Subnets {
+		_, err := ec2Svc.DeleteNetworkAcl(&ec2.DeleteNetworkAclInput{
+			DryRun: &experimentsDetails.DryRun,
+			NetworkAclId: &subnet.DummyAclId,
+		})
+		if err != nil {
+			log.Errorf("Failed to remove dummy ACL %s, err: %v", subnet.DummyAclId, err)
+			failStep := fmt.Sprintf("Failed to revert dummy ACL %s (post-chaos)", subnet.DummyAclId)
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+		log.Info(fmt.Sprintf("DummyAclId:%s removed", subnet.DummyAclId))
+	}
+}

--- a/experiments/kube-aws/az-down/rbac.yaml
+++ b/experiments/kube-aws/az-down/rbac.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: az-down-sa
+  namespace: litmus
+  labels:
+    name: az-down-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: az-down-sa
+  labels:
+    name: az-down-sa
+rules:
+- apiGroups: ["","apps","litmuschaos.io","batch"]
+  resources: ["pods","jobs","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete","deletecollection"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: az-down-sa
+  labels:
+    name: az-down-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: az-down-sa
+subjects:
+- kind: ServiceAccount
+  name: az-down-sa
+  namespace: litmus

--- a/experiments/kube-aws/az-down/test/test.yml
+++ b/experiments/kube-aws/az-down/test/test.yml
@@ -1,0 +1,74 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litmus-experiment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: litmus-experiment
+  template:
+    metadata:
+      labels: 
+        app: litmus-experiment
+    spec:
+      serviceAccountName: "scheduler"
+      containers:
+      - name: gotest
+        image: busybox 
+        command: 
+          - sleep
+          - "3600"
+        env:
+          # provide application namespace
+          - name: APP_NAMESPACE
+            value: ''
+
+          # provide application labels
+          - name: APP_LABEL
+            value: ''
+ 
+          # provide application kind
+          - name: APP_KIND
+            value: ''
+
+          # provide application kind
+          - name: AWS_REGION
+            value: ''
+
+          # provide application kind
+          - name: CLUSTER_IDENTIFIER
+            value: ''
+
+          - name: TOTAL_CHAOS_DURATION
+            value: ''
+
+          # provide auxiliary application details - namespace and labels of the applications
+          # sample input is - "ns1:app=percona,ns2:name=nginx"
+          - name: AUXILIARY_APPINFO
+            value: ''
+          
+          ## Period to wait before injection of chaos in sec
+          - name: RAMP_TIME
+            value: ''
+
+          ## env var that describes the library used to execute the chaos
+          ## default: litmus. Supported values: litmus, powerfulseal, chaoskube
+          - name: LIB
+            value: 'litmus'
+
+          # provide the chaos namespace
+          - name: CHAOS_NAMESPACE
+            value: ''
+        
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
+          - name: CHAOS_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+

--- a/experiments/kube-aws/ec2-terminate/experiment/ec2-terminate.go
+++ b/experiments/kube-aws/ec2-terminate/experiment/ec2-terminate.go
@@ -64,6 +64,8 @@ func EC2Terminate(clients clients.ClientSets) {
 
 	//PRE-CHAOS APPLICATION STATUS CHECK
 	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (pre-chaos)")
+	// TODO - look at expanding this out to check multiple kafka clusters, not just one
+	// TODO - look at expanding this out to kafka-specific checks, or else using an external probe
 	err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
 	if err != nil {
 		log.Errorf("Application status check failed, err: %v", err)
@@ -95,7 +97,6 @@ func EC2Terminate(clients clients.ClientSets) {
 
 		// run the probes in the pre-chaos check
 		if len(resultDetails.ProbeDetails) != 0 {
-
 			err = probe.RunProbes(&chaosDetails, clients, &resultDetails, "PreChaos", &eventsDetails)
 			if err != nil {
 				log.Errorf("Probe Failed, err: %v", err)

--- a/pkg/cloud/aws/client.go
+++ b/pkg/cloud/aws/client.go
@@ -1,0 +1,23 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/types"
+)
+
+func GetNewEC2Client(experimentsDetails *experimentTypes.ExperimentDetails) ec2.EC2 {
+
+	verbose := true
+	// Load session from shared config
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		Config:            aws.Config{Region: aws.String(experimentsDetails.AwsRegion), CredentialsChainVerboseErrors: &verbose},
+	}))
+
+	// Create new EC2 client
+	ec2Svc := ec2.New(sess)
+
+	return *ec2Svc
+}

--- a/pkg/cloud/aws/instances.go
+++ b/pkg/cloud/aws/instances.go
@@ -1,0 +1,50 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	azDown "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/types"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"strings"
+)
+
+// returns all instances by name, id and az for region that cluster identifier
+func GetAllInstancesInRegion(ec2Svc *ec2.EC2) ([]*azDown.InstanceDetails, error) {
+
+	instanceData, err := ec2Svc.DescribeInstances(&ec2.DescribeInstancesInput{})
+
+	if err != nil {
+		log.Error(fmt.Sprintf("Could not list instances in region %s", err.Error()))
+	}
+
+	reservations := instanceData.Reservations
+
+	instances := make([]*azDown.InstanceDetails, len(reservations))
+	for i, res := range reservations {
+		instance := azDown.InstanceDetails{
+			Name: *res.Instances[0].InstanceId,
+			ID:   *res.Instances[0].Placement.AvailabilityZone,
+			AZ:   *res.Instances[0].Placement.AvailabilityZone,
+		}
+		instances[i] = &instance
+	}
+
+	return instances, nil
+}
+
+// returns a list of all instances whose name contains a specified cluster name identifier
+func GetClusterInstancesInRegion(ec2Svc *ec2.EC2, details *azDown.ExperimentDetails) ([]*azDown.InstanceDetails, error) {
+	allInstances, err := GetAllInstancesInRegion(ec2Svc)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterInstances := []*azDown.InstanceDetails{}
+	for _, instance := range allInstances {
+		name := instance.Name
+		if strings.Contains(name, details.ClusterIdentifier) {
+			clusterInstances = append(clusterInstances, instance)
+		}
+	}
+	return clusterInstances, nil
+}

--- a/pkg/kafka/kafka-topic-mgt.go
+++ b/pkg/kafka/kafka-topic-mgt.go
@@ -1,0 +1,3 @@
+package kafka
+
+// TODO implement function to create replicated topic in cluster

--- a/pkg/kube-aws/az-down/environment/environment.go
+++ b/pkg/kube-aws/az-down/environment/environment.go
@@ -1,0 +1,58 @@
+package environment
+
+import (
+	"os"
+	"strconv"
+
+	clientTypes "k8s.io/apimachinery/pkg/types"
+
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/kube-aws/az-down/types"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+)
+
+// STEPS TO GETENV OF YOUR CHOICE HERE
+// ADDED FOR FEW MANDATORY FIELD
+
+//GetENV fetches all the env variables from the runner pod
+func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
+	experimentDetails.ExperimentName = Getenv("EXPERIMENT_NAME", "az-down")
+	experimentDetails.ChaosNamespace = Getenv("CHAOS_NAMESPACE", "litmus")
+	experimentDetails.EngineName = Getenv("CHAOSENGINE", "")
+	experimentDetails.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION", "30"))
+	experimentDetails.ChaosInterval, _ = strconv.Atoi(Getenv("CHAOS_INTERVAL", "10"))
+	experimentDetails.RampTime, _ = strconv.Atoi(Getenv("RAMP_TIME", "0"))
+	experimentDetails.ChaosLib = Getenv("LIB", "litmus")
+	experimentDetails.AppNS = Getenv("APP_NAMESPACE", "")
+	experimentDetails.AppLabel = Getenv("APP_LABEL", "")
+	experimentDetails.AppKind = Getenv("APP_KIND", "")
+	experimentDetails.ChaosUID = clientTypes.UID(Getenv("CHAOS_UID", ""))
+	experimentDetails.InstanceID = Getenv("INSTANCE_ID", "")
+	experimentDetails.ChaosPodName = Getenv("POD_NAME", "")
+	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
+	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
+	experimentDetails.AwsRegion = Getenv("AWS_REGION", "")
+	experimentDetails.ClusterIdentifier = Getenv("CLUSTER_IDENTIFIER", "")
+	experimentDetails.DryRun, _ = strconv.ParseBool(Getenv("DRY_RUN", "false"))
+}
+
+// Getenv fetch the env and set the default value, if any
+func Getenv(key string, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		value = defaultValue
+	}
+	return value
+}
+
+//InitialiseChaosVariables initialise all the global variables
+func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetails *experimentTypes.ExperimentDetails) {
+
+	chaosDetails.ChaosNamespace = experimentDetails.ChaosNamespace
+	chaosDetails.ChaosPodName = experimentDetails.ChaosPodName
+	chaosDetails.ChaosUID = experimentDetails.ChaosUID
+	chaosDetails.EngineName = experimentDetails.EngineName
+	chaosDetails.ExperimentName = experimentDetails.ExperimentName
+	chaosDetails.InstanceID = experimentDetails.InstanceID
+	chaosDetails.Timeout = experimentDetails.Timeout
+	chaosDetails.Delay = experimentDetails.Delay
+}

--- a/pkg/kube-aws/az-down/types/types.go
+++ b/pkg/kube-aws/az-down/types/types.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"fmt"
+	clientTypes "k8s.io/apimachinery/pkg/types"
+)
+
+// ADD THE ATTRIBUTES OF YOUR CHOICE HERE
+// FEW MENDATORY ATTRIBUTES ARE ADDED BY DEFAULT
+
+// ExperimentDetails is for collecting all the experiment-related details
+type ExperimentDetails struct {
+	ExperimentName    string
+	EngineName        string
+	ChaosDuration     int
+	ChaosInterval     int
+	RampTime          int
+	ChaosLib          string
+	AppNS             string
+	AppLabel          string
+	AppKind           string
+	ChaosUID          clientTypes.UID
+	InstanceID        string
+	ChaosNamespace    string
+	ChaosPodName      string
+	Timeout           int
+	Delay             int
+	AwsRegion         string
+	ClusterIdentifier string
+	DryRun            bool
+}
+
+type InstanceDetails struct {
+	Name string
+	ID   string
+	AZ   string
+}
+
+type Subnet struct {
+	Id                      string
+	VpcId                   string
+	NetworkAclAssociationId string
+	NetworkAclId            string
+	DummyAclId              string
+}
+
+type AzDetails struct {
+	AzName  string
+	Subnets []*Subnet
+}
+
+func (az AzDetails) Print() {
+	for _, subnet := range az.Subnets {
+		fmt.Sprintf("Id: %s VpcId: %s NetworkAclAssociationId: %s NetworkAclId: %s DummyAclId: %s", subnet.Id, subnet.VpcId, subnet.NetworkAclAssociationId, subnet.NetworkAclId, subnet.DummyAclId)
+	}
+}
+
+func (inst InstanceDetails) Print() {
+	fmt.Sprintf("Instance:\nID: %s\t, AZ: %s\t, Name: %s\t", inst.ID, inst.AZ, inst.Name)
+}


### PR DESCRIPTION
## What

Add litmus experiment to simulate failure of an aws az.

## Why

Evaluate resiliency of application under test if an az goes down.

## How

- Add new litmus-go experiment for az-down
- create dummy ACLs with deny all traffic policies
- assign ACLs to subnets of az under test
- revert ACL changes after experiment concludes