### PR TITLE
Remove init container for changing permission of the container runtime socket

### DIFF
--- a/chaoslib/litmus/container-kill/helper/container-kill.go
+++ b/chaoslib/litmus/container-kill/helper/container-kill.go
@@ -158,9 +158,9 @@ func StopContainerdContainer(containerID, socketPath, signal string) error {
 	endpoint := "unix://" + socketPath
 	switch signal {
 	case "SIGKILL":
-		cmd = exec.Command("crictl", "-i", endpoint, "-r", endpoint, "stop", "--timeout=0", string(containerID))
+		cmd = exec.Command("sudo", "crictl", "-i", endpoint, "-r", endpoint, "stop", "--timeout=0", string(containerID))
 	case "SIGTERM":
-		cmd = exec.Command("crictl", "-i", endpoint, "-r", endpoint, "stop", string(containerID))
+		cmd = exec.Command("sudo", "crictl", "-i", endpoint, "-r", endpoint, "stop", string(containerID))
 	default:
 		return errors.Errorf("{%v} signal not supported, use either SIGTERM or SIGKILL", signal)
 	}
@@ -175,7 +175,7 @@ func StopContainerdContainer(containerID, socketPath, signal string) error {
 func StopDockerContainer(containerID, socketPath, signal string) error {
 	var errOut bytes.Buffer
 	host := "unix://" + socketPath
-	cmd := exec.Command("docker", "--host", host, "kill", string(containerID), "--signal", signal)
+	cmd := exec.Command("sudo", "docker", "--host", host, "kill", string(containerID), "--signal", signal)
 	cmd.Stderr = &errOut
 	if err := cmd.Run(); err != nil {
 		return errors.Errorf("Unable to run command, err: %v; error output: %v", err, errOut.String())

--- a/chaoslib/litmus/container-kill/lib/container-kill.go
+++ b/chaoslib/litmus/container-kill/lib/container-kill.go
@@ -272,26 +272,6 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 					},
 				},
 			},
-			InitContainers: []apiv1.Container{
-				{
-					Name:            "setup-" + experimentsDetails.ExperimentName,
-					Image:           experimentsDetails.LIBImage,
-					ImagePullPolicy: apiv1.PullPolicy(experimentsDetails.LIBImagePullPolicy),
-					Command: []string{
-						"/bin/bash",
-						"-c",
-						"sudo chmod 777 " + experimentsDetails.SocketPath,
-					},
-					Resources: experimentsDetails.Resources,
-					Env:       GetPodEnv(experimentsDetails, podName),
-					VolumeMounts: []apiv1.VolumeMount{
-						{
-							Name:      "cri-socket",
-							MountPath: experimentsDetails.SocketPath,
-						},
-					},
-				},
-			},
 			Containers: []apiv1.Container{
 				{
 					Name:            experimentsDetails.ExperimentName,

--- a/chaoslib/litmus/network-chaos/helper/netem.go
+++ b/chaoslib/litmus/network-chaos/helper/netem.go
@@ -125,7 +125,7 @@ func GetContainerID(experimentDetails *experimentTypes.ExperimentDetails, client
 	case "docker":
 		host := "unix://" + experimentDetails.SocketPath
 		// deriving the container id of the pause container
-		cmd := "docker --host " + host + " ps | grep k8s_POD_" + experimentDetails.TargetPods + "_" + experimentDetails.AppNS + " | awk '{print $1}'"
+		cmd := "sudo docker --host " + host + " ps | grep k8s_POD_" + experimentDetails.TargetPods + "_" + experimentDetails.AppNS + " | awk '{print $1}'"
 		out, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()
 		if err != nil {
 			log.Error(fmt.Sprintf("[docker]: Failed to run docker ps command: %s", string(out)))
@@ -161,7 +161,7 @@ func GetPID(experimentDetails *experimentTypes.ExperimentDetails, containerID st
 	case "docker":
 		host := "unix://" + experimentDetails.SocketPath
 		// deriving pid from the inspect out of target container
-		out, err := exec.Command("docker", "--host", host, "inspect", containerID).CombinedOutput()
+		out, err := exec.Command("sudo", "docker", "--host", host, "inspect", containerID).CombinedOutput()
 		if err != nil {
 			log.Error(fmt.Sprintf("[docker]: Failed to run docker inspect: %s", string(out)))
 			return 0, err
@@ -175,7 +175,7 @@ func GetPID(experimentDetails *experimentTypes.ExperimentDetails, containerID st
 	case "containerd", "crio":
 		// deriving pid from the inspect out of target container
 		endpoint := "unix://" + experimentDetails.SocketPath
-		out, err := exec.Command("crictl", "-i", endpoint, "-r", endpoint, "inspect", containerID).CombinedOutput()
+		out, err := exec.Command("sudo", "crictl", "-i", endpoint, "-r", endpoint, "inspect", containerID).CombinedOutput()
 		if err != nil {
 			log.Error(fmt.Sprintf("[cri]: Failed to run crictl: %s", string(out)))
 			return 0, err

--- a/chaoslib/litmus/network-chaos/lib/network-chaos.go
+++ b/chaoslib/litmus/network-chaos/lib/network-chaos.go
@@ -268,24 +268,6 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 					},
 				},
 			},
-			InitContainers: []apiv1.Container{
-				{
-					Name:            "setup-" + experimentsDetails.ExperimentName,
-					Image:           experimentsDetails.LIBImage,
-					ImagePullPolicy: apiv1.PullPolicy(experimentsDetails.LIBImagePullPolicy),
-					Command: []string{
-						"/bin/bash",
-						"-c",
-						"sudo chmod 777 " + experimentsDetails.SocketPath,
-					},
-					VolumeMounts: []apiv1.VolumeMount{
-						{
-							Name:      "cri-socket",
-							MountPath: experimentsDetails.SocketPath,
-						},
-					},
-				},
-			},
 
 			Containers: []apiv1.Container{
 				{

--- a/chaoslib/litmus/network-chaos/lib/network-chaos.go
+++ b/chaoslib/litmus/network-chaos/lib/network-chaos.go
@@ -268,25 +268,6 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 					},
 				},
 			},
-			InitContainers: []apiv1.Container{
-				{
-					Name:            "setup-" + experimentsDetails.ExperimentName,
-					Image:           experimentsDetails.LIBImage,
-					ImagePullPolicy: apiv1.PullPolicy(experimentsDetails.LIBImagePullPolicy),
-					Command: []string{
-						"/bin/bash",
-						"-c",
-						"sudo chmod 777 " + experimentsDetails.SocketPath,
-					},
-					VolumeMounts: []apiv1.VolumeMount{
-						{
-							Name:      "cri-socket",
-							MountPath: experimentsDetails.SocketPath,
-						},
-					},
-				},
-			},
-
 			Containers: []apiv1.Container{
 				{
 					Name:            experimentsDetails.ExperimentName,

--- a/chaoslib/litmus/network-chaos/lib/network-chaos.go
+++ b/chaoslib/litmus/network-chaos/lib/network-chaos.go
@@ -268,6 +268,25 @@ func CreateHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 					},
 				},
 			},
+			InitContainers: []apiv1.Container{
+				{
+					Name:            "setup-" + experimentsDetails.ExperimentName,
+					Image:           experimentsDetails.LIBImage,
+					ImagePullPolicy: apiv1.PullPolicy(experimentsDetails.LIBImagePullPolicy),
+					Command: []string{
+						"/bin/bash",
+						"-c",
+						"sudo chmod 777 " + experimentsDetails.SocketPath,
+					},
+					VolumeMounts: []apiv1.VolumeMount{
+						{
+							Name:      "cri-socket",
+							MountPath: experimentsDetails.SocketPath,
+						},
+					},
+				},
+			},
+
 			Containers: []apiv1.Container{
 				{
 					Name:            experimentsDetails.ExperimentName,


### PR DESCRIPTION
With this PR the init container for changing the permissions of the container runtime socket is removed when using litmus-lib. 
As per discussion with @ksatchit, the init container is only necessary for pumba-lib.