### PR TITLE
Chore(stress-chaos): Remove extra previlages and update io stressors and timeout

### DIFF
--- a/chaoslib/litmus/stress-chaos/lib/stress-chaos.go
+++ b/chaoslib/litmus/stress-chaos/lib/stress-chaos.go
@@ -209,8 +209,6 @@ func createHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 		},
 		Spec: apiv1.PodSpec{
 			HostPID:                       true,
-			HostIPC:                       true,
-			HostNetwork:                   true,
 			TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 			ImagePullSecrets:              experimentsDetails.ImagePullSecrets,
 			ServiceAccountName:            experimentsDetails.ChaosServiceAccount,

--- a/pkg/generic/pod-cpu-hog-exec/environment/environment.go
+++ b/pkg/generic/pod-cpu-hog-exec/environment/environment.go
@@ -32,11 +32,8 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.TargetPods = common.Getenv("TARGET_PODS", "")
 	experimentDetails.ChaosInjectCmd = common.Getenv("CHAOS_INJECT_COMMAND", "md5sum /dev/zero")
 	experimentDetails.ChaosKillCmd = common.Getenv("CHAOS_KILL_COMMAND", "kill $(find /proc -name exe -lname '*/md5sum' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}')")
-	experimentDetails.LIBImage = common.Getenv("LIB_IMAGE", "litmuschaos/go-runner:latest")
-	experimentDetails.LIBImagePullPolicy = common.Getenv("LIB_IMAGE_PULL_POLICY", "Always")
 	experimentDetails.TargetContainer = common.Getenv("TARGET_CONTAINER", "")
 	experimentDetails.Sequence = common.Getenv("SEQUENCE", "parallel")
-	experimentDetails.SocketPath = common.Getenv("SOCKET_PATH", "/var/run/docker.sock")
 	experimentDetails.TerminationGracePeriodSeconds, _ = strconv.Atoi(common.Getenv("TERMINATION_GRACE_PERIOD_SECONDS", ""))
 }
 

--- a/pkg/generic/pod-cpu-hog-exec/environment/environment.go
+++ b/pkg/generic/pod-cpu-hog-exec/environment/environment.go
@@ -31,7 +31,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.Timeout, _ = strconv.Atoi(common.Getenv("STATUS_CHECK_TIMEOUT", "180"))
 	experimentDetails.TargetPods = common.Getenv("TARGET_PODS", "")
 	experimentDetails.ChaosInjectCmd = common.Getenv("CHAOS_INJECT_COMMAND", "md5sum /dev/zero")
-	experimentDetails.ChaosKillCmd = common.Getenv("CHAOS_KILL_COMMAND", "kill $(find /proc -name exe -lname '*/md5sum' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}')")
+	experimentDetails.ChaosKillCmd = common.Getenv("CHAOS_KILL_COMMAND", "killall md5sum")
 	experimentDetails.TargetContainer = common.Getenv("TARGET_CONTAINER", "")
 	experimentDetails.Sequence = common.Getenv("SEQUENCE", "parallel")
 	experimentDetails.TerminationGracePeriodSeconds, _ = strconv.Atoi(common.Getenv("TERMINATION_GRACE_PERIOD_SECONDS", ""))

--- a/pkg/generic/pod-cpu-hog-exec/types/types.go
+++ b/pkg/generic/pod-cpu-hog-exec/types/types.go
@@ -27,13 +27,10 @@ type ExperimentDetails struct {
 	TargetPods                    string
 	ChaosInjectCmd                string
 	ChaosKillCmd                  string
-	LIBImage                      string
 	LIBImagePullPolicy            string
-	StressImage                   string
 	Annotations                   map[string]string
 	TargetContainer               string
 	Sequence                      string
-	SocketPath                    string
 	Resources                     corev1.ResourceRequirements
 	ImagePullSecrets              []corev1.LocalObjectReference
 	TerminationGracePeriodSeconds int

--- a/pkg/generic/pod-memory-hog-exec/environment/environment.go
+++ b/pkg/generic/pod-memory-hog-exec/environment/environment.go
@@ -31,12 +31,9 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.Timeout, _ = strconv.Atoi(common.Getenv("STATUS_CHECK_TIMEOUT", "180"))
 	experimentDetails.TargetPods = common.Getenv("TARGET_PODS", "")
 	experimentDetails.ChaosKillCmd = common.Getenv("CHAOS_KILL_COMMAND", "kill $(find /proc -name exe -lname '*/dd' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1)")
-	experimentDetails.LIBImage = common.Getenv("LIB_IMAGE", "litmuschaos/go-runner:latest")
 	experimentDetails.LIBImagePullPolicy = common.Getenv("LIB_IMAGE_PULL_POLICY", "Always")
-	experimentDetails.StressImage = common.Getenv("STRESS_IMAGE", "alexeiled/stress-ng:latest-ubuntu")
 	experimentDetails.TargetContainer = common.Getenv("TARGET_CONTAINER", "")
 	experimentDetails.Sequence = common.Getenv("SEQUENCE", "parallel")
-	experimentDetails.SocketPath = common.Getenv("SOCKET_PATH", "/var/run/docker.sock")
 }
 
 //InitialiseChaosVariables initialise all the global variables

