### PR TITLE
chore(exec): execing inside target pod only if it is in ready state

### DIFF
--- a/experiments/generic/pod-memory-hog/experiment/pod-memory-hog.go
+++ b/experiments/generic/pod-memory-hog/experiment/pod-memory-hog.go
@@ -110,7 +110,7 @@ func PodMemoryHog(clients clients.ClientSets) {
 	if experimentsDetails.ChaosLib == "litmus" {
 		err = litmusLIB.PrepareMemoryStress(&experimentsDetails, clients, &resultDetails, &eventsDetails, &chaosDetails)
 		if err != nil {
-			log.Errorf("[Error]: pod memory hog failed,, err: %v", err)
+			log.Errorf("[Error]: pod memory hog failed, err: %v", err)
 			failStep := "failed in chaos injection phase"
 			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 			return

--- a/pkg/utils/exec/exec.go
+++ b/pkg/utils/exec/exec.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/litmuschaos/litmus-go/pkg/clients"
 	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	"k8s.io/client-go/tools/remotecommand"
 )
 
@@ -22,6 +25,14 @@ type PodDetails struct {
 
 // Exec function will run the provide commands inside the target container
 func Exec(commandDetails *PodDetails, clients clients.ClientSets, command []string) (string, error) {
+
+	pod, err := clients.KubeClient.CoreV1().Pods(commandDetails.Namespace).Get(commandDetails.PodName, v1.GetOptions{})
+	if err != nil {
+		return "", errors.Errorf("unable to get %v pod in %v namespace, err: %v", commandDetails.PodName, commandDetails.Namespace, err)
+	}
+	if err := checkPodStatus(pod, commandDetails.ContainerName); err != nil {
+		return "", err
+	}
 
 	req := clients.KubeClient.CoreV1().RESTClient().Post().
 		Resource("pods").
@@ -86,4 +97,18 @@ func SetExecCommandAttributes(podDetails *PodDetails, PodName, ContainerName, Na
 	podDetails.ContainerName = ContainerName
 	podDetails.Namespace = Namespace
 	podDetails.PodName = PodName
+}
+
+// checkPodStatus verify the status of given pod & container
+func checkPodStatus(pod *apiv1.Pod, containerName string) error {
+
+	if strings.ToLower(string(pod.Status.Phase)) != "running" {
+		return errors.Errorf("%v pod is not in running state, phase: %v", pod.Name, pod.Status.Phase)
+	}
+	for _, container := range pod.Status.ContainerStatuses {
+		if container.Name == containerName && !container.Ready {
+			return errors.Errorf("%v container of %v pod is not in ready state, phase: %v", container.Name, pod.Name, pod.Status.Phase)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

- Before exec inside target container, validating that the status of target pod and container. If the pod is in running state and the container is ready then only exec and run the command else error it out.