### PR TITLE
chore(disk-fill): Adding Block size as tunable in disk-fill

### DIFF
--- a/chaoslib/litmus/disk-fill/helper/disk-fill.go
+++ b/chaoslib/litmus/disk-fill/helper/disk-fill.go
@@ -129,7 +129,7 @@ func DiskFill(experimentsDetails *experimentTypes.ExperimentDetails, clients cli
 
 	if sizeTobeFilled > 0 {
 
-		if err := fillDisk(containerID, sizeTobeFilled); err != nil {
+		if err := fillDisk(containerID, sizeTobeFilled, experimentsDetails.DataBlockSize); err != nil {
 			log.Error(string(out))
 			return err
 		}
@@ -153,7 +153,7 @@ func DiskFill(experimentsDetails *experimentTypes.ExperimentDetails, clients cli
 }
 
 // fillDisk fill the ephemeral disk by creating files
-func fillDisk(containerID string, sizeTobeFilled int) error {
+func fillDisk(containerID string, sizeTobeFilled, bs int) error {
 
 	select {
 	case <-inject:
@@ -162,7 +162,8 @@ func fillDisk(containerID string, sizeTobeFilled int) error {
 	default:
 		// Creating files to fill the required ephemeral storage size of block size of 4K
 		log.Infof("[Fill]: Filling ephemeral storage, size: %vKB", sizeTobeFilled)
-		dd := fmt.Sprintf("sudo dd if=/dev/urandom of=/diskfill/%v/diskfill bs=4K count=%v", containerID, strconv.Itoa(sizeTobeFilled/4))
+		dd := fmt.Sprintf("sudo dd if=/dev/urandom of=/diskfill/%v/diskfill bs=%vK count=%v", containerID, bs, strconv.Itoa(sizeTobeFilled/bs))
+		log.Infof("dd: {%v}", dd)
 		cmd := exec.Command("/bin/bash", "-c", dd)
 		_, err := cmd.CombinedOutput()
 		return err
@@ -289,6 +290,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, name string) {
 	experimentDetails.ChaosPodName = Getenv("POD_NAME", "")
 	experimentDetails.FillPercentage, _ = strconv.Atoi(Getenv("FILL_PERCENTAGE", ""))
 	experimentDetails.EphemeralStorageMebibytes, _ = strconv.Atoi(Getenv("EPHEMERAL_STORAGE_MEBIBYTES", ""))
+	experimentDetails.DataBlockSize, _ = strconv.Atoi(Getenv("DATA_BLOCK_SIZE", "256"))
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/chaoslib/litmus/disk-fill/lib/disk-fill.go
+++ b/chaoslib/litmus/disk-fill/lib/disk-fill.go
@@ -298,6 +298,7 @@ func GetPodEnv(experimentsDetails *experimentTypes.ExperimentDetails, podName st
 		"EXPERIMENT_NAME":             experimentsDetails.ExperimentName,
 		"FILL_PERCENTAGE":             strconv.Itoa(experimentsDetails.FillPercentage),
 		"EPHEMERAL_STORAGE_MEBIBYTES": strconv.Itoa(experimentsDetails.EphemeralStorageMebibytes),
+		"DATA_BLOCK_SIZE":             strconv.Itoa(experimentsDetails.DataBlockSize),
 	}
 	for key, value := range ENVList {
 		var perEnv apiv1.EnvVar

--- a/experiments/generic/disk-fill/test/test.yml
+++ b/experiments/generic/disk-fill/test/test.yml
@@ -45,6 +45,9 @@ spec:
           - name: LIB_IMAGE
             value: 'litmuschaos/go-runner:ci'
 
+          - name: DATA_BLOCK_SIZE
+            value: ''
+
           - name: CONTAINER_PATH
             value: '/var/lib/docker/containers'
 

--- a/pkg/generic/disk-fill/environment/environment.go
+++ b/pkg/generic/disk-fill/environment/environment.go
@@ -37,6 +37,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.Sequence = Getenv("SEQUENCE", "parallel")
 	experimentDetails.EphemeralStorageMebibytes, _ = strconv.Atoi(Getenv("EPHEMERAL_STORAGE_MEBIBYTES", ""))
 	experimentDetails.TerminationGracePeriodSeconds, _ = strconv.Atoi(Getenv("TERMINATION_GRACE_PERIOD_SECONDS", ""))
+	experimentDetails.DataBlockSize, _ = strconv.Atoi(Getenv("DATA_BLOCK_SIZE", "256"))
 }
 
 // Getenv fetch the env and set the default value, if any

--- a/pkg/generic/disk-fill/types/types.go
+++ b/pkg/generic/disk-fill/types/types.go
@@ -37,4 +37,5 @@ type ExperimentDetails struct {
 	ImagePullSecrets              []corev1.LocalObjectReference
 	EphemeralStorageMebibytes     int
 	TerminationGracePeriodSeconds int
+	DataBlockSize                 int
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

- Adding Block size as tunable by ENV in disk-fill. The env is `BLOCK_SIZE`. The unit is always `K`. 