### PR TITLE
Add option to change default container registry for image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 IS_DOCKER_INSTALLED = $(shell which docker >> /dev/null 2>&1; echo $$?)
 
 # Docker info
+DOCKER_REGISTRY ?= docker.io
 DOCKER_REPO ?= litmuschaos
 DOCKER_IMAGE ?= go-runner
 DOCKER_TAG ?= ci
@@ -79,7 +80,7 @@ image-build:
 	@echo "-------------------------"
 	@echo "--> Build go-runner image" 
 	@echo "-------------------------"
-	@docker buildx build --file build/Dockerfile --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) .
+	@docker buildx build --file build/Dockerfile --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag $(DOCKER_REGISTRY)/$(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) .
 
 .PHONY: build-amd64
 build-amd64:
@@ -91,7 +92,7 @@ build-amd64:
 	@echo "-------------------------"
 	@echo "--> Build go-runner image" 
 	@echo "-------------------------"
-	@sudo docker build --file build/Dockerfile --tag $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) . --build-arg TARGETARCH=amd64
+	@sudo docker build --file build/Dockerfile --tag $(DOCKER_REGISTRY)/$(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG) . --build-arg TARGETARCH=amd64
 
 .PHONY: push-amd64
 push-amd64:
@@ -99,7 +100,7 @@ push-amd64:
 	@echo "------------------------------"
 	@echo "--> Pushing image" 
 	@echo "------------------------------"
-	@sudo docker push $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG)
+	@sudo docker push $(DOCKER_REGISTRY)/$(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG)
 	
 .PHONY: push
 push: docker.buildx litmus-go-push
@@ -108,7 +109,7 @@ litmus-go-push:
 	@echo "-------------------"
 	@echo "--> go-runner image" 
 	@echo "-------------------"
-	REPONAME="$(DOCKER_REPO)" IMGNAME="$(DOCKER_IMAGE)" IMGTAG="$(DOCKER_TAG)" ./build/push
+	REGISTRYNAME="$(DOCKER_REGISTRY)" REPONAME="$(DOCKER_REPO)" IMGNAME="$(DOCKER_IMAGE)" IMGTAG="$(DOCKER_TAG)" ./build/push
 	
 .PHONY: trivy-check
 trivy-check:
@@ -116,5 +117,5 @@ trivy-check:
 	@echo "------------------------"
 	@echo "---> Running Trivy Check"
 	@echo "------------------------"
-	@./trivy --exit-code 0 --severity HIGH --no-progress $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG)
-	@./trivy --exit-code 0 --severity CRITICAL --no-progress $(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG)
+	@./trivy --exit-code 0 --severity HIGH --no-progress $(DOCKER_REGISTRY)/$(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG)
+	@./trivy --exit-code 0 --severity CRITICAL --no-progress $(DOCKER_REGISTRY)/$(DOCKER_REPO)/$(DOCKER_IMAGE):$(DOCKER_TAG)

--- a/build/push
+++ b/build/push
@@ -20,15 +20,15 @@ fi
 IMAGEID=$( docker images -q ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${IMGTAG} )
 
 # Push image to docker hub
-echo "Pushing ${REPONAME}/${IMGNAME}:${IMGTAG} ..."; 
+echo "Pushing ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${IMGTAG} ..."; 
 docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${IMGTAG} .
 if [ ! -z "${RELEASE_TAG}" ] ; 
 then
   # Push with different tags if tagged as a release
   # When github is tagged with a release, then Travis will 
   # set the release tag in env RELEASE_TAG
-  echo "Pushing ${REPONAME}/${IMGNAME}:${RELEASE_TAG} ..."; 
+  echo "Pushing ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${RELEASE_TAG} ..."; 
   docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${RELEASE_TAG} .
-  echo "Pushing ${REPONAME}/${IMGNAME}:latest ..."; 
+  echo "Pushing ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:latest ..."; 
   docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:latest .
 fi;

--- a/build/push
+++ b/build/push
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [ -z "${REGISTRYNAME}" ]
+then
+  REGISTRYNAME="docker.io"
+fi
+
 if [ -z "${REPONAME}" ]
 then 
   REPONAME="litmuschaos"
@@ -12,24 +17,39 @@ then
   exit 1
 fi
 
-IMAGEID=$( docker images -q ${REPONAME}/${IMGNAME}:${IMGTAG} )
+IMAGEID=$( docker images -q ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${IMGTAG} )
 
