### PR TITLE
Enhancement for Pod Autoscaler experiment

### DIFF
--- a/chaoslib/litmus/pod-autoscaler/lib/pod-autoscaler.go
+++ b/chaoslib/litmus/pod-autoscaler/lib/pod-autoscaler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/litmuschaos/litmus-go/pkg/events"
 	experimentTypes "github.com/litmuschaos/litmus-go/pkg/generic/pod-autoscaler/types"
 	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/probe"
 	"github.com/litmuschaos/litmus-go/pkg/result"
 	"github.com/litmuschaos/litmus-go/pkg/types"
 	"github.com/litmuschaos/litmus-go/pkg/utils/common"
@@ -239,10 +240,17 @@ func DeploymentStatusCheck(experimentsDetails *experimentTypes.ExperimentDetails
 			return errors.Errorf("Unable to perform autoscaling, err: %v", err)
 		}
 		return errors.Errorf("Failed to scale the application")
-	} else if err != nil {
+	}
+	if err != nil {
 		return err
 	}
 
+	// run the probes during chaos
+	if len(resultDetails.ProbeDetails) != 0 {
+		if err = probe.RunProbes(chaosDetails, clients, resultDetails, "DuringChaos", eventsDetails); err != nil {
+			return err
+		}
+	}
 	//ChaosCurrentTimeStamp contains the current timestamp
 	ChaosCurrentTimeStamp := time.Now().Unix()
 	if int(ChaosCurrentTimeStamp-ChaosStartTimeStamp) <= experimentsDetails.ChaosDuration {
@@ -285,8 +293,16 @@ func StatefulsetStatusCheck(experimentsDetails *experimentTypes.ExperimentDetail
 			return errors.Errorf("Unable to perform autoscaling, err: %v", err)
 		}
 		return errors.Errorf("Failed to scale the application")
-	} else if err != nil {
+	}
+	if err != nil {
 		return err
+	}
+
+	// run the probes during chaos
+	if len(resultDetails.ProbeDetails) != 0 {
+		if err = probe.RunProbes(chaosDetails, clients, resultDetails, "DuringChaos", eventsDetails); err != nil {
+			return err
+		}
 	}
 
 	//ChaosCurrentTimeStamp contains the current timestamp

--- a/chaoslib/litmus/pod-autoscaler/lib/pod-autoscaler.go
+++ b/chaoslib/litmus/pod-autoscaler/lib/pod-autoscaler.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"math"
 	"os"
 	"os/signal"
 	"strings"
