### PR TITLE
chore(kafka): updating kafka pod failure experiment

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 LABEL maintainer="LitmusChaos"
 

--- a/experiments/cassandra/pod-delete/experiment/pod-delete.go
+++ b/experiments/cassandra/pod-delete/experiment/pod-delete.go
@@ -48,8 +48,7 @@ func CasssandraPodDelete(clients clients.ClientSets) {
 	if err != nil {
 		log.Errorf("Unable to Create the Chaos Result, err: %v", err)
 		failStep := "Updating the chaos result of pod-delete experiment (SOT)"
-		types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-		err = result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 		return
 	}
 
@@ -77,8 +76,7 @@ func CasssandraPodDelete(clients clients.ClientSets) {
 	if err != nil {
 		log.Errorf("Application status check failed, err: %v", err)
 		failStep := "Verify that the AUT (Application Under Test) is running (pre-chaos)"
-		types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-		result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 		return
 	}
 
@@ -112,8 +110,8 @@ func CasssandraPodDelete(clients clients.ClientSets) {
 	if err != nil {
 		log.Errorf("[Status]: Chaos node tool status check failed, err: %v", err)
 		failStep := "Checking for load distribution on the ring(pre-chaos)"
-		types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-		result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
 	}
 
 	// Cassandra liveness check
@@ -122,8 +120,8 @@ func CasssandraPodDelete(clients clients.ClientSets) {
 		if err != nil {
 			log.Errorf("[Liveness]: Cassandra liveness check failed, err: %v", err)
 			failStep := "failed while creating liveness pod"
-			types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-			result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
 		}
 		log.Info("[Confirmation]: The cassandra application liveness pod created successfully")
 	} else {
@@ -136,8 +134,7 @@ func CasssandraPodDelete(clients clients.ClientSets) {
 		if err != nil {
 			log.Errorf("Chaos injection failed, err: %v", err)
 			failStep := "failed in chaos injection phase"
-			types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-			result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 			return
 		}
 		log.Info("[Confirmation]: The application pod has been deleted successfully")
@@ -145,8 +142,7 @@ func CasssandraPodDelete(clients clients.ClientSets) {
 	} else {
 		log.Error("[Invalid]: Please Provide the correct LIB")
 		failStep := "no match found for specified lib"
-		types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-		result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 		return
 	}
 
@@ -156,8 +152,7 @@ func CasssandraPodDelete(clients clients.ClientSets) {
 	if err != nil {
 		log.Errorf("Application status check failed, err: %v", err)
 		failStep := "Verify that the AUT (Application Under Test) is running (post-chaos)"
-		types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-		result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 		return
 	}
 	if experimentsDetails.ChaoslibDetail.EngineName != "" {
@@ -190,8 +185,8 @@ func CasssandraPodDelete(clients clients.ClientSets) {
 	if err != nil {
 		log.Errorf("[Status]: Chaos node tool status check is failed, err: %v", err)
 		failStep := "Checking for load distribution on the ring(post-chaos)"
-		types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-		result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
 	}
 
 	// Cassandra statefulset liveness check (post-chaos)
@@ -202,15 +197,15 @@ func CasssandraPodDelete(clients clients.ClientSets) {
 		if err != nil {
 			log.Errorf("Liveness status check failed, err: %v", err)
 			failStep := "failed while checking the status of liveness pod"
-			types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-			result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
 		}
 		err = cassandra.LivenessCleanup(&experimentsDetails, clients, ResourceVersionBefore)
 		if err != nil {
 			log.Errorf("Liveness cleanup failed, err: %v", err)
 			failStep := "failed while deleting liveness pod"
-			types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-			result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
 		}
 	}
 	//Updating the chaosResult in the end of experiment

--- a/experiments/kafka/kafka-broker-pod-failure/experiment/kafka-broker-pod-failure.go
+++ b/experiments/kafka/kafka-broker-pod-failure/experiment/kafka-broker-pod-failure.go
@@ -47,8 +47,7 @@ func KafkaBrokerPodFailure(clients clients.ClientSets) {
 	if err != nil {
 		log.Errorf("Unable to Create the Chaos Result, err: %v", err)
 		failStep := "Updating the chaos result of kafka-broker-pod-failure experiment (SOT)"
-		types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-		err = result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 		return
 	}
 
@@ -74,8 +73,7 @@ func KafkaBrokerPodFailure(clients clients.ClientSets) {
 	if err != nil {
 		log.Errorf("Cluster status check failed, err: %v", err)
 		failStep := "Verify that the AUT (Application Under Test) is running (pre-chaos)"
-		types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-		result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 		return
 	}
 	if experimentsDetails.ChaoslibDetail.EngineName != "" {
@@ -110,10 +108,8 @@ func KafkaBrokerPodFailure(clients clients.ClientSets) {
 			if err != nil {
 				log.Errorf("Liveness check failed, err: %v", err)
 				failStep := "Verify liveness check (pre-chaos)"
-				types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-				result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 				return
-
 			}
 			log.Info("The Liveness pod gets established")
 
@@ -129,8 +125,7 @@ func KafkaBrokerPodFailure(clients clients.ClientSets) {
 			if err != nil {
 				log.Errorf("Error: %v", err)
 				failStep := "Launch the stream derive leader"
-				types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-				result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 				return
 			}
 		} else if experimentsDetails.KafkaLivenessStream == "" || experimentsDetails.KafkaLivenessStream == "disabled" {
@@ -138,8 +133,7 @@ func KafkaBrokerPodFailure(clients clients.ClientSets) {
 			if err != nil {
 				log.Errorf("Error: %v", err)
 				failStep := "Selecting broker when liveness is disabled"
-				types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-				result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 				return
 			}
 		}
@@ -151,8 +145,7 @@ func KafkaBrokerPodFailure(clients clients.ClientSets) {
 		if err != nil {
 			log.Errorf("Chaos injection failed, err: %v", err)
 			failStep := "Including the litmus lib for kafka-broker-pod-failure"
-			types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-			result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 			return
 		}
 		log.Info("[Confirmation]: The application pod has been deleted successfully")
@@ -160,8 +153,7 @@ func KafkaBrokerPodFailure(clients clients.ClientSets) {
 	} else {
 		log.Error("[Invalid]: Please Provide the correct LIB")
 		failStep := "Including the litmus lib for kafka-broker-pod-failure"
-		types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-		result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 		return
 	}
 
@@ -171,8 +163,7 @@ func KafkaBrokerPodFailure(clients clients.ClientSets) {
 	if err != nil {
 		log.Errorf("Cluster status check failed, err: %v", err)
 		failStep := "Verify that the AUT (Application Under Test) is running (pre-chaos)"
-		types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-		result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 		return
 	}
 	if experimentsDetails.ChaoslibDetail.EngineName != "" {
@@ -201,20 +192,18 @@ func KafkaBrokerPodFailure(clients clients.ClientSets) {
 
 	// Liveness Status Check (post-chaos) and cleanup
 	if experimentsDetails.KafkaLivenessStream != "" {
-		err = status.CheckApplicationStatus(experimentsDetails.ChaoslibDetail.AppNS, "name=kafka-liveness", experimentsDetails.ChaoslibDetail.Timeout, experimentsDetails.ChaoslibDetail.Delay, clients)
+		err = status.CheckApplicationStatus(experimentsDetails.ChaoslibDetail.AppNS, "name=kafka-liveness-"+experimentsDetails.RunID, experimentsDetails.ChaoslibDetail.Timeout, experimentsDetails.ChaoslibDetail.Delay, clients)
 		if err != nil {
 			log.Errorf("Application liveness check failed, err: %v", err)
 			failStep := "Verify that the AUT (Application Under Test) is running (post-chaos)"
-			types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-			result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 			return
 		}
 
 		if err := kafka.LivenessCleanup(&experimentsDetails, clients); err != nil {
 			log.Errorf("liveness cleanup failed, err: %v", err)
 			failStep := "Performing cleanup post chaos"
-			types.SetResultAfterCompletion(&resultDetails, "Fail", "Completed", failStep)
-			result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 			return
 		}
 

--- a/pkg/kafka/kafka-liveness-cleanup.go
+++ b/pkg/kafka/kafka-liveness-cleanup.go
@@ -17,16 +17,14 @@ func LivenessCleanup(experimentsDetails *experimentTypes.ExperimentDetails, clie
 		return errors.Errorf("Fail to delete liveness deployment, err: %v", err)
 	}
 
-	err := retry.
+	return retry.
 		Times(uint(experimentsDetails.ChaoslibDetail.Timeout / experimentsDetails.ChaoslibDetail.Delay)).
 		Wait(time.Duration(experimentsDetails.ChaoslibDetail.Delay) * time.Second).
 		Try(func(attempt uint) error {
-			podSpec, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.ChaoslibDetail.AppNS).List(metav1.ListOptions{LabelSelector: "name=kafka-liveness"})
+			podSpec, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.ChaoslibDetail.AppNS).List(metav1.ListOptions{LabelSelector: "name=kafka-liveness-" + experimentsDetails.RunID})
 			if err != nil || len(podSpec.Items) != 0 {
 				return errors.Errorf("Liveness pod is not deleted yet, err: %v", err)
 			}
 			return nil
 		})
-
-	return err
 }

--- a/pkg/kafka/kafka-liveness-stream.go
+++ b/pkg/kafka/kafka-liveness-stream.go
@@ -17,33 +17,23 @@ import (
 
 // LivenessStream will generate kafka liveness deployment on the basic of given condition
 func LivenessStream(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets) (string, error) {
-	var err error
-	var LivenessTopicLeader string
-	var KafkaTopicName string
+
 	var ordinality string
 
-	podList, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.KafkaNamespace).List(metav1.ListOptions{LabelSelector: "name=kafka-liveness"})
+	// Generate a random string as suffix to topic name
+	log.Info("[Liveness]: Set the kafka topic name")
+	experimentsDetails.RunID = common.GetRunID()
+	KafkaTopicName := "topic-" + experimentsDetails.RunID
+
+	log.Info("[Liveness]: Generate the kafka liveness spec from template")
+	err := CreateLivenessPod(experimentsDetails, KafkaTopicName, clients)
 	if err != nil {
-		return "", errors.Errorf("unable to find the liveness pod with matching labels, err: %v", err)
+		return "", err
 	}
-	if len(podList.Items) == 0 {
 
-		// Generate a random string as suffix to topic name
-		log.Info("[Liveness]: Set the kafka topic name")
-		experimentsDetails.RunID = common.GetRunID()
-		KafkaTopicName = "topic-" + experimentsDetails.RunID
-
-		log.Info("[Liveness]: Generate the kafka liveness spec from template")
-		err = CreateLivenessPod(experimentsDetails, KafkaTopicName, clients)
-		if err != nil {
-			return "", err
-		}
-
-		log.Info("[Liveness]: Confirm that the kafka liveness pod is running")
-		err = status.CheckApplicationStatus(experimentsDetails.KafkaNamespace, "name=kafka-liveness", experimentsDetails.ChaoslibDetail.Timeout, experimentsDetails.ChaoslibDetail.Delay, clients)
-		if err != nil {
-			return "", errors.Errorf("Liveness pod status check failed, err: %v", err)
-		}
+	log.Info("[Liveness]: Confirm that the kafka liveness pod is running")
+	if err := status.CheckApplicationStatus(experimentsDetails.KafkaNamespace, "name=kafka-liveness-"+experimentsDetails.RunID, experimentsDetails.ChaoslibDetail.Timeout, experimentsDetails.ChaoslibDetail.Delay, clients); err != nil {
+		return "", errors.Errorf("Liveness pod status check failed, err: %v", err)
 	}
 
 	log.Info("[Liveness]: Obtain the leader broker ordinality for the topic (partition) created by kafka-liveness")
@@ -70,19 +60,18 @@ func LivenessStream(experimentsDetails *experimentTypes.ExperimentDetails, clien
 	}
 
 	log.Info("[Liveness]: Determine the leader broker pod name")
-	podList, err = clients.KubeClient.CoreV1().Pods(experimentsDetails.KafkaNamespace).List(metav1.ListOptions{LabelSelector: experimentsDetails.KafkaLabel})
+	podList, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.KafkaNamespace).List(metav1.ListOptions{LabelSelector: experimentsDetails.KafkaLabel})
 	if err != nil {
 		return "", errors.Errorf("unable to find the pods with matching labels, err: %v", err)
 	}
 
 	for _, pod := range podList.Items {
 		if strings.ContainsAny(pod.Name, ordinality) {
-			LivenessTopicLeader = pod.Name
-			break
+			return pod.Name, nil
 		}
 	}
 
-	return LivenessTopicLeader, nil
+	return "", errors.Errorf("No kafka pod found with %v ordinality", ordinality)
 }
 
 // CreateLivenessPod will create a liveness pod when kafka saslAuth in not enabled
@@ -96,7 +85,8 @@ func CreateLivenessPod(experimentsDetails *experimentTypes.ExperimentDetails, Ka
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kafka-liveness-" + experimentsDetails.RunID,
 			Labels: map[string]string{
-				"name":                      "kafka-liveness",
+				"app":                       "kafka-liveness",
+				"name":                      "kafka-liveness-" + experimentsDetails.RunID,
 				"app.kubernetes.io/part-of": "litmus",
 			},
 		},


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding chaosresult update and event generation for failure cases in kafka-pod-delete and cassandra-pod-delete experiment.
- Adding unique labels inside kafka liveness pod