### PR TITLE
chore(stress): fixing 137 error in cpu & memory chaos

### DIFF
--- a/chaoslib/litmus/pod-cpu-hog/lib/pod-cpu-hog.go
+++ b/chaoslib/litmus/pod-cpu-hog/lib/pod-cpu-hog.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -23,17 +24,13 @@ import (
 // StressCPU Uses the REST API to exec into the target container of the target pod
 // The function will be constantly increasing the CPU utilisation until it reaches the maximum available or allowed number.
 // Using the TOTAL_CHAOS_DURATION we will need to specify for how long this experiment will last
-func StressCPU(experimentsDetails *experimentTypes.ExperimentDetails, podName string, clients clients.ClientSets) error {
+func StressCPU(experimentsDetails *experimentTypes.ExperimentDetails, podName string, clients clients.ClientSets, stressErr chan error) {
 	// It will contains all the pod & container details required for exec command
 	execCommandDetails := litmusexec.PodDetails{}
 	command := []string{"/bin/sh", "-c", experimentsDetails.ChaosInjectCmd}
 	litmusexec.SetExecCommandAttributes(&execCommandDetails, podName, experimentsDetails.TargetContainer, experimentsDetails.AppNS)
 	_, err := litmusexec.Exec(&execCommandDetails, clients, command)
-	if err != nil {
-		return errors.Errorf("Unable to run stress command inside target container, err: %v", err)
-	}
-
-	return nil
+	stressErr <- err
 }
 
 //ExperimentCPU function orchestrates the experiment by calling the StressCPU function for every core, of every container, of every pod that is targeted
@@ -78,6 +75,8 @@ func ExperimentCPU(experimentsDetails *experimentTypes.ExperimentDetails, client
 
 // InjectChaosInSerialMode stressed the cpu of all target application serially (one by one)
 func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList corev1.PodList, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+	// creating err channel to recieve the error from the go routine
+	stressErr := make(chan error)
 
 	// run the probes during chaos
 	if len(resultDetails.ProbeDetails) != 0 {
@@ -104,7 +103,7 @@ func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 		})
 
 		for i := 0; i < experimentsDetails.CPUcores; i++ {
-			go StressCPU(experimentsDetails, pod.Name, clients)
+			go StressCPU(experimentsDetails, pod.Name, clients, stressErr)
 		}
 
 		log.Infof("[Chaos]:Waiting for: %vs", experimentsDetails.ChaosDuration)
@@ -117,6 +116,17 @@ func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 		for {
 			endTime = time.After(timeDelay)
 			select {
+			case err := <-stressErr:
+				// skipping the execution, if recieved any error other than 137, while executing stress command and marked result as fail
+				// it will ignore the error code 137(oom kill), it will skip further execution and marked the result as pass
+				// oom kill occurs if memory to be stressed exceed than the resource limit for the target container
+				if err != nil {
+					if strings.Contains(err.Error(), "137") {
+						log.Warn("Chaos process OOM killed")
+						return nil
+					}
+					return err
+				}
 			case <-signChan:
 				log.Info("[Chaos]: Revert Started")
 				err := KillStressCPUSerial(experimentsDetails, pod.Name, clients)
@@ -140,6 +150,8 @@ func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 
 // InjectChaosInParallelMode stressed the cpu of all target application in parallel mode (all at once)
 func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDetails, targetPodList corev1.PodList, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+	// creating err channel to recieve the error from the go routine
+	stressErr := make(chan error)
 
 	// run the probes during chaos
 	if len(resultDetails.ProbeDetails) != 0 {
@@ -165,7 +177,7 @@ func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 			"CPU CORE":         experimentsDetails.CPUcores,
 		})
 		for i := 0; i < experimentsDetails.CPUcores; i++ {
-			go StressCPU(experimentsDetails, pod.Name, clients)
+			go StressCPU(experimentsDetails, pod.Name, clients, stressErr)
 		}
 	}
 
@@ -179,6 +191,17 @@ loop:
 	for {
 		endTime = time.After(timeDelay)
 		select {
+		case err := <-stressErr:
+			// skipping the execution, if recieved any error other than 137, while executing stress command and marked result as fail
+			// it will ignore the error code 137(oom kill), it will skip further execution and marked the result as pass
+			// oom kill occurs if memory to be stressed exceed than the resource limit for the target container
+			if err != nil {
+				if strings.Contains(err.Error(), "137") {
+					log.Warn("Chaos process OOM killed")
+					return nil
+				}
+				return err
+			}
 		case <-signChan:
 			log.Info("[Chaos]: Revert Started")
 			if err := KillStressCPUParallel(experimentsDetails, targetPodList, clients); err != nil {

--- a/chaoslib/litmus/pod-memory-hog/lib/pod-memory-hog.go
+++ b/chaoslib/litmus/pod-memory-hog/lib/pod-memory-hog.go
@@ -131,6 +131,7 @@ func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 				// oom kill occurs if memory to be stressed exceed than the resource limit for the target container
 				if err != nil {
 					if strings.Contains(err.Error(), "137") {
+						log.Warn("Chaos process OOM killed")
 						return nil
 					}
 					return err
@@ -203,6 +204,7 @@ loop:
 			// oom kill occurs if memory to be stressed exceed than the resource limit for the target container
 			if err != nil {
 				if strings.Contains(err.Error(), "137") {
+					log.Warn("Chaos process OOM killed")
 					return nil
 				}
 				return err

--- a/pkg/utils/exec/exec.go
+++ b/pkg/utils/exec/exec.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/litmuschaos/litmus-go/pkg/clients"
-	"github.com/litmuschaos/litmus-go/pkg/log"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/remotecommand"
@@ -66,15 +64,7 @@ func Exec(commandDetails *PodDetails, clients clients.ClientSets, command []stri
 	})
 
 	if err != nil {
-		errorCode := strings.Contains(err.Error(), "143")
-		if !errorCode {
-			if strings.Contains(err.Error(), "137") {
-				log.Warn("Chaos process OOM killed as the provided value exceeds resource limits")
-			} else {
-				log.Infof("[Prepare]: Unable to run command inside container, err: %v", err.Error())
-			}
-			return "", err
-		}
+		return "", err
 	}
 
 	return out.String(), nil


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

-  fixing 137 error in cpu & memory chaos. When we are using `kill -9` command to kill the process then it terminates the process with 137 error which was considered an error earlier. 