### PR TITLE
feat(randomness): Adding randomness interval inside pod-delete experiment

### DIFF
--- a/chaoslib/litmus/pod-delete/lib/pod-delete.go
+++ b/chaoslib/litmus/pod-delete/lib/pod-delete.go
@@ -1,13 +1,13 @@
 package lib
 
 import (
+	"strconv"
 	"time"
 
 	clients "github.com/litmuschaos/litmus-go/pkg/clients"
 	"github.com/litmuschaos/litmus-go/pkg/events"
 	experimentTypes "github.com/litmuschaos/litmus-go/pkg/generic/pod-delete/types"
 	"github.com/litmuschaos/litmus-go/pkg/log"
-	"github.com/litmuschaos/litmus-go/pkg/math"
 	"github.com/litmuschaos/litmus-go/pkg/probe"
 	"github.com/litmuschaos/litmus-go/pkg/status"
 	"github.com/litmuschaos/litmus-go/pkg/types"
@@ -20,9 +20,6 @@ var err error
 
 //PreparePodDelete contains the prepration steps before chaos injection
 func PreparePodDelete(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
-
-	//Getting the iteration count for the pod deletion
-	GetIterations(experimentsDetails)
 
 	//Waiting for the ramp time before chaos injection
 	if experimentsDetails.RampTime != 0 {
@@ -62,8 +59,8 @@ func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 	//ChaosStartTimeStamp contains the start timestamp, when the chaos injection begin
 	ChaosStartTimeStamp := time.Now().Unix()
 
-	for count := 0; count < experimentsDetails.Iterations; count++ {
-
+loop:
+	for {
 		// Get the target pod details for the chaos execution
 		// if the target pod is not defined it will derive the random target pod list using pod affected percentage
 		targetPodList, err := common.GetPodList(experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, clients, chaosDetails)
@@ -89,7 +86,7 @@ func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 			log.InfoWithValues("[Info]: Killing the following pods", logrus.Fields{
 				"PodName": pod.Name})
 
-			if experimentsDetails.Force == true {
+			if experimentsDetails.Force {
 				err = clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Delete(pod.Name, &v1.DeleteOptions{GracePeriodSeconds: &GracePeriod})
 			} else {
 				err = clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Delete(pod.Name, &v1.DeleteOptions{})
@@ -98,10 +95,18 @@ func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 				return err
 			}
 
-			//Waiting for the chaos interval after chaos injection
-			if experimentsDetails.ChaosInterval != 0 {
-				log.Infof("[Wait]: Wait for the chaos interval %vs", experimentsDetails.ChaosInterval)
-				common.WaitForDuration(experimentsDetails.ChaosInterval)
+			switch chaosDetails.Randomness {
+			case true:
+				if err := common.RandomInterval(experimentsDetails.ChaosInterval); err != nil {
+					return err
+				}
+			default:
+				//Waiting for the chaos interval after chaos injection
+				if experimentsDetails.ChaosInterval != "" {
+					log.Infof("[Wait]: Wait for the chaos interval %vs", experimentsDetails.ChaosInterval)
+					waitTime, _ := strconv.Atoi(experimentsDetails.ChaosInterval)
+					common.WaitForDuration(waitTime)
+				}
 			}
 
 			//Verify the status of pod after the chaos injection
@@ -119,7 +124,7 @@ func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 
 			if int(chaosDiffTimeStamp) >= experimentsDetails.ChaosDuration {
 				log.Infof("[Chaos]: Time is up for experiment: %v", experimentsDetails.ExperimentName)
-				break
+				break loop
 			}
 		}
 
@@ -144,8 +149,8 @@ func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 	//ChaosStartTimeStamp contains the start timestamp, when the chaos injection begin
 	ChaosStartTimeStamp := time.Now().Unix()
 
-	for count := 0; count < experimentsDetails.Iterations; count++ {
-
+loop:
+	for {
 		// Get the target pod details for the chaos execution
 		// if the target pod is not defined it will derive the random target pod list using pod affected percentage
 		targetPodList, err := common.GetPodList(experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, clients, chaosDetails)
@@ -171,7 +176,7 @@ func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 			log.InfoWithValues("[Info]: Killing the following pods", logrus.Fields{
 				"PodName": pod.Name})
 
-			if experimentsDetails.Force == true {
+			if experimentsDetails.Force {
 				err = clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Delete(pod.Name, &v1.DeleteOptions{GracePeriodSeconds: &GracePeriod})
 			} else {
 				err = clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Delete(pod.Name, &v1.DeleteOptions{})
@@ -181,10 +186,18 @@ func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 			}
 		}
 
-		//Waiting for the chaos interval after chaos injection
-		if experimentsDetails.ChaosInterval != 0 {
-			log.Infof("[Wait]: Wait for the chaos interval %vs", experimentsDetails.ChaosInterval)
-			common.WaitForDuration(experimentsDetails.ChaosInterval)
+		switch chaosDetails.Randomness {
+		case true:
+			if err := common.RandomInterval(experimentsDetails.ChaosInterval); err != nil {
+				return err
+			}
+		default:
+			//Waiting for the chaos interval after chaos injection
+			if experimentsDetails.ChaosInterval != "" {
+				log.Infof("[Wait]: Wait for the chaos interval %vs", experimentsDetails.ChaosInterval)
+				waitTime, _ := strconv.Atoi(experimentsDetails.ChaosInterval)
+				common.WaitForDuration(waitTime)
+			}
 		}
 
 		//Verify the status of pod after the chaos injection
@@ -202,90 +215,10 @@ func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 
 		if int(chaosDiffTimeStamp) >= experimentsDetails.ChaosDuration {
 			log.Infof("[Chaos]: Time is up for experiment: %v", experimentsDetails.ExperimentName)
-			break
+			break loop
 		}
 	}
 
-	log.Infof("[Completion]: %v chaos is done", experimentsDetails.ExperimentName)
-
-	return nil
-}
-
-//GetIterations derive the iterations value from given parameters
-func GetIterations(experimentsDetails *experimentTypes.ExperimentDetails) {
-	var Iterations int
-	if experimentsDetails.ChaosInterval != 0 {
-		Iterations = experimentsDetails.ChaosDuration / experimentsDetails.ChaosInterval
-	} else {
-		Iterations = 0
-	}
-	experimentsDetails.Iterations = math.Maximum(Iterations, 1)
-
-}
-
-//PodDeleteChaos deletes the random single/multiple pods
-func PodDeleteChaos(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails, resultDetails *types.ResultDetails) error {
-
-	GracePeriod := int64(0)
-	//ChaosStartTimeStamp contains the start timestamp, when the chaos injection begin
-	ChaosStartTimeStamp := time.Now().Unix()
-
-	for count := 0; count < experimentsDetails.Iterations; count++ {
-
-		// Get the target pod details for the chaos execution
-		// if the target pod is not defined it will derive the random target pod list using pod affected percentage
-		targetPodList, err := common.GetPodList(experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, clients, chaosDetails)
-		if err != nil {
-			return err
-		}
-
-		if experimentsDetails.EngineName != "" {
-			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
-			types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
-			events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
-		}
-
-		//Deleting the application pod
-		for _, pod := range targetPodList.Items {
-
-			log.InfoWithValues("[Info]: Killing the following pods", logrus.Fields{
-				"PodName": pod.Name})
-
-			if experimentsDetails.Force == true {
-				err = clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Delete(pod.Name, &v1.DeleteOptions{GracePeriodSeconds: &GracePeriod})
-			} else {
-				err = clients.KubeClient.CoreV1().Pods(experimentsDetails.AppNS).Delete(pod.Name, &v1.DeleteOptions{})
-			}
-			if err != nil {
-				return err
-			}
-		}
-
-		//Waiting for the chaos interval after chaos injection
-		if experimentsDetails.ChaosInterval != 0 {
-			log.Infof("[Wait]: Wait for the chaos interval %vs", experimentsDetails.ChaosInterval)
-			common.WaitForDuration(experimentsDetails.ChaosInterval)
-		}
-
-		//Verify the status of pod after the chaos injection
-		log.Info("[Status]: Verification for the recreation of application pod")
-		if err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
-			return err
-		}
-
-		//ChaosCurrentTimeStamp contains the current timestamp
-		ChaosCurrentTimeStamp := time.Now().Unix()
-
-		//ChaosDiffTimeStamp contains the difference of current timestamp and start timestamp
-		//It will helpful to track the total chaos duration
-		chaosDiffTimeStamp := ChaosCurrentTimeStamp - ChaosStartTimeStamp
-
-		if int(chaosDiffTimeStamp) >= experimentsDetails.ChaosDuration {
-			log.Infof("[Chaos]: Time is up for experiment: %v", experimentsDetails.ExperimentName)
-			break
-		}
-
-	}
 	log.Infof("[Completion]: %v chaos is done", experimentsDetails.ExperimentName)
 
 	return nil

--- a/chaoslib/powerfulseal/pod-delete/lib/pod-delete.go
+++ b/chaoslib/powerfulseal/pod-delete/lib/pod-delete.go
@@ -103,7 +103,7 @@ func GetServiceAccount(experimentsDetails *experimentTypes.ExperimentDetails, cl
 // CreateConfigMap creates a configmap for the powerfulseal deployment
 func CreateConfigMap(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, runID string) error {
 
-	data := make(map[string]string, 0)
+	data := map[string]string{}
 
 	// It will store all the details inside a string in well formated way
 	policy := GetConfigMapData(experimentsDetails)
@@ -128,9 +128,10 @@ func CreateConfigMap(experimentsDetails *experimentTypes.ExperimentDetails, clie
 // GetConfigMapData generates the configmap data for the powerfulseal deployments in desired format format
 func GetConfigMapData(experimentsDetails *experimentTypes.ExperimentDetails) string {
 
+	waitTime, _ := strconv.Atoi(experimentsDetails.ChaosInterval)
 	policy := "config:" + "\n" +
 		"  minSecondsBetweenRuns: 1" + "\n" +
-		"  maxSecondsBetweenRuns: " + strconv.Itoa(experimentsDetails.ChaosInterval) + "\n" +
+		"  maxSecondsBetweenRuns: " + strconv.Itoa(waitTime) + "\n" +
 		"podScenarios:" + "\n" +
 		"  - name: \"delete random pods in application namespace\"" + "\n" +
 		"    match:" + "\n" +

--- a/pkg/cassandra/pod-delete/environment/environment.go
+++ b/pkg/cassandra/pod-delete/environment/environment.go
@@ -19,7 +19,7 @@ func GetENV(cassandraDetails *cassandraTypes.ExperimentDetails) {
 	ChaoslibDetail.ChaosNamespace = Getenv("CHAOS_NAMESPACE", "litmus")
 	ChaoslibDetail.EngineName = Getenv("CHAOSENGINE", "")
 	ChaoslibDetail.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION", "30"))
-	ChaoslibDetail.ChaosInterval, _ = strconv.Atoi(Getenv("CHAOS_INTERVAL", "10"))
+	ChaoslibDetail.ChaosInterval = Getenv("CHAOS_INTERVAL", "10")
 	ChaoslibDetail.RampTime, _ = strconv.Atoi(Getenv("RAMP_TIME", "0"))
 	ChaoslibDetail.ChaosLib = Getenv("LIB", "litmus")
 	ChaoslibDetail.ChaosServiceAccount = Getenv("CHAOS_SERVICE_ACCOUNT", "")
@@ -73,4 +73,5 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, cassandraDetails
 	chaosDetails.Delay = cassandraDetails.ChaoslibDetail.Delay
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.ProbeImagePullPolicy = cassandraDetails.ChaoslibDetail.LIBImagePullPolicy
+	chaosDetails.Randomness, _ = strconv.ParseBool(Getenv("RANDOMNESS", "false"))
 }

--- a/pkg/generic/pod-delete/environment/environment.go
+++ b/pkg/generic/pod-delete/environment/environment.go
@@ -16,7 +16,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.ChaosNamespace = Getenv("CHAOS_NAMESPACE", "litmus")
 	experimentDetails.EngineName = Getenv("CHAOSENGINE", "")
 	experimentDetails.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION", "30"))
-	experimentDetails.ChaosInterval, _ = strconv.Atoi(Getenv("CHAOS_INTERVAL", "10"))
+	experimentDetails.ChaosInterval = Getenv("CHAOS_INTERVAL", "10")
 	experimentDetails.RampTime, _ = strconv.Atoi(Getenv("RAMP_TIME", "0"))
 	experimentDetails.ChaosLib = Getenv("LIB", "litmus")
 	experimentDetails.ChaosServiceAccount = Getenv("CHAOS_SERVICE_ACCOUNT", "")
@@ -64,4 +64,5 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetail
 	chaosDetails.Delay = experimentDetails.Delay
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.ProbeImagePullPolicy = experimentDetails.LIBImagePullPolicy
+	chaosDetails.Randomness, _ = strconv.ParseBool(Getenv("RANDOMNESS", "false"))
 }

--- a/pkg/generic/pod-delete/types/types.go
+++ b/pkg/generic/pod-delete/types/types.go
@@ -9,7 +9,7 @@ type ExperimentDetails struct {
 	ExperimentName      string
 	EngineName          string
 	ChaosDuration       int
-	ChaosInterval       int
+	ChaosInterval       string
 	RampTime            int
 	Force               bool
 	ChaosLib            string
@@ -21,7 +21,6 @@ type ExperimentDetails struct {
 	InstanceID          string
 	ChaosNamespace      string
 	ChaosPodName        string
-	Iterations          int
 	Timeout             int
 	Delay               int
 	TargetPods          string

--- a/pkg/kafka/environment/environment.go
+++ b/pkg/kafka/environment/environment.go
@@ -19,7 +19,7 @@ func GetENV(kafkaDetails *kafkaTypes.ExperimentDetails) {
 	ChaoslibDetail.ChaosNamespace = Getenv("CHAOS_NAMESPACE", "litmus")
 	ChaoslibDetail.EngineName = Getenv("CHAOSENGINE", "")
 	ChaoslibDetail.ChaosDuration, _ = strconv.Atoi(Getenv("TOTAL_CHAOS_DURATION", "60"))
-	ChaoslibDetail.ChaosInterval, _ = strconv.Atoi(Getenv("CHAOS_INTERVAL", "10"))
+	ChaoslibDetail.ChaosInterval = Getenv("CHAOS_INTERVAL", "10")
 	ChaoslibDetail.RampTime, _ = strconv.Atoi(Getenv("RAMP_TIME", "0"))
 	ChaoslibDetail.ChaosLib = Getenv("LIB", "litmus")
 	ChaoslibDetail.ChaosServiceAccount = Getenv("CHAOS_SERVICE_ACCOUNT", "")
@@ -84,4 +84,5 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, kafkaDetails *ka
 	chaosDetails.Delay = kafkaDetails.ChaoslibDetail.Delay
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.ProbeImagePullPolicy = kafkaDetails.ChaoslibDetail.LIBImagePullPolicy
+	chaosDetails.Randomness, _ = strconv.ParseBool(Getenv("RANDOMNESS", "false"))
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -77,6 +77,7 @@ type ChaosDetails struct {
 	ChaosDuration        int
 	JobCleanupPolicy     string
 	ProbeImagePullPolicy string
+	Randomness           bool
 }
 
 // AppDetails contains all the application related envs

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -4,6 +4,8 @@ import (
 	"math/rand"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -12,11 +14,32 @@ import (
 	"github.com/litmuschaos/litmus-go/pkg/log"
 	"github.com/litmuschaos/litmus-go/pkg/result"
 	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/pkg/errors"
 )
 
 //WaitForDuration waits for the given time duration (in seconds)
 func WaitForDuration(duration int) {
 	time.Sleep(time.Duration(duration) * time.Second)
+}
+
+func RandomInterval(interval string) error {
+	intervals := strings.Split(interval, "-")
+	var lowerBound, upperBound int
+	switch len(intervals) {
+	case 1:
+		lowerBound = 0
+		upperBound, _ = strconv.Atoi(intervals[0])
+	case 2:
+		lowerBound, _ = strconv.Atoi(intervals[0])
+		upperBound, _ = strconv.Atoi(intervals[1])
+	default:
+		return errors.Errorf("unable to parse CHAOS_INTERVAL, provide in valid format")
+	}
+	rand.Seed(time.Now().UnixNano())
+	waitTime := lowerBound + rand.Intn(upperBound-lowerBound)
+	log.Infof("[Wait]: Wait for the random chaos interval %vs", waitTime)
+	WaitForDuration(waitTime)
+	return nil
 }
 
 // GetRunID generate a random string


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

- Adding randomness interval inside pod-delete experiment
- It accepts a lower and an upper bound for the chaos-interval separated by hyphens `-`. If only a single value is provided i.e `10` then it will consider the given value as upper bound and 0 as lower bound.
- It will wait for the random time interval in each iteration of the chaos