@@ -44,40 +45,40 @@ func PreparePodAutoscaler(experimentsDetails *experimentTypes.ExperimentDetails,
 	switch strings.ToLower(experimentsDetails.AppKind) {
 	case "deployment", "deployments":
 
-		appName, replicaCount, err := GetDeploymentDetails(experimentsDetails, clients)
+		appsUnderTest, err := GetDeploymentDetails(experimentsDetails, clients)
 		if err != nil {
 			return errors.Errorf("Unable to get the name & replicaCount of the deployment, err: %v", err)
 		}
 
 		//calling go routine which will continuously watch for the abort signal
-		go AbortPodAutoScalerChaos(replicaCount, appName, experimentsDetails, clients, resultDetails, eventsDetails, chaosDetails)
+		go AbortPodAutoScalerChaos(appsUnderTest, experimentsDetails, clients, resultDetails, eventsDetails, chaosDetails)
 
-		err = PodAutoscalerChaosInDeployment(experimentsDetails, clients, replicaCount, appName, resultDetails, eventsDetails, chaosDetails)
+		err = PodAutoscalerChaosInDeployment(experimentsDetails, clients, appsUnderTest, resultDetails, eventsDetails, chaosDetails)
 		if err != nil {
 			return errors.Errorf("Unable to perform autoscaling, err: %v", err)
 		}
 
-		err = AutoscalerRecoveryInDeployment(experimentsDetails, clients, replicaCount, appName)
+		err = AutoscalerRecoveryInDeployment(experimentsDetails, clients, appsUnderTest)
 		if err != nil {
 			return errors.Errorf("Unable to rollback the autoscaling, err: %v", err)
 		}
 
 	case "statefulset", "statefulsets":
 
-		appName, replicaCount, err := GetStatefulsetDetails(experimentsDetails, clients)
+		appsUnderTest, err := GetStatefulsetDetails(experimentsDetails, clients)
 		if err != nil {
 			return errors.Errorf("Unable to get the name & replicaCount of the statefulset, err: %v", err)
 		}
 
 		//calling go routine which will continuously watch for the abort signal
-		go AbortPodAutoScalerChaos(replicaCount, appName, experimentsDetails, clients, resultDetails, eventsDetails, chaosDetails)
+		go AbortPodAutoScalerChaos(appsUnderTest, experimentsDetails, clients, resultDetails, eventsDetails, chaosDetails)
 
-		err = PodAutoscalerChaosInStatefulset(experimentsDetails, clients, replicaCount, appName, resultDetails, eventsDetails, chaosDetails)
+		err = PodAutoscalerChaosInStatefulset(experimentsDetails, clients, appsUnderTest, resultDetails, eventsDetails, chaosDetails)
 		if err != nil {
 			return errors.Errorf("Unable to perform autoscaling, err: %v", err)
 		}
 
-		err = AutoscalerRecoveryInStatefulset(experimentsDetails, clients, replicaCount, appName)
+		err = AutoscalerRecoveryInStatefulset(experimentsDetails, clients, appsUnderTest)
 		if err != nil {
 			return errors.Errorf("Unable to rollback the autoscaling, err: %v", err)
 		}
@@ -94,64 +95,77 @@ func PreparePodAutoscaler(experimentsDetails *experimentTypes.ExperimentDetails,
 	return nil
 }
 
-//GetDeploymentDetails is used to get the name and total number of replicas of the deployment
-func GetDeploymentDetails(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets) (string, int, error) {
+func getSliceOfTotalApplicationsTargeted(appList []experimentTypes.ApplicationUnderTest, experimentsDetails *experimentTypes.ExperimentDetails) ([]experimentTypes.ApplicationUnderTest, error) {
 
-	var appReplica int
-	var appName string
+	slice := int(math.Round(float64(len(appList)*experimentsDetails.AppAffectPercentage) / float64(100)))
+	if slice < 0 || slice > len(appList) {
+		return nil, errors.Errorf("slice of applications to target out of range %d/%d", slice, len(appList))
+	}
+	return appList[:slice], nil
+}
+
+//GetDeploymentDetails is used to get the name and total number of replicas of the deployment
+func GetDeploymentDetails(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets) ([]experimentTypes.ApplicationUnderTest, error) {
 
 	deploymentList, err := appsv1DeploymentClient.List(metav1.ListOptions{LabelSelector: experimentsDetails.AppLabel})
 	if err != nil || len(deploymentList.Items) == 0 {
-		return "", 0, errors.Errorf("Unable to find the deployments with matching labels, err: %v", err)
+		return nil, errors.Errorf("Unable to find the deployments with matching labels, err: %v", err)
 	}
+	appsUnderTest := []experimentTypes.ApplicationUnderTest{}
 	for _, app := range deploymentList.Items {
-		appReplica = int(*app.Spec.Replicas)
-		appName = app.Name
+		log.Infof("[DeploymentDetails]: Found deployment name %s with replica count %d", app.Name, int(*app.Spec.Replicas))
+		appsUnderTest = append(appsUnderTest, experimentTypes.ApplicationUnderTest{AppName: app.Name, ReplicaCount: int(*app.Spec.Replicas)})
 	}
+	// Applying the APP_AFFECT_PERC variable to determine the total target deployments to scale
+	return getSliceOfTotalApplicationsTargeted(appsUnderTest, experimentsDetails)
 
-	return appName, appReplica, nil
 }
 
 //GetStatefulsetDetails is used to get the name and total number of replicas of the statefulsets
-func GetStatefulsetDetails(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets) (string, int, error) {
-
-	var appReplica int
-	var appName string
+func GetStatefulsetDetails(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets) ([]experimentTypes.ApplicationUnderTest, error) {
 
 	statefulsetList, err := appsv1StatefulsetClient.List(metav1.ListOptions{LabelSelector: experimentsDetails.AppLabel})
 	if err != nil || len(statefulsetList.Items) == 0 {
-		return "", 0, errors.Errorf("Unable to find the statefulsets with matching labels, err: %v", err)
-	}
-	for _, app := range statefulsetList.Items {
-		appReplica = int(*app.Spec.Replicas)
-		appName = app.Name
+		return nil, errors.Errorf("Unable to find the statefulsets with matching labels, err: %v", err)
 	}
 
-	return appName, appReplica, nil
+	appsUnderTest := []experimentTypes.ApplicationUnderTest{}
+	for _, app := range statefulsetList.Items {
+		log.Infof("[DeploymentDetails]: Found statefulset name %s with replica count %d", app.Name, int(*app.Spec.Replicas))
+		appsUnderTest = append(appsUnderTest, experimentTypes.ApplicationUnderTest{AppName: app.Name, ReplicaCount: int(*app.Spec.Replicas)})
+	}
+	// Applying the APP_AFFECT_PERC variable to determine the total target deployments to scale
+	return getSliceOfTotalApplicationsTargeted(appsUnderTest, experimentsDetails)
 }
 
 //PodAutoscalerChaosInDeployment scales up the replicas of deployment and verify the status
-func PodAutoscalerChaosInDeployment(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, replicaCount int, appName string, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+func PodAutoscalerChaosInDeployment(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, appsUnderTest []experimentTypes.ApplicationUnderTest, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
 	// Scale Application
 	retryErr := retries.RetryOnConflict(retries.DefaultRetry, func() error {
-		// Retrieve the latest version of Deployment before attempting update
-		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-		appUnderTest, err := appsv1DeploymentClient.Get(appName, metav1.GetOptions{})
-		if err != nil {
-			return errors.Errorf("Failed to get latest version of Application Deployment, err: %v", err)
+		for _, app := range appsUnderTest {
+			// Retrieve the latest version of Deployment before attempting update
+			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+			appUnderTest, err := appsv1DeploymentClient.Get(app.AppName, metav1.GetOptions{})
+			if err != nil {
+				return errors.Errorf("Failed to get latest version of Application Deployment, err: %v", err)
+			}
+			// modifying the replica count
+			appUnderTest.Spec.Replicas = int32Ptr(int32(experimentsDetails.Replicas))
+			log.Infof("Updating deployment %s to number of replicas %d", appUnderTest.ObjectMeta.Name, experimentsDetails.Replicas)
+			_, err = appsv1DeploymentClient.Update(appUnderTest)
+			if err != nil {
+				return err
+			}
 		}
-		// modifying the replica count
-		appUnderTest.Spec.Replicas = int32Ptr(int32(experimentsDetails.Replicas))
-		_, updateErr := appsv1DeploymentClient.Update(appUnderTest)
-		return updateErr
+		return nil
 	})
 	if retryErr != nil {
 		return errors.Errorf("Unable to scale the deployment, err: %v", retryErr)
 	}
 	log.Info("Application Started Scaling")
 
-	err = DeploymentStatusCheck(experimentsDetails, appName, clients, replicaCount, resultDetails, eventsDetails, chaosDetails)
+	err = DeploymentStatusCheck(experimentsDetails, clients, appsUnderTest, resultDetails, eventsDetails, chaosDetails)
 	if err != nil {
 		return errors.Errorf("Status Check failed, err: %v", err)
 	}
@@ -160,27 +174,32 @@ func PodAutoscalerChaosInDeployment(experimentsDetails *experimentTypes.Experime
 }
 
 //PodAutoscalerChaosInStatefulset scales up the replicas of statefulset and verify the status
-func PodAutoscalerChaosInStatefulset(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, replicaCount int, appName string, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+func PodAutoscalerChaosInStatefulset(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, appsUnderTest []experimentTypes.ApplicationUnderTest, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
 	// Scale Application
 	retryErr := retries.RetryOnConflict(retries.DefaultRetry, func() error {
-		// Retrieve the latest version of Statefulset before attempting update
-		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-		appUnderTest, err := appsv1StatefulsetClient.Get(appName, metav1.GetOptions{})
-		if err != nil {
-			return errors.Errorf("Failed to get latest version of Application Statefulset, err: %v", err)
+		for _, app := range appsUnderTest {
+			// Retrieve the latest version of Statefulset before attempting update
+			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+			appUnderTest, err := appsv1StatefulsetClient.Get(app.AppName, metav1.GetOptions{})
+			if err != nil {
+				return errors.Errorf("Failed to get latest version of Application Statefulset, err: %v", err)
+			}
+			// modifying the replica count
+			appUnderTest.Spec.Replicas = int32Ptr(int32(experimentsDetails.Replicas))
+			_, err = appsv1StatefulsetClient.Update(appUnderTest)
+			if err != nil {
+				return err
+			}
 		}
-		// modifying the replica count
-		appUnderTest.Spec.Replicas = int32Ptr(int32(experimentsDetails.Replicas))
-		_, updateErr := appsv1StatefulsetClient.Update(appUnderTest)
-		return updateErr
+		return nil
 	})
 	if retryErr != nil {
 		return errors.Errorf("Unable to scale the statefulset, err: %v", retryErr)
 	}
 	log.Info("Application Started Scaling")
 
-	err = StatefulsetStatusCheck(experimentsDetails, appName, clients, replicaCount, resultDetails, eventsDetails, chaosDetails)
+	err = StatefulsetStatusCheck(experimentsDetails, clients, appsUnderTest, resultDetails, eventsDetails, chaosDetails)
 	if err != nil {
 		return errors.Errorf("Status Check failed, err: %v", err)
 	}
@@ -189,7 +208,7 @@ func PodAutoscalerChaosInStatefulset(experimentsDetails *experimentTypes.Experim
 }
 
 // DeploymentStatusCheck check the status of deployment and verify the available replicas
-func DeploymentStatusCheck(experimentsDetails *experimentTypes.ExperimentDetails, appName string, clients clients.ClientSets, replicaCount int, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+func DeploymentStatusCheck(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, appsUnderTest []experimentTypes.ApplicationUnderTest, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
 	//Record start timestamp
 	ChaosStartTimeStamp := time.Now().Unix()
@@ -199,22 +218,23 @@ func DeploymentStatusCheck(experimentsDetails *experimentTypes.ExperimentDetails
 		Times(uint(experimentsDetails.ChaosDuration / experimentsDetails.Delay)).
 		Wait(time.Duration(experimentsDetails.Delay) * time.Second).
 		Try(func(attempt uint) error {
-
-			deployment, err := appsv1DeploymentClient.Get(appName, metav1.GetOptions{})
-			if err != nil {
-				return errors.Errorf("Unable to find the deployment with name %v, err: %v", appName, err)
-			}
-			log.Infof("Deployment's Available Replica Count is %v", deployment.Status.AvailableReplicas)
-			if int(deployment.Status.AvailableReplicas) != experimentsDetails.Replicas {
-				isFailed = true
-				return errors.Errorf("Application is not scaled yet, err: %v", err)
+			for _, app := range appsUnderTest {
+				deployment, err := appsv1DeploymentClient.Get(app.AppName, metav1.GetOptions{})
+				if err != nil {
+					return errors.Errorf("Unable to find the deployment with name %v, err: %v", app.AppName, err)
+				}
+				log.Infof("Deployment's Available Replica Count is %v", deployment.Status.AvailableReplicas)
+				if int(deployment.Status.AvailableReplicas) != app.ReplicaCount {
+					isFailed = true
+					return errors.Errorf("Application %s is not scaled yet, err: %v", app.AppName, err)
+				}
 			}
 			isFailed = false
 			return nil
 		})
 
 	if isFailed {
-		err = AutoscalerRecoveryInDeployment(experimentsDetails, clients, replicaCount, appName)
+		err = AutoscalerRecoveryInDeployment(experimentsDetails, clients, appsUnderTest)
 		if err != nil {
 			return errors.Errorf("Unable to perform autoscaling, err: %v", err)
 		}
@@ -234,7 +254,7 @@ func DeploymentStatusCheck(experimentsDetails *experimentTypes.ExperimentDetails
 }
 
 // StatefulsetStatusCheck check the status of statefulset and verify the available replicas
-func StatefulsetStatusCheck(experimentsDetails *experimentTypes.ExperimentDetails, appName string, clients clients.ClientSets, replicaCount int, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+func StatefulsetStatusCheck(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, appsUnderTest []experimentTypes.ApplicationUnderTest, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
 	//Record start timestamp
 	ChaosStartTimeStamp := time.Now().Unix()
@@ -244,21 +264,23 @@ func StatefulsetStatusCheck(experimentsDetails *experimentTypes.ExperimentDetail
 		Times(uint(experimentsDetails.ChaosDuration / experimentsDetails.Delay)).
 		Wait(time.Duration(experimentsDetails.Delay) * time.Second).
 		Try(func(attempt uint) error {
-			statefulset, err := appsv1StatefulsetClient.Get(appName, metav1.GetOptions{})
-			if err != nil {
-				return errors.Errorf("Unable to find the statefulset with name %v, err: %v", appName, err)
-			}
-			log.Infof("Statefulset's Ready Replica Count is: %v", statefulset.Status.ReadyReplicas)
-			if int(statefulset.Status.ReadyReplicas) != experimentsDetails.Replicas {
-				isFailed = true
-				return errors.Errorf("Application is not scaled yet, err: %v", err)
+			for _, app := range appsUnderTest {
+				statefulset, err := appsv1StatefulsetClient.Get(app.AppName, metav1.GetOptions{})
+				if err != nil {
+					return errors.Errorf("Unable to find the statefulset with name %v, err: %v", app.AppName, err)
+				}
+				log.Infof("Statefulset's Ready Replica Count is: %v", statefulset.Status.ReadyReplicas)
+				if int(statefulset.Status.ReadyReplicas) != experimentsDetails.Replicas {
+					isFailed = true
+					return errors.Errorf("Application is not scaled yet, err: %v", err)
+				}
 			}
 			isFailed = false
 			return nil
 		})
 
 	if isFailed {
-		err = AutoscalerRecoveryInStatefulset(experimentsDetails, clients, replicaCount, appName)
+		err = AutoscalerRecoveryInStatefulset(experimentsDetails, clients, appsUnderTest)
 		if err != nil {
 			return errors.Errorf("Unable to perform autoscaling, err: %v", err)
 		}
@@ -278,20 +300,25 @@ func StatefulsetStatusCheck(experimentsDetails *experimentTypes.ExperimentDetail
 }
 
 //AutoscalerRecoveryInDeployment rollback the replicas to initial values in deployment
-func AutoscalerRecoveryInDeployment(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, replicaCount int, appName string) error {
+func AutoscalerRecoveryInDeployment(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, appsUnderTest []experimentTypes.ApplicationUnderTest) error {
 
 	// Scale back to initial number of replicas
 	retryErr := retries.RetryOnConflict(retries.DefaultRetry, func() error {
 		// Retrieve the latest version of Deployment before attempting update
 		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-		appUnderTest, err := appsv1DeploymentClient.Get(appName, metav1.GetOptions{})
-		if err != nil {
-			return errors.Errorf("Failed to find the latest version of Application Deployment with name %v, err: %v", appName, err)
-		}
+		for _, app := range appsUnderTest {
+			appUnderTest, err := appsv1DeploymentClient.Get(app.AppName, metav1.GetOptions{})
+			if err != nil {
+				return errors.Errorf("Failed to find the latest version of Application Deployment with name %v, err: %v", app.AppName, err)
+			}
 
-		appUnderTest.Spec.Replicas = int32Ptr(int32(replicaCount)) // modify replica count
-		_, updateErr := appsv1DeploymentClient.Update(appUnderTest)
-		return updateErr
+			appUnderTest.Spec.Replicas = int32Ptr(int32(app.ReplicaCount)) // modify replica count
+			_, err = appsv1DeploymentClient.Update(appUnderTest)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 	if retryErr != nil {
 		return errors.Errorf("Unable to rollback the deployment, err: %v", retryErr)
@@ -302,13 +329,15 @@ func AutoscalerRecoveryInDeployment(experimentsDetails *experimentTypes.Experime
 		Times(uint(experimentsDetails.Timeout / experimentsDetails.Delay)).
 		Wait(time.Duration(experimentsDetails.Delay) * time.Second).
 		Try(func(attempt uint) error {
-			applicationDeploy, err := appsv1DeploymentClient.Get(appName, metav1.GetOptions{})
-			if err != nil {
-				return errors.Errorf("Unable to find the deployment with name %v, err: %v", appName, err)
-			}
-			if int(applicationDeploy.Status.AvailableReplicas) != replicaCount {
-				log.Infof("Application Available Replica Count is: %v", applicationDeploy.Status.AvailableReplicas)
-				return errors.Errorf("Unable to rollback to older replica count, err: %v", err)
+			for _, app := range appsUnderTest {
+				applicationDeploy, err := appsv1DeploymentClient.Get(app.AppName, metav1.GetOptions{})
+				if err != nil {
+					return errors.Errorf("Unable to find the deployment with name %v, err: %v", app.AppName, err)
+				}
+				if int(applicationDeploy.Status.AvailableReplicas) != app.ReplicaCount {
+					log.Infof("Application Available Replica Count is: %v", applicationDeploy.Status.AvailableReplicas)
+					return errors.Errorf("Unable to rollback to older replica count, err: %v", err)
+				}
 			}
 			return nil
 		})
@@ -322,20 +351,25 @@ func AutoscalerRecoveryInDeployment(experimentsDetails *experimentTypes.Experime
 }
 
 //AutoscalerRecoveryInStatefulset rollback the replicas to initial values in deployment
-func AutoscalerRecoveryInStatefulset(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, replicaCount int, appName string) error {
+func AutoscalerRecoveryInStatefulset(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, appsUnderTest []experimentTypes.ApplicationUnderTest) error {
 
 	// Scale back to initial number of replicas
 	retryErr := retries.RetryOnConflict(retries.DefaultRetry, func() error {
-		// Retrieve the latest version of Statefulset before attempting update
-		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-		appUnderTest, err := appsv1StatefulsetClient.Get(appName, metav1.GetOptions{})
-		if err != nil {
-			return errors.Errorf("Failed to find the latest version of Statefulset with name %v, err: %v", appName, err)
-		}
+		for _, app := range appsUnderTest {
+			// Retrieve the latest version of Statefulset before attempting update
+			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+			appUnderTest, err := appsv1StatefulsetClient.Get(app.AppName, metav1.GetOptions{})
+			if err != nil {
+				return errors.Errorf("Failed to find the latest version of Statefulset with name %v, err: %v", app.AppName, err)
+			}
 
-		appUnderTest.Spec.Replicas = int32Ptr(int32(replicaCount)) // modify replica count
-		_, updateErr := appsv1StatefulsetClient.Update(appUnderTest)
-		return updateErr
+			appUnderTest.Spec.Replicas = int32Ptr(int32(app.ReplicaCount)) // modify replica count
+			_, err = appsv1StatefulsetClient.Update(appUnderTest)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 	if retryErr != nil {
 		return errors.Errorf("Unable to rollback the statefulset, err: %v", retryErr)
@@ -346,13 +380,16 @@ func AutoscalerRecoveryInStatefulset(experimentsDetails *experimentTypes.Experim
 		Times(uint(experimentsDetails.Timeout / experimentsDetails.Delay)).
 		Wait(time.Duration(experimentsDetails.Delay) * time.Second).
 		Try(func(attempt uint) error {
-			applicationDeploy, err := appsv1StatefulsetClient.Get(appName, metav1.GetOptions{})
-			if err != nil {
-				return errors.Errorf("Unable to find the statefulset with name %v, err: %v", appName, err)
-			}
-			if int(applicationDeploy.Status.ReadyReplicas) != replicaCount {
-				log.Infof("Application Ready Replica Count is: %v", applicationDeploy.Status.ReadyReplicas)
-				return errors.Errorf("Unable to roll back to older replica count, err: %v", err)
+			for _, app := range appsUnderTest {
+				applicationDeploy, err := appsv1StatefulsetClient.Get(app.AppName, metav1.GetOptions{})
+
+				if err != nil {
+					return errors.Errorf("Unable to find the statefulset with name %v, err: %v", app.AppName, err)
+				}
+				if int(applicationDeploy.Status.ReadyReplicas) != app.ReplicaCount {
+					log.Infof("Application Ready Replica Count is: %v", applicationDeploy.Status.ReadyReplicas)
+					return errors.Errorf("Unable to roll back to older replica count, err: %v", err)
+				}
 			}
 			return nil
 		})
@@ -368,7 +405,7 @@ func AutoscalerRecoveryInStatefulset(experimentsDetails *experimentTypes.Experim
 func int32Ptr(i int32) *int32 { return &i }
 
 //AbortPodAutoScalerChaos go routine will continuously watch for the abort signal for the entire chaos duration and generate the required events and result
-func AbortPodAutoScalerChaos(replicaCount int, appName string, experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+func AbortPodAutoScalerChaos(appsUnderTest []experimentTypes.ApplicationUnderTest, experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
 	// signChan channel is used to transmit signal notifications.
 	signChan := make(chan os.Signal, 1)
@@ -403,14 +440,12 @@ func AbortPodAutoScalerChaos(replicaCount int, appName string, experimentsDetail
 			// Other experiments have simpler "recoveries" that are more or less guaranteed to work.
 			switch strings.ToLower(experimentsDetails.AppKind) {
 			case "deployment", "deployments":
-
-				if err := AutoscalerRecoveryInDeployment(experimentsDetails, clients, replicaCount, appName); err != nil {
+				if err := AutoscalerRecoveryInDeployment(experimentsDetails, clients, appsUnderTest); err != nil {
 					log.Errorf("the recovery after abortion failed err: %v", err)
 				}
-
 			case "statefulset", "statefulsets":
 
-				if err := AutoscalerRecoveryInStatefulset(experimentsDetails, clients, replicaCount, appName); err != nil {
+				if err := AutoscalerRecoveryInStatefulset(experimentsDetails, clients, appsUnderTest); err != nil {
 					log.Errorf("the recovery after abortion failed err: %v", err)
 				}
 

--- a/pkg/generic/pod-autoscaler/environment/environment.go
+++ b/pkg/generic/pod-autoscaler/environment/environment.go
@@ -20,6 +20,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.AppNS = Getenv("APP_NAMESPACE", "")
 	experimentDetails.AppLabel = Getenv("APP_LABEL", "")
 	experimentDetails.AppKind = Getenv("APP_KIND", "")
+	experimentDetails.AppAffectPercentage, _ = strconv.Atoi(Getenv("APP_AFFECT_PERC", "100"))
 	experimentDetails.Replicas, _ = strconv.Atoi(Getenv("REPLICA_COUNT", ""))
 	experimentDetails.ChaosUID = clientTypes.UID(Getenv("CHAOS_UID", ""))
 	experimentDetails.InstanceID = Getenv("INSTANCE_ID", "")

--- a/pkg/generic/pod-autoscaler/types/types.go
+++ b/pkg/generic/pod-autoscaler/types/types.go
@@ -6,21 +6,28 @@ import (
 
 // ExperimentDetails is for collecting all the experiment-related details
 type ExperimentDetails struct {
-	ExperimentName   string
-	EngineName       string
-	ChaosDuration    int
-	RampTime         int
-	Replicas         int
-	ChaosLib         string
-	AppNS            string
-	AppLabel         string
-	AppKind          string
-	ChaosUID         clientTypes.UID
-	InstanceID       string
-	ChaosNamespace   string
-	ChaosPodName     string
-	RunID            string
-	AuxiliaryAppInfo string
-	Timeout          int
-	Delay            int
+	ExperimentName      string
+	EngineName          string
+	ChaosDuration       int
+	RampTime            int
+	Replicas            int
+	ChaosLib            string
+	AppNS               string
+	AppLabel            string
+	AppKind             string
+	AppAffectPercentage int
+	ChaosUID            clientTypes.UID
+	InstanceID          string
+	ChaosNamespace      string
+	ChaosPodName        string
+	RunID               string
+	AuxiliaryAppInfo    string
+	Timeout             int
+	Delay               int
+}
+
+// ApplicationUnderTest contains the name of the deployment object and the current replica count
+type ApplicationUnderTest struct {
+	AppName      string
+	ReplicaCount int
 }

--- a/pkg/probe/k8sprobe.go
+++ b/pkg/probe/k8sprobe.go
@@ -72,12 +72,12 @@ func TriggerK8sProbe(probe v1alpha1.ProbeAttributes, clients clients.ClientSets,
 			switch probe.Operation {
 			case "create", "Create":
 				if err = CreateResource(probe, gvr, clients); err != nil {
-					log.Errorf("The %v k8s probe has been Failed, err: %v", probe.Name, err)
+					log.Errorf("The %v k8s probe has Failed, err: %v", probe.Name, err)
 					return err
 				}
 			case "delete", "Delete":
 				if err = DeleteResource(probe, gvr, clients); err != nil {
-					log.Errorf("The %v k8s probe has been Failed, err: %v", probe.Name, err)
+					log.Errorf("The %v k8s probe has Failed, err: %v", probe.Name, err)
 					return err
 				}
 			case "present", "Present":
@@ -86,7 +86,7 @@ func TriggerK8sProbe(probe v1alpha1.ProbeAttributes, clients clients.ClientSets,
 					LabelSelector: cmd.LabelSelector,
 				})
 				if err != nil || len(resourceList.Items) == 0 {
-					log.Errorf("The %v k8s probe has been Failed, err: %v", probe.Name, err)
+					log.Errorf("The %v k8s probe has Failed, err: %v", probe.Name, err)
 					return fmt.Errorf("unable to list the resources with matching selector, err: %v", err)
 				}
 			case "absent", "Absent":
@@ -98,7 +98,7 @@ func TriggerK8sProbe(probe v1alpha1.ProbeAttributes, clients clients.ClientSets,
 					return fmt.Errorf("unable to list the resources with matching selector, err: %v", err)
 				}
 				if len(resourceList.Items) != 0 {
-					log.Errorf("The %v k8s probe has been Failed, err: %v", probe.Name, err)
+					log.Errorf("The %v k8s probe has Failed, err: %v", probe.Name, err)
 					return fmt.Errorf("Resource is not deleted yet due to, err: %v", err)
 				}
 			default:
@@ -148,7 +148,6 @@ func CreateResource(probe v1alpha1.ProbeAttributes, gvr schema.GroupVersionResou
 	if err != nil {
 		return err
 	}
-
 	_, err := clients.DynamicClient.Resource(gvr).Namespace(probe.K8sProbeInputs.Command.Namespace).Create(data, v1.CreateOptions{})
 
 	return err


### PR DESCRIPTION
This PR enhances the Pod Autoscaler experiment in 3 areas:
* Currently, the existing code only impacts a single deployment/statefulset based on the label selector defined in the engine, but the label selector itself could produce more than 1 result. This change is to follow the behaviour in the `kubelect scale deploy -l <label> --replicas <x>`. The change proposed here captures the name and the current replica count for all the impacted objects and uses this information across the experiment. 
* Adds a new ENV variable `APP_AFFECT_PERC` to specify the percentage of the target applications to be affected by the experiment. This comes in handy when the return query to list all the objects that match the label selector return more than one object. By default it is 100%. The final value is rounded up/down based on the `math.Round()` function.
* Adds support for probes with mode `OnChaos`. 