### PR TITLE
Chore(new_Exp): Add ec2 spot instance terminate chaos experiment

### DIFF
--- a/bin/go-runner.go
+++ b/bin/go-runner.go
@@ -36,6 +36,7 @@ import (
 	ebsLoss "github.com/litmuschaos/litmus-go/experiments/kube-aws/ebs-loss/experiment"
 	ec2TerminateByID "github.com/litmuschaos/litmus-go/experiments/kube-aws/ec2-terminate-by-id/experiment"
 	ec2TerminateByTag "github.com/litmuschaos/litmus-go/experiments/kube-aws/ec2-terminate-by-tag/experiment"
+	spotInstanceTerminate "github.com/litmuschaos/litmus-go/experiments/kube-aws/spot-instance-terminate/experiment"
 
 	"github.com/litmuschaos/litmus-go/pkg/clients"
 	"github.com/litmuschaos/litmus-go/pkg/log"
@@ -110,6 +111,8 @@ func main() {
 		ec2TerminateByID.EC2TerminateByID(clients)
 	case "ec2-terminate-by-tag":
 		ec2TerminateByTag.EC2TerminateByTag(clients)
+	case "spot-instance-terminate":
+		spotInstanceTerminate.SpotInstanceTerminate(clients)
 	case "ebs-loss":
 		ebsLoss.EBSLoss(clients)
 	case "node-restart":

--- a/chaoslib/litmus/ec2-terminate-by-id/lib/ec2-terminate-by-id.go
+++ b/chaoslib/litmus/ec2-terminate-by-id/lib/ec2-terminate-by-id.go
@@ -102,7 +102,7 @@ loop:
 
 				//Wait for ec2 instance to come in running state
 				log.Infof("[Wait]: Wait for EC2 instance '%v' to get in running state", id)
-				if err := awslib.WaitForEC2Up(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ManagedNodegroup, experimentsDetails.Region, id); err != nil {
+				if err := awslib.WaitForEC2TargetState("running", experimentsDetails.Region, id, experimentsDetails.Timeout, experimentsDetails.Delay); err != nil {
 					return errors.Errorf("unable to start the ec2 instance, err: %v", err)
 				}
 			}
@@ -186,7 +186,7 @@ loop:
 				//Wait for ec2 instance to come in running state
 				log.Infof("[Wait]: Wait for EC2 instance '%v' to get in running state", id)
 				experimentsDetails.Ec2InstanceID = id
-				if err := awslib.WaitForEC2Up(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ManagedNodegroup, experimentsDetails.Region, id); err != nil {
+				if err := awslib.WaitForEC2TargetState("running", experimentsDetails.Region, id, experimentsDetails.Timeout, experimentsDetails.Delay); err != nil {
 					return errors.Errorf("unable to start the ec2 instance, err: %v", err)
 				}
 			}

--- a/chaoslib/litmus/ec2-terminate-by-tag/lib/ec2-terminate-by-tag.go
+++ b/chaoslib/litmus/ec2-terminate-by-tag/lib/ec2-terminate-by-tag.go
@@ -108,7 +108,7 @@ loop:
 
 				//Wait for ec2 instance to come in running state
 				log.Infof("[Wait]: Wait for EC2 instance '%v' to get in running state", id)
-				if err := awslib.WaitForEC2Up(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ManagedNodegroup, experimentsDetails.Region, id); err != nil {
+				if err := awslib.WaitForEC2TargetState("running", experimentsDetails.Region, id, experimentsDetails.Timeout, experimentsDetails.Delay); err != nil {
 					return errors.Errorf("unable to start the ec2 instance, err: %v", err)
 				}
 			}
@@ -191,7 +191,7 @@ loop:
 			for _, id := range instanceIDList {
 				//Wait for ec2 instance to come in running state
 				log.Infof("[Wait]: Wait for EC2 instance '%v' to get in running state", id)
-				if err := awslib.WaitForEC2Up(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ManagedNodegroup, experimentsDetails.Region, id); err != nil {
+				if err := awslib.WaitForEC2TargetState("running", experimentsDetails.Region, id, experimentsDetails.Timeout, experimentsDetails.Delay); err != nil {
 					return errors.Errorf("unable to start the ec2 instance, err: %v", err)
 				}
 			}

--- a/chaoslib/litmus/spot-instance-terminate/lib/spot-instance-terminate.go
+++ b/chaoslib/litmus/spot-instance-terminate/lib/spot-instance-terminate.go
@@ -1,0 +1,96 @@
+package lib
+
+import (
+	clients "github.com/litmuschaos/litmus-go/pkg/clients"
+	awslib "github.com/litmuschaos/litmus-go/pkg/cloud/aws"
+	"github.com/litmuschaos/litmus-go/pkg/events"
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/kube-aws/spot-instance-terminate/types"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/probe"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/litmuschaos/litmus-go/pkg/utils/common"
+	"github.com/pkg/errors"
+)
+
+//PrepareSpotInstanceTerminate contains the prepration and injection steps for the experiment
+func PrepareSpotInstanceTerminate(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+
+	//Waiting for the ramp time before chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time before injecting chaos", experimentsDetails.RampTime)
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+
+	//Get spot instance ID
+	instanceID, err := awslib.GetSpotFleetInstanceID(experimentsDetails.SpotFleetRequestID, experimentsDetails.Region)
+	if err != nil {
+		return errors.Errorf("fail to get the spot instace id, err: %v", err)
+	}
+
+	//Check spot instance status
+	instanceStatus, err := awslib.GetEC2InstanceStatus(instanceID, experimentsDetails.Region)
+	if err != nil {
+		return errors.Errorf("fail to get the spot instance status, err: %v", err)
+	}
+	if instanceStatus != "running" {
+		return errors.Errorf("fail to get the spot instance status in running state, current state is: %v ", instanceStatus)
+	}
+
+	if experimentsDetails.EngineName != "" {
+		msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on spot instance"
+		types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
+		events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+	}
+
+	//Cancelthe spot fleet request
+	err = awslib.CancelSpotFleetRequest(experimentsDetails.SpotFleetRequestID, experimentsDetails.Region)
+	if err != nil {
+		return errors.Errorf("fail to cancel spot fleet request, err: %v", err)
+	}
+
+	// run the probes during chaos
+	if len(resultDetails.ProbeDetails) != 0 {
+		if err = probe.RunProbes(chaosDetails, clients, resultDetails, "DuringChaos", eventsDetails); err != nil {
+			return err
+		}
+	}
+
+	// wait for spot instance to terminate
+	err = awslib.WaitForEC2TargetState("terminated", instanceID, experimentsDetails.Region, experimentsDetails.Timeout, experimentsDetails.Delay)
+	if err != nil {
+		return errors.Errorf("fail to terminate spot instance, err: %v", err)
+	}
+
+	//Waiting for the ramp time after chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+	return nil
+}
+
+// PreChaosSpotFleetRequestStatusCheck will the spot-fleet-request before chaos injection
+func PreChaosSpotFleetRequestStatusCheck(experimentsDetails *experimentTypes.ExperimentDetails) error {
+
+	spotFleetRequestState, err := awslib.GetSpotFleetRequestState(experimentsDetails.SpotFleetRequestID, experimentsDetails.Region)
+	if err != nil {
+		return errors.Errorf("fail to get the spot fleet request, err: %v", err)
+	}
+	if spotFleetRequestState != "active" {
+		return errors.Errorf("the spot fleet request is not in active state, the current state is: %v", spotFleetRequestState)
+	}
+	return nil
+}
+
+// PostChaosSpotFleetRequestStatusCheck will the spot-fleet-request after chaos injection
+func PostChaosSpotFleetRequestStatusCheck(experimentsDetails *experimentTypes.ExperimentDetails) error {
+
+	spotFleetRequestState, err := awslib.GetSpotFleetRequestState(experimentsDetails.SpotFleetRequestID, experimentsDetails.Region)
+	if err != nil {
+		return errors.Errorf("fail to get the spot fleet request, err: %v", err)
+	}
+	if spotFleetRequestState != "cancelled" && spotFleetRequestState != "cancelled_terminating" {
+		return errors.Errorf("the spot fleet request is not cancelled, the current state is: %v", spotFleetRequestState)
+	}
+	return nil
+}

--- a/experiments/kube-aws/ec2-terminate-by-id/README.md
+++ b/experiments/kube-aws/ec2-terminate-by-id/README.md
@@ -9,6 +9,6 @@
 <tr>
  <td> EC2 Terminate </td>
  <td> This experiment causes termination of an EC2 instance before bringing it back to running state after the specified chaos duration. One or more target instance is provided in the list format in `EC2_INSTANCE_ID` env as comma(,) seperated envs (eg: instance1,instance2)</td>
- <td>  <a href=""> Coming Soon </a> </td>
+ <td>  <a href="https://docs.litmuschaos.io/docs/ec2-terminate-by-id/"> Click Here </a> </td>
  </tr>
  </table>

--- a/experiments/kube-aws/ec2-terminate-by-tag/README.md
+++ b/experiments/kube-aws/ec2-terminate-by-tag/README.md
@@ -9,6 +9,6 @@
 <tr>
  <td> EC2 Terminate By Tag </td>
  <td> This experiment causes termination of an EC2 instance before bringing it back to running state using the instance tag after the specified chaos duration. We can also control the number of target instance using instance affected percentage</td>
- <td>  <a href=""> Coming Soon </a> </td>
+ <td>  <a href="https://docs.litmuschaos.io/docs/ec2-terminate-by-tag/"> Click Here </a> </td>
  </tr>
  </table>

--- a/experiments/kube-aws/spot-instance-terminate/README.md
+++ b/experiments/kube-aws/spot-instance-terminate/README.md
@@ -1,0 +1,14 @@
+## Experiment Metadata
+
+<table>
+<tr>
+<th> Name </th>
+<th> Description </th>
+<th> Documentation Link </th>
+</tr>
+<tr>
+ <td> Spot Instance Terminate </td>
+ <td> This experiment causes termination of a Spot instance by canceling the spot fleet request for the instance. The spot fleet ID need to provided the experiment.</td>
+ <td>  <a href=""> Coming Soon </a> </td>
+ </tr>
+ </table>

--- a/experiments/kube-aws/spot-instance-terminate/experiment/spot-instance-terminate.go
+++ b/experiments/kube-aws/spot-instance-terminate/experiment/spot-instance-terminate.go
@@ -1,0 +1,222 @@
+package experiment
+
+import (
+	litmusLIB "github.com/litmuschaos/litmus-go/chaoslib/litmus/spot-instance-terminate/lib"
+	clients "github.com/litmuschaos/litmus-go/pkg/clients"
+	"github.com/litmuschaos/litmus-go/pkg/events"
+	experimentEnv "github.com/litmuschaos/litmus-go/pkg/kube-aws/spot-instance-terminate/environment"
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/kube-aws/spot-instance-terminate/types"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/probe"
+	"github.com/litmuschaos/litmus-go/pkg/result"
+	"github.com/litmuschaos/litmus-go/pkg/status"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/sirupsen/logrus"
+)
+
+// SpotInstanceTerminate inject the ebs volume loss chaos
+func SpotInstanceTerminate(clients clients.ClientSets) {
+
+	var err error
+	experimentsDetails := experimentTypes.ExperimentDetails{}
+	resultDetails := types.ResultDetails{}
+	eventsDetails := types.EventDetails{}
+	chaosDetails := types.ChaosDetails{}
+
+	//Fetching all the ENV passed from the runner pod
+	log.Infof("[PreReq]: Getting the ENV for the %v experiment", experimentsDetails.ExperimentName)
+	experimentEnv.GetENV(&experimentsDetails)
+
+	// Intialise the chaos attributes
+	experimentEnv.InitialiseChaosVariables(&chaosDetails, &experimentsDetails)
+
+	// Intialise Chaos Result Parameters
+	types.SetResultAttributes(&resultDetails, chaosDetails)
+
+	if experimentsDetails.EngineName != "" {
+		// Intialise the probe details. Bail out upon error, as we haven't entered exp business logic yet
+		if err = probe.InitializeProbesInChaosResultDetails(&chaosDetails, clients, &resultDetails); err != nil {
+			log.Errorf("Unable to initialize the probes, err: %v", err)
+			return
+		}
+	}
+
+	//Updating the chaos result in the beginning of experiment
+	log.Infof("[PreReq]: Updating the chaos result of %v experiment (SOT)", experimentsDetails.ExperimentName)
+	err = result.ChaosResult(&chaosDetails, clients, &resultDetails, "SOT")
+	if err != nil {
+		log.Errorf("Unable to Create the Chaos Result, err: %v", err)
+		failStep := "Updating the chaos result of ec2 terminate experiment (SOT)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// Set the chaos result uid
+	result.SetResultUID(&resultDetails, clients, &chaosDetails)
+
+	//DISPLAY THE INSTANCE INFORMATION
+	log.InfoWithValues("The instance information is as follows", logrus.Fields{
+		"Chaos Namespace":       experimentsDetails.ChaosNamespace,
+		"Ramp Time":             experimentsDetails.RampTime,
+		"Spot Fleet Request ID": experimentsDetails.SpotFleetRequestID,
+		"Region":                experimentsDetails.Region,
+	})
+
+	//PRE-CHAOS APPLICATION STATUS CHECK
+	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (pre-chaos)")
+	if err = status.AUTStatusCheck(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.TargetContainer, experimentsDetails.Timeout, experimentsDetails.Delay, clients, &chaosDetails); err != nil {
+		log.Errorf("Application status check failed, err: %v", err)
+		failStep := "Verify that the AUT (Application Under Test) is running (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	//PRE-CHAOS AUXILIARY APPLICATION STATUS CHECK
+	if experimentsDetails.AuxiliaryAppInfo != "" {
+		log.Info("[Status]: Verify that the Auxiliary Applications are running (pre-chaos)")
+		err = status.CheckAuxiliaryApplicationStatus(experimentsDetails.AuxiliaryAppInfo, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+		if err != nil {
+			log.Errorf("Auxiliary Application status check failed, err: %v", err)
+			failStep := "Verify that the Auxiliary Applications are running (pre-chaos)"
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+	}
+
+	// generating the event in chaosresult to marked the verdict as awaited
+	msg := "experiment: " + experimentsDetails.ExperimentName + ", Result: Awaited"
+	types.SetResultEventAttributes(&eventsDetails, types.AwaitedVerdict, msg, "Normal", &resultDetails)
+	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := "AUT: Running"
+
+		// run the probes in the pre-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+
+			err = probe.RunProbes(&chaosDetails, clients, &resultDetails, "PreChaos", &eventsDetails)
+			if err != nil {
+				log.Errorf("Probe Failed, err: %v", err)
+				failStep := "Failed while running probes"
+				msg := "AUT: Running, Probes: Unsuccessful"
+				types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = "AUT: Running, Probes: Successful"
+		}
+		// generating the events for the pre-chaos check
+		types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	//Verify the aws spot fleet request status (pre chaos)
+	err = litmusLIB.PreChaosSpotFleetRequestStatusCheck(&experimentsDetails)
+	if err != nil {
+		log.Errorf("failed to get the spot fleet request, err: %v", err)
+		failStep := "Verify the AWS spot fleet request state (pre-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+	log.Info("[Status]: Spot fleet request state is active(pre-chaos)")
+
+	// Including the litmus lib for spot-instance-terminate
+	if experimentsDetails.ChaosLib == "litmus" {
+		err = litmusLIB.PrepareSpotInstanceTerminate(&experimentsDetails, clients, &resultDetails, &eventsDetails, &chaosDetails)
+		if err != nil {
+			log.Errorf("Chaos injection failed, err: %v", err)
+			failStep := "failed in chaos injection phase"
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+		log.Info("[Confirmation]: Spot instance terminate chaos has been injected successfully")
+		resultDetails.Verdict = "Pass"
+	} else {
+		log.Error("[Invalid]: Please Provide the correct LIB")
+		failStep := "no match found for specified lib"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	//Verify the aws spot fleet request (post chaos)
+	err = litmusLIB.PostChaosSpotFleetRequestStatusCheck(&experimentsDetails)
+	if err != nil {
+		log.Errorf("failed to get the spot fleet request, err: %v", err)
+		failStep := "Verify the AWS spot fleet request state (post-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	//POST-CHAOS APPLICATION STATUS CHECK
+	log.Info("[Status]: Verify that the AUT (Application Under Test) is running (post-chaos)")
+	if err = status.AUTStatusCheck(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.TargetContainer, experimentsDetails.Timeout, experimentsDetails.Delay, clients, &chaosDetails); err != nil {
+		log.Errorf("Application status check failed, err: %v", err)
+		failStep := "Verify that the AUT (Application Under Test) is running (post-chaos)"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	//POST-CHAOS AUXILIARY APPLICATION STATUS CHECK
+	if experimentsDetails.AuxiliaryAppInfo != "" {
+		log.Info("[Status]: Verify that the Auxiliary Applications are running (post-chaos)")
+		err = status.CheckAuxiliaryApplicationStatus(experimentsDetails.AuxiliaryAppInfo, experimentsDetails.Timeout, experimentsDetails.Delay, clients)
+		if err != nil {
+			log.Errorf("Auxiliary Application status check failed, err: %v", err)
+			failStep := "Verify that the Auxiliary Applications are running (post-chaos)"
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+	}
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := "AUT: Running"
+
+		// run the probes in the post-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+			err = probe.RunProbes(&chaosDetails, clients, &resultDetails, "PostChaos", &eventsDetails)
+			if err != nil {
+				log.Errorf("Probes Failed, err: %v", err)
+				failStep := "Failed while running probes"
+				msg := "AUT: Running, Probes: Unsuccessful"
+				types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = "AUT: Running, Probes: Successful"
+		}
+
+		// generating post chaos event
+		types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	//Updating the chaosResult in the end of experiment
+	log.Infof("[The End]: Updating the chaos result of %v experiment (EOT)", experimentsDetails.ExperimentName)
+	err = result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT")
+	if err != nil {
+		log.Errorf("Unable to Update the Chaos Result, err:  %v", err)
+		return
+	}
+
+	// generating the event in chaosresult to marked the verdict as pass/fail
+	msg = "experiment: " + experimentsDetails.ExperimentName + ", Result: " + resultDetails.Verdict
+	reason := types.PassVerdict
+	eventType := "Normal"
+	if resultDetails.Verdict != "Pass" {
+		reason = types.FailVerdict
+		eventType = "Warning"
+	}
+	types.SetResultEventAttributes(&eventsDetails, reason, msg, eventType, &resultDetails)
+	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
+
+	if experimentsDetails.EngineName != "" {
+		msg := experimentsDetails.ExperimentName + " experiment has been " + resultDetails.Verdict + "ed"
+		types.SetEngineEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+}

--- a/experiments/kube-aws/spot-instance-terminate/rbac.yaml
+++ b/experiments/kube-aws/spot-instance-terminate/rbac.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spot-instance-terminate-sa
+  namespace: default
+  labels:
+    name: spot-instance-terminate-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spot-instance-terminate-sa
+  labels:
+    name: spot-instance-terminate-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+- apiGroups: [""]
+  resources: ["pods","events","secrets"]
+  verbs: ["create","list","get","patch","update","delete","deletecollection"]
+- apiGroups: [""]
+  resources: ["pods/exec","pods/log"]
+  verbs: ["create","list","get"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create","list","get","delete","deletecollection"]
+- apiGroups: ["litmuschaos.io"]
+  resources: ["chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["patch","get","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spot-instance-terminate-sa
+  labels:
+    name: spot-instance-terminate-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: spot-instance-terminate-sa
+subjects:
+- kind: ServiceAccount
+  name: spot-instance-terminate-sa
+  namespace: default

--- a/experiments/kube-aws/spot-instance-terminate/test/test.yml
+++ b/experiments/kube-aws/spot-instance-terminate/test/test.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litmus-experiment
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      app: litmus-experiment
+  template:
+    metadata:
+      labels:
+        app: litmus-experiment
+    spec:
+      serviceAccountName: spot-instance-terminate-sa
+      containers:
+      - name: gotest
+        image: busybox
+        command:
+          - sleep 
+          - "3600"
+        env:
+          - name: LIB
+            value: 'litmus'
+
+          - name: SPOT_FLEET_REQUEST_ID
+            value: ''
+
+          - name: CHAOS_NAMESPACE
+            value: 'default'
+
+          - name: REGION
+            value: ''
+
+          - name: RAMP_TIME
+            value: ''
+
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
+          secrets:
+            - name: cloud-secret
+              mountPath: /tmp/                 

--- a/pkg/kube-aws/spot-instance-terminate/environment/environment.go
+++ b/pkg/kube-aws/spot-instance-terminate/environment/environment.go
@@ -1,0 +1,55 @@
+package environment
+
+import (
+	"os"
+	"strconv"
+
+	clientTypes "k8s.io/apimachinery/pkg/types"
+
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/kube-aws/spot-instance-terminate/types"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+)
+
+//GetENV fetches all the env variables from the runner pod
+func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
+	experimentDetails.ExperimentName = Getenv("EXPERIMENT_NAME", "spot-instance-terminate")
+	experimentDetails.ChaosNamespace = Getenv("CHAOS_NAMESPACE", "litmus")
+	experimentDetails.EngineName = Getenv("CHAOSENGINE", "")
+	experimentDetails.AppNS = Getenv("APP_NAMESPACE", "")
+	experimentDetails.AppLabel = Getenv("APP_LABEL", "")
+	experimentDetails.AppKind = Getenv("APP_KIND", "")
+	experimentDetails.AuxiliaryAppInfo = Getenv("AUXILIARY_APPINFO", "")
+	experimentDetails.RampTime, _ = strconv.Atoi(Getenv("RAMP_TIME", "0"))
+	experimentDetails.ChaosLib = Getenv("LIB", "litmus")
+	experimentDetails.ChaosUID = clientTypes.UID(Getenv("CHAOS_UID", ""))
+	experimentDetails.InstanceID = Getenv("INSTANCE_ID", "")
+	experimentDetails.ChaosPodName = Getenv("POD_NAME", "")
+	experimentDetails.Delay, _ = strconv.Atoi(Getenv("STATUS_CHECK_DELAY", "2"))
+	experimentDetails.Timeout, _ = strconv.Atoi(Getenv("STATUS_CHECK_TIMEOUT", "180"))
+	experimentDetails.SpotFleetRequestID = Getenv("SPOT_FLEET_REQUEST_ID", "")
+	experimentDetails.Region = Getenv("REGION", "")
+	experimentDetails.TargetContainer = Getenv("TARGET_CONTAINER", "")
+}
+
+// Getenv fetch the env and set the default value, if any
+func Getenv(key string, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		value = defaultValue
+	}
+	return value
+}
+
+//InitialiseChaosVariables initialise all the global variables
+func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetails *experimentTypes.ExperimentDetails) {
+
+	chaosDetails.ChaosNamespace = experimentDetails.ChaosNamespace
+	chaosDetails.ChaosPodName = experimentDetails.ChaosPodName
+	chaosDetails.ChaosUID = experimentDetails.ChaosUID
+	chaosDetails.EngineName = experimentDetails.EngineName
+	chaosDetails.ExperimentName = experimentDetails.ExperimentName
+	chaosDetails.InstanceID = experimentDetails.InstanceID
+	chaosDetails.Timeout = experimentDetails.Timeout
+	chaosDetails.Delay = experimentDetails.Delay
+	chaosDetails.ProbeImagePullPolicy = experimentDetails.LIBImagePullPolicy
+}

--- a/pkg/kube-aws/spot-instance-terminate/types/types.go
+++ b/pkg/kube-aws/spot-instance-terminate/types/types.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	clientTypes "k8s.io/apimachinery/pkg/types"
+)
+
+// ExperimentDetails is for collecting all the experiment-related details
+type ExperimentDetails struct {
+	ExperimentName     string
+	EngineName         string
+	RampTime           int
+	AppNS              string
+	AppLabel           string
+	AppKind            string
+	AuxiliaryAppInfo   string
+	ChaosLib           string
+	ChaosUID           clientTypes.UID
+	InstanceID         string
+	ChaosNamespace     string
+	ChaosPodName       string
+	Timeout            int
+	Delay              int
+	Region             string
+	ActiveNodes        int
+	LIBImagePullPolicy string
+	TargetContainer    string
+	SpotFleetRequestID string
+}


### PR DESCRIPTION
Signed-off-by: uditgaurav <udit@chaosnative.com>

#### Details:

- This PR adds `spot instance terminate` chaos experiment which terminates an instance based on the spot feel request id provided. 
- The Pre chaos check includes two checks:
    - 1. Fleet Request state should be active before chaos injection.
    - 2. The Spot instance should be healthy before chaos injection.
 - The Post Chaos checks are:
   - 1. The spot fleet request should be `canceled`.
   - 2.  The spot instance should be in a `terminated` state

Note: The experiment doesn't have `CHAOS_DURATION` (the instance gets terminated directly) and `INSTANCE_ID` (as we are selecting the instance based on the fleet request) parameters.