### PR TITLE
chore(logs): skip chaos pod status check for infra chaos

### DIFF
--- a/pkg/status/application.go
+++ b/pkg/status/application.go
@@ -15,20 +15,63 @@ import (
 // CheckApplicationStatus checks the status of the AUT
 func CheckApplicationStatus(appNs, appLabel string, timeout, delay int, clients clients.ClientSets) error {
 
-	// Checking whether application containers are in ready state
-	log.Info("[Status]: Checking whether application containers are in ready state")
-	err := CheckContainerStatus(appNs, appLabel, timeout, delay, clients)
-	if err != nil {
-		return err
+	switch appLabel {
+	case "":
+		// Checking whether applications are healthy
+		log.Info("[Status]: Checking whether applications are in healthy state")
+		err := CheckPodAndContainerStatusInAppNs(appNs, timeout, delay, clients)
+		if err != nil {
+			return err
+		}
+	default:
+		// Checking whether application containers are in ready state
+		log.Info("[Status]: Checking whether application containers are in ready state")
+		err := CheckContainerStatus(appNs, appLabel, timeout, delay, clients)
+		if err != nil {
+			return err
+		}
+		// Checking whether application pods are in running state
+		log.Info("[Status]: Checking whether application pods are in running state")
+		err = CheckPodStatus(appNs, appLabel, timeout, delay, clients)
+		if err != nil {
+			return err
+		}
 	}
-	// Checking whether application pods are in running state
-	log.Info("[Status]: Checking whether application pods are in running state")
-	err = CheckPodStatus(appNs, appLabel, timeout, delay, clients)
-	if err != nil {
-		return err
-	}
-
 	return nil
+}
+
+// CheckPodAndContainerStatusInAppNs check status of pods and containers present in appns
+func CheckPodAndContainerStatusInAppNs(appNs string, timeout, delay int, clients clients.ClientSets) error {
+	return retry.
+		Times(uint(timeout / delay)).
+		Wait(time.Duration(delay) * time.Second).
+		Try(func(attempt uint) error {
+			podList, err := clients.KubeClient.CoreV1().Pods(appNs).List(metav1.ListOptions{})
+			if err != nil || len(podList.Items) == 0 {
+				return errors.Errorf("Unable to find any pod in %v namespace, err: %v", appNs, err)
+			}
+			for _, pod := range podList.Items {
+				if isChaosPod(pod.Labels) {
+					continue
+				}
+				for _, container := range pod.Status.ContainerStatuses {
+					if container.State.Terminated != nil {
+						return errors.Errorf("container is in terminated state")
+					}
+					if container.Ready != true {
+						return errors.Errorf("containers are not yet in running state")
+					}
+					log.InfoWithValues("[Status]: The Container status are as follows", logrus.Fields{
+						"container": container.Name, "Pod": pod.Name, "Readiness": container.Ready})
+				}
+				if pod.Status.Phase != "Running" {
+					return errors.Errorf("pods are not yet in running state")
+				}
+				log.InfoWithValues("[Status]: The Pod status are as follows", logrus.Fields{
+					"Pod": pod.Name, "Phase": pod.Status.Phase})
+			}
+			return nil
+		})
 }
 
 // CheckAuxiliaryApplicationStatus checks the status of the Auxiliary applications
@@ -152,4 +195,13 @@ func WaitForCompletion(appNs, appLabel string, clients clients.ClientSets, durat
 		return "", err
 	}
 	return podStatus, nil
+}
+
+// IsChaosPod check wheather the given pod is chaos pod or not
+// based on labels present inside pod
+func isChaosPod(labels map[string]string) bool {
+	if labels["chaosUID"] != "" || labels["name"] == "chaos-operator" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

**Problem**
- In infra chaos, When the appLabels are not provided it will check the status of all the pods available in that namespace. There can be the possibility that the residue pods(completed state) of the previous run are available in that namespace which can fail the status check.

**Soln:**
- Ignoring the status check of the chaos pod, while checking application status, if applabel is undefined(not provided).