### PR TITLE
Chore(EC2-checks): Update the ec2 terminate with tags experiment to target only running instances

### DIFF
--- a/chaoslib/litmus/ec2-terminate-by-id/lib/ec2-terminate-by-id.go
+++ b/chaoslib/litmus/ec2-terminate-by-id/lib/ec2-terminate-by-id.go
@@ -57,7 +57,7 @@ func InjectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 loop:
 	for {
 
-		log.Infof("Target instanceID list, %v", instanceIDList)
+		log.Infof("[Info]: Target instanceID list, %v", instanceIDList)
 
 		if experimentsDetails.EngineName != "" {
 			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on ec2 instance"
@@ -68,15 +68,15 @@ loop:
 		//PowerOff the instance
 		for _, id := range instanceIDList {
 
-			//Stoping the EC2 instance
-			log.Info("[Chaos]: Stoping the desired EC2 instance")
+			//Stopping the EC2 instance
+			log.Info("[Chaos]: Stopping the desired EC2 instance")
 			err := awslib.EC2Stop(id, experimentsDetails.Region)
 			if err != nil {
 				return errors.Errorf("ec2 instance failed to stop, err: %v", err)
 			}
 
 			//Wait for ec2 instance to completely stop
-			log.Infof("[Wait]: Wait for EC2 instance '%v' to come in stopped state", id)
+			log.Infof("[Wait]: Wait for EC2 instance '%v' to get in stopped state", id)
 			if err := awslib.WaitForEC2Down(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ManagedNodegroup, experimentsDetails.Region, id); err != nil {
 				return errors.Errorf("unable to stop the ec2 instance, err: %v", err)
 			}
@@ -89,7 +89,7 @@ loop:
 			}
 
 			//Wait for chaos interval
-			log.Infof("[Wait]: Waiting for chaos interval of %vs before starting the instance", experimentsDetails.ChaosInterval)
+			log.Infof("[Wait]: Waiting for chaos interval of %vs", experimentsDetails.ChaosInterval)
 			time.Sleep(time.Duration(experimentsDetails.ChaosInterval) * time.Second)
 
 			//Starting the EC2 instance
@@ -100,7 +100,7 @@ loop:
 					return errors.Errorf("ec2 instance failed to start, err: %v", err)
 				}
 
-				//Wait for ec2 instance to come in running state
+				//Wait for ec2 instance to get in running state
 				log.Infof("[Wait]: Wait for EC2 instance '%v' to get in running state", id)
 				if err := awslib.WaitForEC2Up(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ManagedNodegroup, experimentsDetails.Region, id); err != nil {
 					return errors.Errorf("unable to start the ec2 instance, err: %v", err)
@@ -134,7 +134,7 @@ func InjectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 loop:
 	for {
 
-		log.Infof("Target instanceID list, %v", instanceIDList)
+		log.Infof("[Info]: Target instanceID list, %v", instanceIDList)
 
 		if experimentsDetails.EngineName != "" {
 			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on ec2 instance"
@@ -144,8 +144,8 @@ loop:
 
 		//PowerOff the instance
 		for _, id := range instanceIDList {
-			//Stoping the EC2 instance
-			log.Info("[Chaos]: Stoping the desired EC2 instance")
+			//Stopping the EC2 instance
+			log.Info("[Chaos]: Stopping the desired EC2 instance")
 			err := awslib.EC2Stop(id, experimentsDetails.Region)
 			if err != nil {
 				return errors.Errorf("ec2 instance failed to stop, err: %v", err)
@@ -154,7 +154,7 @@ loop:
 
 		for _, id := range instanceIDList {
 			//Wait for ec2 instance to completely stop
-			log.Infof("[Wait]: Wait for EC2 instance '%v' to come in stopped state", id)
+			log.Infof("[Wait]: Wait for EC2 instance '%v' to get in stopped state", id)
 			if err := awslib.WaitForEC2Down(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ManagedNodegroup, experimentsDetails.Region, id); err != nil {
 				return errors.Errorf("unable to stop the ec2 instance, err: %v", err)
 			}
@@ -168,7 +168,7 @@ loop:
 		}
 
 		//Wait for chaos interval
-		log.Infof("[Wait]: Waiting for chaos interval of %vs before starting the instance", experimentsDetails.ChaosInterval)
+		log.Infof("[Wait]: Waiting for chaos interval of %vs", experimentsDetails.ChaosInterval)
 		time.Sleep(time.Duration(experimentsDetails.ChaosInterval) * time.Second)
 
 		//Starting the EC2 instance
@@ -183,7 +183,7 @@ loop:
 			}
 
 			for _, id := range instanceIDList {
-				//Wait for ec2 instance to come in running state
+				//Wait for ec2 instance to get in running state
 				log.Infof("[Wait]: Wait for EC2 instance '%v' to get in running state", id)
 				experimentsDetails.Ec2InstanceID = id
 				if err := awslib.WaitForEC2Up(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ManagedNodegroup, experimentsDetails.Region, id); err != nil {

--- a/experiments/kube-aws/ec2-terminate-by-tag/experiment/ec2-terminate-tag.go
+++ b/experiments/kube-aws/ec2-terminate-by-tag/experiment/ec2-terminate-tag.go
@@ -126,15 +126,14 @@ func EC2TerminateByTag(clients clients.ClientSets) {
 		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
 	}
 
-	//Verify the aws ec2 instance is running (pre chaos)
-	err = litmusLIB.InstanceStatusCheckByTag(experimentsDetails.InstanceTag, experimentsDetails.Region)
+	//selecting the target instance (pre chaos)
+	err = litmusLIB.SetTargetInstance(&experimentsDetails)
 	if err != nil {
-		log.Errorf("failed to get the ec2 instance status, err: %v", err)
-		failStep := "Verify the AWS ec2 instance status (pre-chaos)"
+		log.Errorf("failed to get the target ec2 instance, err: %v", err)
+		failStep := "Select the target AWS ec2 instance from tag (pre-chaos)"
 		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 		return
 	}
-	log.Info("[Status]: EC2 instance is in running state")
 
 	// Including the litmus lib for ec2-terminate
 	if experimentsDetails.ChaosLib == "litmus" {
@@ -167,9 +166,9 @@ func EC2TerminateByTag(clients clients.ClientSets) {
 
 	//Verify the aws ec2 instance is running (post chaos)
 	if experimentsDetails.ManagedNodegroup != "enable" {
-		err = litmusLIB.InstanceStatusCheckByTag(experimentsDetails.InstanceTag, experimentsDetails.Region)
+		err = litmusLIB.PostChaosInstanceStatusCheck(experimentsDetails.TargetInstanceIDList, experimentsDetails.Region)
 		if err != nil {
-			log.Errorf("failed to get the ec2 instance status, err: %v", err)
+			log.Errorf("failed to get the ec2 instance status as running post chaos, err: %v", err)
 			failStep := "Verify the AWS ec2 instance status (post-chaos)"
 			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 			return

--- a/pkg/cloud/aws/ec2-operations.go
+++ b/pkg/cloud/aws/ec2-operations.go
@@ -43,7 +43,7 @@ func EC2Stop(instanceID, region string) error {
 		}
 	}
 
-	log.InfoWithValues("Stopping an ec2 instance:", logrus.Fields{
+	log.InfoWithValues("Stopping ec2 instance:", logrus.Fields{
 		"CurrentState":  *result.StoppingInstances[0].CurrentState.Name,
 		"PreviousState": *result.StoppingInstances[0].PreviousState.Name,
 		"InstanceId":    *result.StoppingInstances[0].InstanceId,

--- a/pkg/kube-aws/ec2-terminate-by-tag/types/types.go
+++ b/pkg/kube-aws/ec2-terminate-by-tag/types/types.go
@@ -30,4 +30,5 @@ type ExperimentDetails struct {
 	ActiveNodes          int
 	LIBImagePullPolicy   string
 	TargetContainer      string
+	TargetInstanceIDList []string
 }


### PR DESCRIPTION
Signed-off-by: uditgaurav <udit@chaosnative.com>

####  This PR is for:

- Update the pre and post chaos check for ec2-terminate using tags.
   - `pre-chaos`: Will check if any running instance found filtered from given instance tag. If no instance found it will fail. So it will now manage the case where the filtered set of instances are both running and non-running instances.
   - `post-chaos`: Status check of the target instance under chaos (IUC). It will fail if the target instance is not in running state post chaos.