### PR TITLE
chore(aut-check): skip autStatus check if appinfo not provided

### DIFF
--- a/pkg/status/application.go
+++ b/pkg/status/application.go
@@ -65,10 +65,7 @@ func CheckApplicationStatus(appNs, appLabel string, timeout, delay int, clients 
 	switch appLabel {
 	case "":
 		// Checking whether applications are healthy
-		log.Info("[Status]: Checking whether applications are in healthy state")
-		if err := CheckPodAndContainerStatusInAppNs(appNs, timeout, delay, clients); err != nil {
-			return err
-		}
+		log.Info("[Status]: No appLabels provided, skipping the application status checks")
 	default:
 		// Checking whether application containers are in ready state
 		log.Info("[Status]: Checking whether application containers are in ready state")
@@ -82,40 +79,6 @@ func CheckApplicationStatus(appNs, appLabel string, timeout, delay int, clients 
 		}
 	}
 	return nil
-}
-
-// CheckPodAndContainerStatusInAppNs check status of pods and containers present in appns
-func CheckPodAndContainerStatusInAppNs(appNs string, timeout, delay int, clients clients.ClientSets) error {
-	return retry.
-		Times(uint(timeout / delay)).
-		Wait(time.Duration(delay) * time.Second).
-		Try(func(attempt uint) error {
-			podList, err := clients.KubeClient.CoreV1().Pods(appNs).List(metav1.ListOptions{})
-			if err != nil || len(podList.Items) == 0 {
-				return errors.Errorf("Unable to find any pod in %v namespace, err: %v", appNs, err)
-			}
-			for _, pod := range podList.Items {
-				if isChaosPod(pod.Labels) {
-					continue
-				}
-				for _, container := range pod.Status.ContainerStatuses {
-					if container.State.Terminated != nil {
-						return errors.Errorf("container is in terminated state")
-					}
-					if container.Ready != true {
-						return errors.Errorf("containers are not yet in running state")
-					}
-					log.InfoWithValues("[Status]: The Container status are as follows", logrus.Fields{
-						"container": container.Name, "Pod": pod.Name, "Readiness": container.Ready})
-				}
-				if pod.Status.Phase != "Running" {
-					return errors.Errorf("pods are not yet in running state")
-				}
-				log.InfoWithValues("[Status]: The Pod status are as follows", logrus.Fields{
-					"Pod": pod.Name, "Phase": pod.Status.Phase})
-			}
-			return nil
-		})
 }
 
 // CheckAuxiliaryApplicationStatus checks the status of the Auxiliary applications


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

- skip the AUTStatus check if appinfo is not provided.
- This is useful for the node level chaos where applnfo is optional.