-if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
-then 
-  docker login -u "${DNAME}" -p "${DPASS}";
-  # Push image to docker hub
-  echo "Pushing ${REPONAME}/${IMGNAME}:${IMGTAG} ..."; 
-  docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REPONAME}/${IMGNAME}:${IMGTAG} .
-  if [ ! -z "${RELEASE_TAG}" ] ; 
-  then
-    # Push with different tags if tagged as a release
-    # When github is tagged with a release, then Travis will 
-    # set the release tag in env RELEASE_TAG
-    echo "Pushing ${REPONAME}/${IMGNAME}:${RELEASE_TAG} ..."; 
-    docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REPONAME}/${IMGNAME}:${RELEASE_TAG} .
-    echo "Pushing ${REPONAME}/${IMGNAME}:latest ..."; 
-    docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REPONAME}/${IMGNAME}:latest .
-  fi;
-else
-  echo "No docker credentials provided. Skip uploading ${REPONAME}/${IMGNAME}:${IMGTAG} to docker hub"; 
+# Push image to docker hub
+echo "Pushing ${REPONAME}/${IMGNAME}:${IMGTAG} ..."; 
+docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${IMGTAG} .
+if [ ! -z "${RELEASE_TAG}" ] ; 
+then
+  # Push with different tags if tagged as a release
+  # When github is tagged with a release, then Travis will 
+  # set the release tag in env RELEASE_TAG
+  echo "Pushing ${REPONAME}/${IMGNAME}:${RELEASE_TAG} ..."; 
+  docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${RELEASE_TAG} .
+  echo "Pushing ${REPONAME}/${IMGNAME}:latest ..."; 
+  docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:latest .
 fi;
+
+
+# if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
+# then 
+#   docker login -u "${DNAME}" -p "${DPASS}";
+#   # Push image to docker hub
+#   echo "Pushing ${REPONAME}/${IMGNAME}:${IMGTAG} ..."; 
+#   docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${IMGTAG} .
+#   if [ ! -z "${RELEASE_TAG}" ] ; 
+#   then
+#     # Push with different tags if tagged as a release
+#     # When github is tagged with a release, then Travis will 
+#     # set the release tag in env RELEASE_TAG
+#     echo "Pushing ${REPONAME}/${IMGNAME}:${RELEASE_TAG} ..."; 
+#     docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${RELEASE_TAG} .
+#     echo "Pushing ${REPONAME}/${IMGNAME}:latest ..."; 
+#     docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:latest .
+#   fi;
+# else
+#   echo "No docker credentials provided. Skip uploading ${REPONAME}/${IMGNAME}:${IMGTAG} to docker hub"; 
+# fi;

--- a/build/push
+++ b/build/push
@@ -32,24 +32,3 @@ then
   echo "Pushing ${REPONAME}/${IMGNAME}:latest ..."; 
   docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:latest .
 fi;
-
-
-# if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
-# then 
-#   docker login -u "${DNAME}" -p "${DPASS}";
-#   # Push image to docker hub
-#   echo "Pushing ${REPONAME}/${IMGNAME}:${IMGTAG} ..."; 
-#   docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${IMGTAG} .
-#   if [ ! -z "${RELEASE_TAG}" ] ; 
-#   then
-#     # Push with different tags if tagged as a release
-#     # When github is tagged with a release, then Travis will 
-#     # set the release tag in env RELEASE_TAG
-#     echo "Pushing ${REPONAME}/${IMGNAME}:${RELEASE_TAG} ..."; 
-#     docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:${RELEASE_TAG} .
-#     echo "Pushing ${REPONAME}/${IMGNAME}:latest ..."; 
-#     docker buildx build --file build/Dockerfile --push --progress plane --platform linux/arm64,linux/amd64 --no-cache --tag ${REGISTRYNAME}/${REPONAME}/${IMGNAME}:latest .
-#   fi;
-# else
-#   echo "No docker credentials provided. Skip uploading ${REPONAME}/${IMGNAME}:${IMGTAG} to docker hub"; 
-# fi;


### PR DESCRIPTION
Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR introduces an option to specify a container registry where litmus images will be pushed after the build. The registry is specified by env variable `DOCKER_REGISTRY`. This PR also removes `docker login` command from `push` script. I think all users should do this out of this script.

**Special notes for your reviewer**:

This change might be useful for users who build their own images and it adds an option to push images to multiple container registries during automated builds.

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
