### PR TITLE
(enhancement)stress-image: add env for stress-image used in pumba lib

### DIFF
--- a/chaoslib/pumba/cpu-chaos/lib/cpu-chaos.go
+++ b/chaoslib/pumba/cpu-chaos/lib/cpu-chaos.go
@@ -295,6 +295,8 @@ func GetContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails
 		"stress",
 		"--duration",
 		strconv.Itoa(experimentsDetails.ChaosDuration) + "s",
+		"--stress-image",
+		experimentsDetails.StressImage,
 		"--stressors",
 		"--cpu " + strconv.Itoa(experimentsDetails.CPUcores) + " --timeout " + strconv.Itoa(experimentsDetails.ChaosDuration) + "s",
 	}

--- a/chaoslib/pumba/memory-chaos/lib/memory-chaos.go
+++ b/chaoslib/pumba/memory-chaos/lib/memory-chaos.go
@@ -296,6 +296,8 @@ func GetContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails
 		"stress",
 		"--duration",
 		strconv.Itoa(experimentsDetails.ChaosDuration) + "s",
+		"--stress-image",
+		experimentsDetails.StressImage,
 		"--stressors",
 		"--cpu 1 --vm 1 --vm-bytes " + strconv.Itoa(experimentsDetails.MemoryConsumption) + "M --timeout " + strconv.Itoa(experimentsDetails.ChaosDuration) + "s",
 	}

--- a/pkg/generic/pod-cpu-hog/environment/environment.go
+++ b/pkg/generic/pod-cpu-hog/environment/environment.go
@@ -33,6 +33,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.ChaosKillCmd = Getenv("CHAOS_KILL_COMMAND", "kill $(find /proc -name exe -lname '*/md5sum' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}')")
 	experimentDetails.LIBImage = Getenv("LIB_IMAGE", "litmuschaos/go-runner:latest")
 	experimentDetails.LIBImagePullPolicy = Getenv("LIB_IMAGE_PULL_POLICY", "Always")
+	experimentDetails.StressImage = Getenv("STRESS_IMAGE", "alexeiled/stress-ng:latest-ubuntu")
 	experimentDetails.TargetContainer = Getenv("TARGET_CONTAINER", "")
 	experimentDetails.Sequence = Getenv("SEQUENCE", "parallel")
 	experimentDetails.SocketPath = Getenv("SOCKET_PATH", "/var/run/docker.sock")

--- a/pkg/generic/pod-cpu-hog/types/types.go
+++ b/pkg/generic/pod-cpu-hog/types/types.go
@@ -29,6 +29,7 @@ type ExperimentDetails struct {
 	ChaosKillCmd                  string
 	LIBImage                      string
 	LIBImagePullPolicy            string
+	StressImage                   string
 	Annotations                   map[string]string
 	TargetContainer               string
 	Sequence                      string

--- a/pkg/generic/pod-memory-hog/environment/environment.go
+++ b/pkg/generic/pod-memory-hog/environment/environment.go
@@ -32,6 +32,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.ChaosKillCmd = Getenv("CHAOS_KILL_COMMAND", "kill $(find /proc -name exe -lname '*/dd' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1)")
 	experimentDetails.LIBImage = Getenv("LIB_IMAGE", "litmuschaos/go-runner:latest")
 	experimentDetails.LIBImagePullPolicy = Getenv("LIB_IMAGE_PULL_POLICY", "Always")
+	experimentDetails.StressImage = Getenv("STRESS_IMAGE", "alexeiled/stress-ng:latest-ubuntu")
 	experimentDetails.TargetContainer = Getenv("TARGET_CONTAINER", "")
 	experimentDetails.Sequence = Getenv("SEQUENCE", "parallel")
 	experimentDetails.SocketPath = Getenv("SOCKET_PATH", "/var/run/docker.sock")

--- a/pkg/generic/pod-memory-hog/types/types.go
+++ b/pkg/generic/pod-memory-hog/types/types.go
@@ -28,6 +28,7 @@ type ExperimentDetails struct {
 	ChaosKillCmd       string
 	LIBImage           string
 	LIBImagePullPolicy string
+	StressImage        string
 	Annotations        map[string]string
 	TargetContainer    string
 	Sequence           string


### PR DESCRIPTION
- Adds an additional environment variable "STRESS_IMAGE" for use in pumba lib - with default pointing to `alexeiled/stress-ng:latest-ubuntu`
- This will help users of pumba lib running with private image registries to define their own version of the stress-image. 

Signed-off-by: ksatchit <karthik.s@mayadata.io>