### PR TITLE
In pod-network-latency use "replace" rather than "add" with tc.

### DIFF
--- a/chaoslib/litmus/network-chaos/helper/netem.go
+++ b/chaoslib/litmus/network-chaos/helper/netem.go
@@ -309,7 +309,7 @@ func InjectChaos(experimentDetails *experimentTypes.ExperimentDetails, pid int) 
 	destinationIPs := os.Getenv("DESTINATION_IPS")
 
 	if destinationIPs == "" {
-		tc := fmt.Sprintf("sudo nsenter -t %d -n tc qdisc add dev %s root netem %v", pid, experimentDetails.NetworkInterface, netemCommands)
+		tc := fmt.Sprintf("sudo nsenter -t %d -n tc qdisc replace dev %s root netem %v", pid, experimentDetails.NetworkInterface, netemCommands)
 		cmd := exec.Command("/bin/bash", "-c", tc)
 		out, err := cmd.CombinedOutput()
 		log.Info(cmd.String())
@@ -338,7 +338,7 @@ func InjectChaos(experimentDetails *experimentTypes.ExperimentDetails, pid int) 
 
 		// Create a priority-based queue
 		// This instantly creates classes 1:1, 1:2, 1:3
-		priority := fmt.Sprintf("sudo nsenter -t %v -n tc qdisc add dev %v root handle 1: prio", pid, experimentDetails.NetworkInterface)
+		priority := fmt.Sprintf("sudo nsenter -t %v -n tc qdisc replace dev %v root handle 1: prio", pid, experimentDetails.NetworkInterface)
 		cmd := exec.Command("/bin/bash", "-c", priority)
 		out, err := cmd.CombinedOutput()
 		log.Info(cmd.String())
@@ -349,7 +349,7 @@ func InjectChaos(experimentDetails *experimentTypes.ExperimentDetails, pid int) 
 
 		// Add queueing discipline for 1:3 class.
 		// No traffic is going through 1:3 yet
-		traffic := fmt.Sprintf("sudo nsenter -t %v -n tc qdisc add dev %v parent 1:3 netem %v", pid, experimentDetails.NetworkInterface, netemCommands)
+		traffic := fmt.Sprintf("sudo nsenter -t %v -n tc qdisc replace dev %v parent 1:3 netem %v", pid, experimentDetails.NetworkInterface, netemCommands)
 		cmd = exec.Command("/bin/bash", "-c", traffic)
 		out, err = cmd.CombinedOutput()
 		log.Info(cmd.String())

--- a/chaoslib/litmus/network_latency/tc/tc.go
+++ b/chaoslib/litmus/network_latency/tc/tc.go
@@ -29,7 +29,7 @@ func CreateDelayQdisc(PID int, latency float64, jitter float64) error {
 
 	log.Info(fmt.Sprintf("[tc] CreateDelayQdisc: PID=%d interface=%s latency=%fs jitter=%fs", PID, iface, latency, jitter))
 
-	tc := fmt.Sprintf("sudo nsenter -t %d -n tc qdisc add dev %s root handle 1: prio", PID, iface)
+	tc := fmt.Sprintf("sudo nsenter -t %d -n tc qdisc replace dev %s root handle 1: prio", PID, iface)
 	cmd := exec.Command("/bin/bash", "-c", tc)
 	out, err := cmd.CombinedOutput()
 	log.Info(cmd.String())
@@ -40,9 +40,9 @@ func CreateDelayQdisc(PID int, latency float64, jitter float64) error {
 
 	if almostZero(jitter) {
 		// no jitter
-		tc = fmt.Sprintf("sudo nsenter -t %d -n tc qdisc add dev %s parent 1:3 netem delay %fs", PID, iface, latency)
+		tc = fmt.Sprintf("sudo nsenter -t %d -n tc qdisc replace dev %s parent 1:3 netem delay %fs", PID, iface, latency)
 	} else {
-		tc = fmt.Sprintf("sudo nsenter -t %d -n tc qdisc add dev %s parent 1:3 netem delay %fs %fs", PID, iface, latency, jitter)
+		tc = fmt.Sprintf("sudo nsenter -t %d -n tc qdisc replace dev %s parent 1:3 netem delay %fs %fs", PID, iface, latency, jitter)
 	}
 	cmd = exec.Command("/bin/bash", "-c", tc)
 	out, err = cmd.CombinedOutput()


### PR DESCRIPTION
If a previous run doesn't manage to clean up all of the state that tc(8)
leaves behind, then "tc qdisc add" will fail.  But, "tc qdisc replace"
will succeed if there is an existing rule or not.