### PR TITLE
chore(n/w-chaos): Handling the unknown destination hosts

### DIFF
--- a/chaoslib/litmus/network-chaos/lib/network-chaos.go
+++ b/chaoslib/litmus/network-chaos/lib/network-chaos.go
@@ -63,6 +63,11 @@ func PrepareAndInjectChaos(experimentsDetails *experimentTypes.ExperimentDetails
 		}
 	}
 
+	experimentsDetails.DestinationIPs, err = GetTargetIps(experimentsDetails.DestinationIPs, experimentsDetails.DestinationHosts)
+	if err != nil {
+		return err
+	}
+
 	if experimentsDetails.EngineName != "" {
 		// Get Chaos Pod Annotation
 		experimentsDetails.Annotations, err = common.GetChaosPodAnnotation(experimentsDetails.ChaosPodName, experimentsDetails.ChaosNamespace, clients)
@@ -338,7 +343,7 @@ func GetPodEnv(experimentsDetails *experimentTypes.ExperimentDetails, podName, a
 		"NETWORK_INTERFACE":    experimentsDetails.NetworkInterface,
 		"EXPERIMENT_NAME":      experimentsDetails.ExperimentName,
 		"SOCKET_PATH":          experimentsDetails.SocketPath,
-		"DESTINATION_IPS":      GetTargetIpsArgs(experimentsDetails.DestinationIPs, experimentsDetails.DestinationHosts),
+		"DESTINATION_IPS":      experimentsDetails.DestinationIPs,
 	}
 	for key, value := range ENVList {
 		var perEnv apiv1.EnvVar
@@ -367,39 +372,52 @@ func GetValueFromDownwardAPI(apiVersion string, fieldPath string) apiv1.EnvVarSo
 	return downwardENV
 }
 
-// GetTargetIpsArgs return the comma separated target ips
+// GetTargetIps return the comma separated target ips
 // It fetch the ips from the target ips (if defined by users)
 // it append the ips from the host, if target host is provided
-func GetTargetIpsArgs(targetIPs, targetHosts string) string {
+func GetTargetIps(targetIPs, targetHosts string) (string, error) {
 
-	ipsFromHost := GetIpsForTargetHosts(targetHosts)
+	ipsFromHost, err := GetIpsForTargetHosts(targetHosts)
+	if err != nil {
+		return "", err
+	}
 	if targetIPs == "" {
 		targetIPs = ipsFromHost
 	} else if ipsFromHost != "" {
 		targetIPs = targetIPs + "," + ipsFromHost
 	}
-	return targetIPs
+	return targetIPs, nil
 }
 
 // GetIpsForTargetHosts resolves IP addresses for comma-separated list of target hosts and returns comma-separated ips
-func GetIpsForTargetHosts(targetHosts string) string {
+func GetIpsForTargetHosts(targetHosts string) (string, error) {
 	if targetHosts == "" {
-		return ""
+		return "", nil
 	}
 	hosts := strings.Split(targetHosts, ",")
+	finalHosts := ""
 	var commaSeparatedIPs []string
 	for i := range hosts {
 		ips, err := net.LookupIP(hosts[i])
 		if err != nil {
-			log.Infof("Unknown host")
+			log.Warnf("Unknown host: {%v}", hosts[i])
 		} else {
 			for j := range ips {
-				log.Infof("IP address: %v", ips[j])
+				log.Infof("Host: {%v}, IP address: {%v}", hosts[i], ips[j])
 				commaSeparatedIPs = append(commaSeparatedIPs, ips[j].String())
+			}
+			if finalHosts == "" {
+				finalHosts = hosts[i]
+			} else {
+				finalHosts = finalHosts + "," + hosts[i]
 			}
 		}
 	}
-	return strings.Join(commaSeparatedIPs, ",")
+	if len(commaSeparatedIPs) == 0 {
+		return "", errors.Errorf("Provided hosts: {%v} are invalid, unable to resolve", targetHosts)
+	}
+	log.Infof("Injecting chaos on {%v} hosts", finalHosts)
+	return strings.Join(commaSeparatedIPs, ","), nil
 }
 
 // abortWatcher continuosly watch for the abort signals

--- a/chaoslib/pumba/network-chaos/lib/corruption/corruption.go
+++ b/chaoslib/pumba/network-chaos/lib/corruption/corruption.go
@@ -14,17 +14,15 @@ var err error
 //PodNetworkCorruptionChaos contains the steps to prepare and inject chaos
 func PodNetworkCorruptionChaos(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
-	args := GetContainerArguments(experimentsDetails)
-	err = network_chaos.PrepareAndInjectChaos(experimentsDetails, clients, resultDetails, eventsDetails, chaosDetails, args)
+	args, err := GetContainerArguments(experimentsDetails)
 	if err != nil {
 		return err
 	}
-
-	return nil
+	return network_chaos.PrepareAndInjectChaos(experimentsDetails, clients, resultDetails, eventsDetails, chaosDetails, args)
 }
 
 // GetContainerArguments derives the args for the pumba pod
-func GetContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails) []string {
+func GetContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails) ([]string, error) {
 	baseArgs := []string{
 		"netem",
 		"--tc-image",
@@ -36,9 +34,11 @@ func GetContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails
 	}
 
 	args := baseArgs
-	args = network_chaos.AddTargetIpsArgs(experimentsDetails.DestinationIPs, args)
-	args = network_chaos.AddTargetIpsArgs(network_chaos.GetIpsForTargetHosts(experimentsDetails.DestinationHosts), args)
+	args, err := network_chaos.AddTargetIpsArgs(experimentsDetails.DestinationIPs, experimentsDetails.DestinationHosts, args)
+	if err != nil {
+		return args, err
+	}
 	args = append(args, "corrupt", "--percent", strconv.Itoa(experimentsDetails.NetworkPacketCorruptionPercentage))
 
-	return args
+	return args, nil
 }

--- a/chaoslib/pumba/network-chaos/lib/latency/latency.go
+++ b/chaoslib/pumba/network-chaos/lib/latency/latency.go
@@ -14,17 +14,15 @@ var err error
 //PodNetworkLatencyChaos contains the steps to prepare and inject chaos
 func PodNetworkLatencyChaos(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
-	args := GetContainerArguments(experimentsDetails)
-	err = network_chaos.PrepareAndInjectChaos(experimentsDetails, clients, resultDetails, eventsDetails, chaosDetails, args)
+	args, err := GetContainerArguments(experimentsDetails)
 	if err != nil {
 		return err
 	}
-
-	return nil
+	return network_chaos.PrepareAndInjectChaos(experimentsDetails, clients, resultDetails, eventsDetails, chaosDetails, args)
 }
 
 // GetContainerArguments derives the args for the pumba pod
-func GetContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails) []string {
+func GetContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails) ([]string, error) {
 	baseArgs := []string{
 		"netem",
 		"--tc-image",
@@ -36,9 +34,11 @@ func GetContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails
 	}
 
 	args := baseArgs
-	args = network_chaos.AddTargetIpsArgs(experimentsDetails.DestinationIPs, args)
-	args = network_chaos.AddTargetIpsArgs(network_chaos.GetIpsForTargetHosts(experimentsDetails.DestinationHosts), args)
+	args, err := network_chaos.AddTargetIpsArgs(experimentsDetails.DestinationIPs, experimentsDetails.DestinationHosts, args)
+	if err != nil {
+		return args, err
+	}
 	args = append(args, "delay", "--time", strconv.Itoa(experimentsDetails.NetworkLatency))
 
-	return args
+	return args, nil
 }

--- a/chaoslib/pumba/network-chaos/lib/loss/loss.go
+++ b/chaoslib/pumba/network-chaos/lib/loss/loss.go
@@ -14,17 +14,15 @@ var err error
 //PodNetworkLossChaos contains the steps to prepare and inject chaos
 func PodNetworkLossChaos(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
-	args := GetContainerArguments(experimentsDetails)
-	err = network_chaos.PrepareAndInjectChaos(experimentsDetails, clients, resultDetails, eventsDetails, chaosDetails, args)
+	args, err := GetContainerArguments(experimentsDetails)
 	if err != nil {
 		return err
 	}
-
-	return nil
+	return network_chaos.PrepareAndInjectChaos(experimentsDetails, clients, resultDetails, eventsDetails, chaosDetails, args)
 }
 
 // GetContainerArguments derives the args for the pumba pod
-func GetContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails) []string {
+func GetContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails) ([]string, error) {
 	baseArgs := []string{
 		"netem",
 		"--tc-image",
@@ -36,9 +34,11 @@ func GetContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails
 	}
 
 	args := baseArgs
-	args = network_chaos.AddTargetIpsArgs(experimentsDetails.DestinationIPs, args)
-	args = network_chaos.AddTargetIpsArgs(network_chaos.GetIpsForTargetHosts(experimentsDetails.DestinationHosts), args)
+	args, err := network_chaos.AddTargetIpsArgs(experimentsDetails.DestinationIPs, experimentsDetails.DestinationHosts, args)
+	if err != nil {
+		return args, err
+	}
 	args = append(args, "loss", "--percent", strconv.Itoa(experimentsDetails.NetworkPacketLossPercentage))
 
-	return args
+	return args, nil
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Handling the unknown destination hosts in the network chaos experiments. If all the provided hosts are invalid/unknown then failed the experiment. 
- If any subset of destination hosts are known then inject the chaos in those hosts. 