### PR TITLE
feat(annotation): skipping parent resources listing, if annotationCheck is false

### DIFF
--- a/pkg/result/chaosresult.go
+++ b/pkg/result/chaosresult.go
@@ -297,6 +297,6 @@ func GetChaosStatus(resultDetails *types.ResultDetails, chaosDetails *types.Chao
 		}
 	}
 
-	chaosDetails.Targets = targetList
+	chaosDetails.Targets = append(chaosDetails.Targets, targetList...)
 	return annotations, nil
 }


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Earlier, if the parent resource labels are not provided then it was failing to list the parent resources even if annotationCheck is false.
- Marking the parent resource labels as an optional field if annotationCheck is false but it is mandatory if annoationCheck is provided as true.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
