### PR TITLE
Add timeout in node-drain operation and ensure error is returned

### DIFF
--- a/chaoslib/litmus/node-drain/lib/node-drain.go
+++ b/chaoslib/litmus/node-drain/lib/node-drain.go
@@ -147,7 +147,7 @@ func DrainNode(experimentsDetails *experimentTypes.ExperimentDetails, clients cl
 		return fmt.Errorf("Unable to drain the %v node, err: %v", experimentsDetails.TargetNode, err)
 	}
 
-	err = retry.
+	return retry.
 		Times(90).
 		Wait(1 * time.Second).
 		Try(func(attempt uint) error {
@@ -160,8 +160,6 @@ func DrainNode(experimentsDetails *experimentTypes.ExperimentDetails, clients cl
 			}
 			return nil
 		})
-
-	return nil
 }
 
 // UncordonNode uncordon the application node
@@ -178,7 +176,7 @@ func UncordonNode(experimentsDetails *experimentTypes.ExperimentDetails, clients
 		return fmt.Errorf("Unable to uncordon the %v node, err: %v", experimentsDetails.TargetNode, err)
 	}
 
-	err = retry.
+	return retry.
 		Times(90).
 		Wait(1 * time.Second).
 		Try(func(attempt uint) error {
@@ -191,6 +189,4 @@ func UncordonNode(experimentsDetails *experimentTypes.ExperimentDetails, clients
 			}
 			return nil
 		})
-
-	return nil
 }

--- a/chaoslib/litmus/node-drain/lib/node-drain.go
+++ b/chaoslib/litmus/node-drain/lib/node-drain.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -137,7 +138,7 @@ func DrainNode(experimentsDetails *experimentTypes.ExperimentDetails, clients cl
 
 	log.Infof("[Inject]: Draining the %v node", experimentsDetails.TargetNode)
 
-	command := exec.Command("kubectl", "drain", experimentsDetails.TargetNode, "--ignore-daemonsets", "--delete-local-data", "--force")
+	command := exec.Command("kubectl", "drain", experimentsDetails.TargetNode, "--ignore-daemonsets", "--delete-local-data", "--force", "--timeout", strconv.Itoa(experimentsDetails.ChaosDuration)+"s")
 	var out, stderr bytes.Buffer
 	command.Stdout = &out
 	command.Stderr = &stderr


### PR DESCRIPTION
This PR guarantees that the potential error generated in the `retry` loop is returned to the caller. In its current form, the error is captured in the `err` variable, but its contents are never returned, instead it always returns a `nil`.

It also adds the `--timeout` flag to the `kubectl` command to `drain` the node, the time being equal to the experiment duration. I noticed in a draining scenario that the `kubelet` CLI failed to complete the operation due to instabilities in the cluster (Pod Disruption Budget of one of the deployments prevented the drain operation to complete, and that kept the experiment running indefinitely). With the timeout, the command will return an error and it will avoid its endless run.