--- a/pkg/generic/pod-memory-hog-exec/environment/environment.go
+++ b/pkg/generic/pod-memory-hog-exec/environment/environment.go
@@ -30,7 +30,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.Delay, _ = strconv.Atoi(common.Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(common.Getenv("STATUS_CHECK_TIMEOUT", "180"))
 	experimentDetails.TargetPods = common.Getenv("TARGET_PODS", "")
-	experimentDetails.ChaosKillCmd = common.Getenv("CHAOS_KILL_COMMAND", "kill $(find /proc -name exe -lname '*/dd' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1)")
+	experimentDetails.ChaosKillCmd = common.Getenv("CHAOS_KILL_COMMAND", "killall dd")
 	experimentDetails.LIBImagePullPolicy = common.Getenv("LIB_IMAGE_PULL_POLICY", "Always")
 	experimentDetails.TargetContainer = common.Getenv("TARGET_CONTAINER", "")
 	experimentDetails.Sequence = common.Getenv("SEQUENCE", "parallel")

--- a/pkg/generic/pod-memory-hog-exec/types/types.go
+++ b/pkg/generic/pod-memory-hog-exec/types/types.go
@@ -26,13 +26,10 @@ type ExperimentDetails struct {
 	Delay              int
 	TargetPods         string
 	ChaosKillCmd       string
-	LIBImage           string
 	LIBImagePullPolicy string
-	StressImage        string
 	Annotations        map[string]string
 	TargetContainer    string
 	Sequence           string
-	SocketPath         string
 	Resources          corev1.ResourceRequirements
 	ImagePullSecrets   []corev1.LocalObjectReference
 }

--- a/pkg/generic/stress-chaos/environment/environment.go
+++ b/pkg/generic/stress-chaos/environment/environment.go
@@ -50,6 +50,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 		experimentDetails.NumberOfWorkers, _ = strconv.Atoi(common.Getenv("NUMBER_OF_WORKERS", "4"))
 		experimentDetails.VolumeMountPath = common.Getenv("VOLUME_MOUNT_PATH", "")
 		experimentDetails.StressImage = common.Getenv("STRESS_IMAGE", "alexeiled/stress-ng:latest-ubuntu")
+		experimentDetails.CPUcores, _ = strconv.Atoi(common.Getenv("CPU_CORES", "0"))
 	}
 }
 

--- a/pkg/kube-aws/ebs-loss/types/types.go
+++ b/pkg/kube-aws/ebs-loss/types/types.go
@@ -20,7 +20,6 @@ type ExperimentDetails struct {
 	ChaosNamespace     string
 	ChaosPodName       string
 	AuxiliaryAppInfo   string
-	RunID              string
 	Timeout            int
 	Delay              int
 	Sequence           string


### PR DESCRIPTION
Signed-off-by: udit <udit@chaosnative.com>
**What this PR does / why we need it**:

- Remove extra privileges from helper pod for stress chaos

_For IO Stress:_

- Have removed the `--cpu` flag in the stress-ng as it is not specific to the exp. It is now an optional value if the user has provided some CPU then it will take otherwise it will skip.
- In place of waiting for 10s of grace period for stress-ng to get completed after the `--timeout` value is completed. We have increased it to `30s` for some edge cases.

NOTE: This is a different grace period not for helper completion but for stress-ng completion after `--timeout` in stress-ng command. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
