### PR TITLE
Fix docker buildx command in actions CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ unused-package-check:
 	fi
 
 .PHONY: build
-build: experiment-build image-build
+build: experiment-build docker.buildx image-build
 
 .PHONY: experiment-build
 experiment-build:
@@ -80,12 +80,23 @@ experiment-build:
 	@echo "------------------------------"
 	@./build/go-multiarch-build.sh build/generate_go_binary
 
+.PHONY: docker.buildx
+docker.buildx:
+	@echo "------------------------------"
+	@echo "--> Setting up Builder        " 
+	@echo "------------------------------"
+	@if ! docker buildx ls | grep -q multibuilder; then\
+		docker buildx create --name multibuilder;\
+		docker buildx inspect multibuilder --bootstrap;\
+		docker buildx use multibuilder;\
+	fi
+
 .PHONY: image-build
 image-build:	
 	@echo "-------------------------"
 	@echo "--> Build go-runner image" 
 	@echo "-------------------------"
-	@sudo docker buildx build --file build/Dockerfile --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) .
+	@docker buildx build --file build/Dockerfile --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) .
 
 .PHONY: build-amd64
 build-amd64:
@@ -108,7 +119,7 @@ push-amd64:
 	@sudo docker push $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG)
 	
 .PHONY: push
-push: litmus-go-push
+push: docker.buildx litmus-go-push
 
 litmus-go-push:
 	@echo "-------------------"

--- a/build/push
+++ b/build/push
@@ -19,16 +19,16 @@ then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
   echo "Pushing ${REPONAME}/${IMGNAME}:${IMGTAG} ..."; 
-  sudo docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REPONAME}/${IMGNAME}:${IMGTAG} .
+  docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REPONAME}/${IMGNAME}:${IMGTAG} .
   if [ ! -z "${RELEASE_TAG}" ] ; 
   then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will 
     # set the release tag in env RELEASE_TAG
     echo "Pushing ${REPONAME}/${IMGNAME}:${RELEASE_TAG} ..."; 
-    sudo docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REPONAME}/${IMGNAME}:${RELEASE_TAG} .
+    docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REPONAME}/${IMGNAME}:${RELEASE_TAG} .
     echo "Pushing ${REPONAME}/${IMGNAME}:latest ..."; 
-    sudo docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REPONAME}/${IMGNAME}:latest .
+    docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REPONAME}/${IMGNAME}:latest .
   fi;
 else
   echo "No docker credentials provided. Skip uploading ${REPONAME}/${IMGNAME}:${IMGTAG} to docker hub"; 


### PR DESCRIPTION
Signed-off-by: udit <udit.gaurav@mayadata.io>

### Details

- This PR fixed the broken buildx in CI.

The issue was -- it is not picking the builder created from `buildx` actions that's why I have added a check in Makefile that will verify if the driver is not changed from docker then it will change it. Also, the buildx creates a driver instance which wasn't available on the root repo and hence not accessible from `sudo`.
