### PR TITLE
Adding ProbeImagePullPolicy variable for Container Kill Experiment only

### DIFF
--- a/pkg/generic/container-kill/environment/environment.go
+++ b/pkg/generic/container-kill/environment/environment.go
@@ -67,4 +67,5 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetail
 	chaosDetails.Delay = experimentDetails.Delay
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.JobCleanupPolicy = Getenv("JOB_CLEANUP_POLICY", "retain")
+	chaosDetails.ProbeImagePullPolicy = experimentDetails.LIBImagePullPolicy
 }

--- a/pkg/probe/cmdprobe.go
+++ b/pkg/probe/cmdprobe.go
@@ -142,7 +142,7 @@ func CreateProbePod(clients clients.ClientSets, chaosDetails *types.ChaosDetails
 				{
 					Name:            chaosDetails.ExperimentName + "-probe",
 					Image:           source,
-					ImagePullPolicy: apiv1.PullAlways,
+					ImagePullPolicy: apiv1.PullPolicy(chaosDetails.ProbeImagePullPolicy),
 					Command: []string{
 						"/bin/sh",
 					},

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -65,17 +65,18 @@ type EventDetails struct {
 
 // ChaosDetails is for collecting all the global variables
 type ChaosDetails struct {
-	ChaosUID         clientTypes.UID
-	ChaosNamespace   string
-	ChaosPodName     string
-	EngineName       string
-	InstanceID       string
-	ExperimentName   string
-	Timeout          int
-	Delay            int
-	AppDetail        AppDetails
-	ChaosDuration    int
-	JobCleanupPolicy string
+	ChaosUID             clientTypes.UID
+	ChaosNamespace       string
+	ChaosPodName         string
+	EngineName           string
+	InstanceID           string
+	ExperimentName       string
+	Timeout              int
+	Delay                int
+	AppDetail            AppDetails
+	ChaosDuration        int
+	JobCleanupPolicy     string
+	ProbeImagePullPolicy string
 }
 
 // AppDetails contains all the application related envs


### PR DESCRIPTION
Adding a variable to make the probe image pull policy configurable.
Changes are only done in the container kill experiment for testing purpose.