### PR TITLE
feat(imagePullSecrets): Passing imagePullSecrets into helper pod

### DIFF
--- a/chaoslib/litmus/container-kill/lib/container-kill.go
+++ b/chaoslib/litmus/container-kill/lib/container-kill.go
@@ -68,6 +68,12 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
+
 	}
 
 	if experimentsDetails.Sequence == "serial" {
@@ -236,6 +242,7 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 		},
 		Spec: apiv1.PodSpec{
 			ServiceAccountName: experimentsDetails.ChaosServiceAccount,
+			ImagePullSecrets:   experimentsDetails.ImagePullSecrets,
 			RestartPolicy:      apiv1.RestartPolicyNever,
 			NodeName:           nodeName,
 			Volumes: []apiv1.Volume{

--- a/chaoslib/litmus/disk-fill/lib/disk-fill.go
+++ b/chaoslib/litmus/disk-fill/lib/disk-fill.go
@@ -67,6 +67,11 @@ func PrepareDiskFill(experimentsDetails *experimentTypes.ExperimentDetails, clie
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 
 	if experimentsDetails.Sequence == "serial" {
@@ -213,6 +218,7 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 		},
 		Spec: apiv1.PodSpec{
 			RestartPolicy:      apiv1.RestartPolicyNever,
+			ImagePullSecrets:   experimentsDetails.ImagePullSecrets,
 			NodeName:           appNodeName,
 			ServiceAccountName: experimentsDetails.ChaosServiceAccount,
 			Volumes: []apiv1.Volume{

--- a/chaoslib/litmus/kubelet-service-kill/lib/kubelet-service-kill.go
+++ b/chaoslib/litmus/kubelet-service-kill/lib/kubelet-service-kill.go
@@ -57,6 +57,11 @@ func PrepareKubeletKill(experimentsDetails *experimentTypes.ExperimentDetails, c
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 
 	// Creating the helper pod to perform node memory hog
@@ -132,8 +137,9 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 			Annotations: experimentsDetails.Annotations,
 		},
 		Spec: apiv1.PodSpec{
-			RestartPolicy: apiv1.RestartPolicyNever,
-			NodeName:      appNodeName,
+			RestartPolicy:    apiv1.RestartPolicyNever,
+			ImagePullSecrets: experimentsDetails.ImagePullSecrets,
+			NodeName:         appNodeName,
 			Volumes: []apiv1.Volume{
 				{
 					Name: "bus",

--- a/chaoslib/litmus/network-chaos/lib/network-chaos.go
+++ b/chaoslib/litmus/network-chaos/lib/network-chaos.go
@@ -68,6 +68,11 @@ func PrepareAndInjectChaos(experimentsDetails *experimentTypes.ExperimentDetails
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 
 	if experimentsDetails.Sequence == "serial" {
@@ -218,6 +223,7 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 		},
 		Spec: apiv1.PodSpec{
 			HostPID:            true,
+			ImagePullSecrets:   experimentsDetails.ImagePullSecrets,
 			ServiceAccountName: experimentsDetails.ChaosServiceAccount,
 			RestartPolicy:      apiv1.RestartPolicyNever,
 			NodeName:           nodeName,

--- a/chaoslib/litmus/node-cpu-hog/lib/node-cpu-hog.go
+++ b/chaoslib/litmus/node-cpu-hog/lib/node-cpu-hog.go
@@ -48,6 +48,11 @@ func PrepareNodeCPUHog(experimentsDetails *experimentTypes.ExperimentDetails, cl
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 
 	if experimentsDetails.Sequence == "serial" {
@@ -245,8 +250,9 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, appN
 			Annotations: experimentsDetails.Annotations,
 		},
 		Spec: apiv1.PodSpec{
-			RestartPolicy: apiv1.RestartPolicyNever,
-			NodeName:      appNode,
+			RestartPolicy:    apiv1.RestartPolicyNever,
+			ImagePullSecrets: experimentsDetails.ImagePullSecrets,
+			NodeName:         appNode,
 			Containers: []apiv1.Container{
 				{
 					Name:            experimentsDetails.ExperimentName,

--- a/chaoslib/litmus/node-io-stress/lib/node-io-stress.go
+++ b/chaoslib/litmus/node-io-stress/lib/node-io-stress.go
@@ -48,6 +48,11 @@ func PrepareNodeIOStress(experimentsDetails *experimentTypes.ExperimentDetails, 
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 
 	if experimentsDetails.Sequence == "serial" {
@@ -213,8 +218,9 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, appN
 			Annotations: experimentsDetails.Annotations,
 		},
 		Spec: apiv1.PodSpec{
-			RestartPolicy: apiv1.RestartPolicyNever,
-			NodeName:      appNode,
+			RestartPolicy:    apiv1.RestartPolicyNever,
+			ImagePullSecrets: experimentsDetails.ImagePullSecrets,
+			NodeName:         appNode,
 			Containers: []apiv1.Container{
 				{
 					Name:            experimentsDetails.ExperimentName,

--- a/chaoslib/litmus/node-memory-hog/lib/node-memory-hog.go
+++ b/chaoslib/litmus/node-memory-hog/lib/node-memory-hog.go
@@ -46,6 +46,11 @@ func PrepareNodeMemoryHog(experimentsDetails *experimentTypes.ExperimentDetails,
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 
 	if experimentsDetails.Sequence == "serial" {
@@ -317,8 +322,9 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, appN
 			Annotations: experimentsDetails.Annotations,
 		},
 		Spec: apiv1.PodSpec{
-			RestartPolicy: apiv1.RestartPolicyNever,
-			NodeName:      appNode,
+			RestartPolicy:    apiv1.RestartPolicyNever,
+			ImagePullSecrets: experimentsDetails.ImagePullSecrets,
+			NodeName:         appNode,
 			Containers: []apiv1.Container{
 				{
 					Name:            experimentsDetails.ExperimentName,

--- a/chaoslib/litmus/node-restart/lib/node-restart.go
+++ b/chaoslib/litmus/node-restart/lib/node-restart.go
@@ -87,6 +87,11 @@ func PrepareNodeRestart(experimentsDetails *experimentTypes.ExperimentDetails, c
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 	// Creating the helper pod to perform node restart
 	err = CreateHelperPod(experimentsDetails, clients)
@@ -153,7 +158,8 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 			Annotations: experimentsDetails.Annotations,
 		},
 		Spec: apiv1.PodSpec{
-			RestartPolicy: apiv1.RestartPolicyNever,
+			RestartPolicy:    apiv1.RestartPolicyNever,
+			ImagePullSecrets: experimentsDetails.ImagePullSecrets,
 			Affinity: &k8stypes.Affinity{
 				NodeAffinity: &k8stypes.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &k8stypes.NodeSelector{

--- a/chaoslib/pumba/container-kill/lib/container-kill.go
+++ b/chaoslib/pumba/container-kill/lib/container-kill.go
@@ -58,6 +58,11 @@ func PrepareContainerKill(experimentsDetails *experimentTypes.ExperimentDetails,
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 
 	if experimentsDetails.EngineName != "" {
@@ -295,8 +300,9 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 			Annotations: experimentsDetails.Annotations,
 		},
 		Spec: apiv1.PodSpec{
-			RestartPolicy: apiv1.RestartPolicyNever,
-			NodeName:      appNodeName,
+			RestartPolicy:    apiv1.RestartPolicyNever,
+			ImagePullSecrets: experimentsDetails.ImagePullSecrets,
+			NodeName:         appNodeName,
 			Volumes: []apiv1.Volume{
 				{
 					Name: "dockersocket",

--- a/chaoslib/pumba/cpu-chaos/lib/cpu-chaos.go
+++ b/chaoslib/pumba/cpu-chaos/lib/cpu-chaos.go
@@ -55,6 +55,11 @@ func PreparePodCPUHog(experimentsDetails *experimentTypes.ExperimentDetails, cli
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 
 	if experimentsDetails.Sequence == "serial" {
@@ -194,8 +199,9 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 			Annotations: experimentsDetails.Annotations,
 		},
 		Spec: apiv1.PodSpec{
-			RestartPolicy: apiv1.RestartPolicyNever,
-			NodeName:      appNodeName,
+			RestartPolicy:    apiv1.RestartPolicyNever,
+			ImagePullSecrets: experimentsDetails.ImagePullSecrets,
+			NodeName:         appNodeName,
 			Volumes: []apiv1.Volume{
 				{
 					Name: "dockersocket",

--- a/chaoslib/pumba/memory-chaos/lib/memory-chaos.go
+++ b/chaoslib/pumba/memory-chaos/lib/memory-chaos.go
@@ -55,6 +55,11 @@ func PreparePodMemoryHog(experimentsDetails *experimentTypes.ExperimentDetails, 
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 
 	if experimentsDetails.Sequence == "serial" {
@@ -195,8 +200,9 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 			Annotations: experimentsDetails.Annotations,
 		},
 		Spec: apiv1.PodSpec{
-			RestartPolicy: apiv1.RestartPolicyNever,
-			NodeName:      appNodeName,
+			RestartPolicy:    apiv1.RestartPolicyNever,
+			ImagePullSecrets: experimentsDetails.ImagePullSecrets,
+			NodeName:         appNodeName,
 			Volumes: []apiv1.Volume{
 				{
 					Name: "dockersocket",

--- a/chaoslib/pumba/network-chaos/lib/network-chaos.go
+++ b/chaoslib/pumba/network-chaos/lib/network-chaos.go
@@ -53,6 +53,11 @@ func PrepareAndInjectChaos(experimentsDetails *experimentTypes.ExperimentDetails
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 
 	if experimentsDetails.EngineName != "" {
@@ -215,8 +220,9 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 			Annotations: experimentsDetails.Annotations,
 		},
 		Spec: apiv1.PodSpec{
-			RestartPolicy: apiv1.RestartPolicyNever,
-			NodeName:      appNodeName,
+			RestartPolicy:    apiv1.RestartPolicyNever,
+			ImagePullSecrets: experimentsDetails.ImagePullSecrets,
+			NodeName:         appNodeName,
 			Volumes: []apiv1.Volume{
 				{
 					Name: "dockersocket",

--- a/chaoslib/pumba/pod-io-stress/lib/pod-io-stress.go
+++ b/chaoslib/pumba/pod-io-stress/lib/pod-io-stress.go
@@ -55,6 +55,11 @@ func PreparePodIOStress(experimentsDetails *experimentTypes.ExperimentDetails, c
 		if err != nil {
 			return errors.Errorf("Unable to get resource requirements, err: %v", err)
 		}
+		// Get ImagePullSecrets
+		experimentsDetails.ImagePullSecrets, err = common.GetImagePullSecrets(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
+		if err != nil {
+			return errors.Errorf("Unable to get imagePullSecrets, err: %v", err)
+		}
 	}
 
 	if experimentsDetails.Sequence == "serial" {
@@ -197,8 +202,9 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 			Annotations: experimentsDetails.Annotations,
 		},
 		Spec: apiv1.PodSpec{
-			RestartPolicy: apiv1.RestartPolicyNever,
-			NodeName:      appNodeName,
+			RestartPolicy:    apiv1.RestartPolicyNever,
+			ImagePullSecrets: experimentsDetails.ImagePullSecrets,
+			NodeName:         appNodeName,
 			Volumes: []apiv1.Volume{
 				{
 					Name: "dockersocket",

--- a/pkg/generic/container-kill/types/types.go
+++ b/pkg/generic/container-kill/types/types.go
@@ -36,4 +36,5 @@ type ExperimentDetails struct {
 	Sequence            string
 	Resources           corev1.ResourceRequirements
 	Signal              string
+	ImagePullSecrets    []corev1.LocalObjectReference
 }

--- a/pkg/generic/disk-fill/types/types.go
+++ b/pkg/generic/disk-fill/types/types.go
@@ -34,4 +34,5 @@ type ExperimentDetails struct {
 	Sequence            string
 	Resources           corev1.ResourceRequirements
 	ChaosServiceAccount string
+	ImagePullSecrets    []corev1.LocalObjectReference
 }

--- a/pkg/generic/kubelet-service-kill/types/types.go
+++ b/pkg/generic/kubelet-service-kill/types/types.go
@@ -28,4 +28,5 @@ type ExperimentDetails struct {
 	LIBImage           string
 	LIBImagePullPolicy string
 	Resources          corev1.ResourceRequirements
+	ImagePullSecrets   []corev1.LocalObjectReference
 }

--- a/pkg/generic/network-chaos/types/types.go
+++ b/pkg/generic/network-chaos/types/types.go
@@ -41,4 +41,5 @@ type ExperimentDetails struct {
 	SocketPath                         string
 	Sequence                           string
 	Resources                          corev1.ResourceRequirements
+	ImagePullSecrets                   []corev1.LocalObjectReference
 }

--- a/pkg/generic/node-cpu-hog/types/types.go
+++ b/pkg/generic/node-cpu-hog/types/types.go
@@ -31,4 +31,5 @@ type ExperimentDetails struct {
 	NodesAffectedPerc  int
 	Sequence           string
 	Resources          corev1.ResourceRequirements
+	ImagePullSecrets   []corev1.LocalObjectReference
 }

--- a/pkg/generic/node-io-stress/types/types.go
+++ b/pkg/generic/node-io-stress/types/types.go
@@ -33,4 +33,5 @@ type ExperimentDetails struct {
 	NodesAffectedPerc               int
 	Sequence                        string
 	Resources                       corev1.ResourceRequirements
+	ImagePullSecrets                []corev1.LocalObjectReference
 }

--- a/pkg/generic/node-memory-hog/types/types.go
+++ b/pkg/generic/node-memory-hog/types/types.go
@@ -32,4 +32,5 @@ type ExperimentDetails struct {
 	NodesAffectedPerc           int
 	Sequence                    string
 	Resources                   corev1.ResourceRequirements
+	ImagePullSecrets            []corev1.LocalObjectReference
 }

--- a/pkg/generic/node-restart/types/types.go
+++ b/pkg/generic/node-restart/types/types.go
@@ -31,4 +31,5 @@ type ExperimentDetails struct {
 	TargetNode         string
 	TargetNodeIP       string
 	Resources          corev1.ResourceRequirements
+	ImagePullSecrets   []corev1.LocalObjectReference
 }

--- a/pkg/generic/pod-cpu-hog/types/types.go
+++ b/pkg/generic/pod-cpu-hog/types/types.go
@@ -34,4 +34,5 @@ type ExperimentDetails struct {
 	Sequence           string
 	SocketPath         string
 	Resources          corev1.ResourceRequirements
+	ImagePullSecrets   []corev1.LocalObjectReference
 }

--- a/pkg/generic/pod-io-stress/types/types.go
+++ b/pkg/generic/pod-io-stress/types/types.go
@@ -33,4 +33,5 @@ type ExperimentDetails struct {
 	VolumeMountPath                 string
 	SocketPath                      string
 	Resources                       corev1.ResourceRequirements
+	ImagePullSecrets                []corev1.LocalObjectReference
 }

--- a/pkg/generic/pod-memory-hog/types/types.go
+++ b/pkg/generic/pod-memory-hog/types/types.go
@@ -33,4 +33,5 @@ type ExperimentDetails struct {
 	Sequence           string
 	SocketPath         string
 	Resources          corev1.ResourceRequirements
+	ImagePullSecrets   []corev1.LocalObjectReference
 }

--- a/pkg/utils/common/pods.go
+++ b/pkg/utils/common/pods.go
@@ -75,6 +75,16 @@ func GetChaosPodAnnotation(podName, namespace string, clients clients.ClientSets
 	return pod.Annotations, nil
 }
 
+// GetImagePullSecrets return the imagePullSecrets from the experiment pod
+func GetImagePullSecrets(podName, namespace string, clients clients.ClientSets) ([]core_v1.LocalObjectReference, error) {
+
+	pod, err := clients.KubeClient.CoreV1().Pods(namespace).Get(podName, v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return pod.Spec.ImagePullSecrets, nil
+}
+
 // GetChaosPodResourceRequirements will return the resource requirements on chaos pod
 func GetChaosPodResourceRequirements(podName, containerName, namespace string, clients clients.ClientSets) (core_v1.ResourceRequirements, error) {
 


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Getting imagePullSecrets from the experiment pod and forward it to the helper pod. Which can be used in case of a private image registry.