### PR TITLE
Chore(Azure): Azure Instance Stop experiment (support for: virtual machine scale sets)

### DIFF
--- a/chaoslib/litmus/azure-instance-stop/lib/azure-instance-stop.go
+++ b/chaoslib/litmus/azure-instance-stop/lib/azure-instance-stop.go
@@ -103,7 +103,7 @@ func injectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 						return errors.Errorf("unable to start the Azure instance, err: %v", err)
 					}
 				} else {
-					if err := azureStatus.AzureInstanceStart(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
+					if err := azureStatus.AzureInstanceStop(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 						return errors.Errorf("unable to start the Azure instance, err: %v", err)
 					}
 				}
@@ -270,7 +270,7 @@ func abortWatcher(experimentsDetails *experimentTypes.ExperimentDetails, instanc
 		log.Info("[Abort]: Waiting for the Azure instance to start")
 		err := azureStatus.WaitForAzureComputeUp(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.IsScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName)
 		if err != nil {
-			log.Errorf("Azure instance failed to start when an abort signal is recieved, err: %v", err)
+			log.Errorf("Azure instance failed to start when an abort signal is received, err: %v", err)
 		}
 	}
 	log.Infof("[Abort]: Chaos Revert Completed")

--- a/chaoslib/litmus/azure-instance-stop/lib/azure-instance-stop.go
+++ b/chaoslib/litmus/azure-instance-stop/lib/azure-instance-stop.go
@@ -97,7 +97,7 @@ func injectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 
 				// Stopping the Azure instance
 				log.Infof("[Chaos]: Stopping the Azure instance: %v", vmName)
-				if experimentsDetails.IsScaleSet == "true" {
+				if experimentsDetails.ScaleSet == "enable" {
 					if err := azureStatus.AzureScaleSetInstanceStop(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 						return errors.Errorf("unable to stop the Azure instance, err: %v", err)
 					}
@@ -109,7 +109,7 @@ func injectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 
 				// Wait for Azure instance to completely stop
 				log.Infof("[Wait]: Waiting for Azure instance '%v' to get in the stopped state", vmName)
-				if err := azureStatus.WaitForAzureComputeDown(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.IsScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
+				if err := azureStatus.WaitForAzureComputeDown(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 					return errors.Errorf("instance poweroff status check failed, err: %v", err)
 				}
 
@@ -126,7 +126,7 @@ func injectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 
 				// Starting the Azure instance
 				log.Info("[Chaos]: Starting back the Azure instance")
-				if experimentsDetails.IsScaleSet == "true" {
+				if experimentsDetails.ScaleSet == "enable" {
 					if err := azureStatus.AzureScaleSetInstanceStart(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 						return errors.Errorf("unable to start the Azure instance, err: %v", err)
 					}
@@ -138,7 +138,7 @@ func injectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 
 				// Wait for Azure instance to get in running state
 				log.Infof("[Wait]: Waiting for Azure instance '%v' to get in the running state", vmName)
-				if err := azureStatus.WaitForAzureComputeUp(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.IsScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
+				if err := azureStatus.WaitForAzureComputeUp(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 					return errors.Errorf("instance power on status check failed, err: %v", err)
 				}
 			}
@@ -173,7 +173,7 @@ func injectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 			for _, vmName := range instanceNameList {
 				// Stopping the Azure instance
 				log.Infof("[Chaos]: Stopping the Azure instance: %v", vmName)
-				if experimentsDetails.IsScaleSet == "true" {
+				if experimentsDetails.ScaleSet == "enable" {
 					if err := azureStatus.AzureScaleSetInstanceStop(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 						return errors.Errorf("unable to stop azure instance, err: %v", err)
 					}
@@ -187,7 +187,7 @@ func injectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 			// Wait for all Azure instances to completely stop
 			for _, vmName := range instanceNameList {
 				log.Infof("[Wait]: Waiting for Azure instance '%v' to get in the stopped state", vmName)
-				if err := azureStatus.WaitForAzureComputeDown(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.IsScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
+				if err := azureStatus.WaitForAzureComputeDown(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 					return errors.Errorf("instance poweroff status check failed, err: %v", err)
 				}
 			}
@@ -206,7 +206,7 @@ func injectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 			// Starting the Azure instance
 			for _, vmName := range instanceNameList {
 				log.Infof("[Chaos]: Starting back the Azure instance: %v", vmName)
-				if experimentsDetails.IsScaleSet == "true" {
+				if experimentsDetails.ScaleSet == "enable" {
 					if err := azureStatus.AzureScaleSetInstanceStart(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 						return errors.Errorf("unable to start the Azure instance, err: %v", err)
 					}
@@ -220,7 +220,7 @@ func injectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 			// Wait for Azure instance to get in running state
 			for _, vmName := range instanceNameList {
 				log.Infof("[Wait]: Waiting for Azure instance '%v' to get in the running state", vmName)
-				if err := azureStatus.WaitForAzureComputeUp(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.IsScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
+				if err := azureStatus.WaitForAzureComputeUp(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 					return errors.Errorf("instance power on status check failed, err: %v", err)
 				}
 			}
@@ -239,7 +239,7 @@ func abortWatcher(experimentsDetails *experimentTypes.ExperimentDetails, instanc
 
 	log.Info("[Abort]: Chaos Revert Started")
 	for _, vmName := range instanceNameList {
-		if experimentsDetails.IsScaleSet == "true" {
+		if experimentsDetails.ScaleSet == "enable" {
 			scaleSetName, vmId := azureStatus.GetScaleSetNameAndInstanceId(vmName)
 			instanceState, err = azureStatus.GetAzureScaleSetInstanceStatus(experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, scaleSetName, vmId)
 		} else {
@@ -250,12 +250,12 @@ func abortWatcher(experimentsDetails *experimentTypes.ExperimentDetails, instanc
 		}
 		if instanceState != "VM running" && instanceState != "VM starting" {
 			log.Info("[Abort]: Waiting for the Azure instance to get down")
-			if err := azureStatus.WaitForAzureComputeDown(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.IsScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
+			if err := azureStatus.WaitForAzureComputeDown(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 				log.Errorf("[Abort]: Instance power off status check failed, err: %v", err)
 			}
 
 			log.Info("[Abort]: Starting Azure instance as abort signal received")
-			if experimentsDetails.IsScaleSet == "true" {
+			if experimentsDetails.ScaleSet == "enable" {
 				if err := azureStatus.AzureScaleSetInstanceStart(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 					log.Errorf("[Abort]: Unable to start the Azure instance, err: %v", err)
 				}
@@ -267,7 +267,7 @@ func abortWatcher(experimentsDetails *experimentTypes.ExperimentDetails, instanc
 		}
 
 		log.Info("[Abort]: Waiting for the Azure instance to start")
-		err := azureStatus.WaitForAzureComputeUp(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.IsScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName)
+		err := azureStatus.WaitForAzureComputeUp(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.ScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName)
 		if err != nil {
 			log.Errorf("[Abort]: Instance power on status check failed, err: %v", err)
 			log.Errorf("[Abort]: Azure instance %v failed to start after an abort signal is received", vmName)

--- a/chaoslib/litmus/azure-instance-stop/lib/azure-instance-stop.go
+++ b/chaoslib/litmus/azure-instance-stop/lib/azure-instance-stop.go
@@ -255,6 +255,7 @@ func abortWatcher(experimentsDetails *experimentTypes.ExperimentDetails, instanc
 				log.Errorf("unable to wait till stop of the instance, err: %v", err)
 			}
 
+			log.Info("[Abort]: Starting Azure instance as abort signal received")
 			if experimentsDetails.IsScaleSet == "true" {
 				if err := azureStatus.AzureScaleSetInstanceStart(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName); err != nil {
 					log.Errorf("unable to start the Azure instance, err: %v", err)
@@ -264,12 +265,12 @@ func abortWatcher(experimentsDetails *experimentTypes.ExperimentDetails, instanc
 					log.Errorf("unable to start the Azure instance, err: %v", err)
 				}
 			}
+		}
 
-			log.Info("[Abort]: Starting Azure instance as abort signal received")
-			err := azureStatus.WaitForAzureComputeUp(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.IsScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName)
-			if err != nil {
-				log.Errorf("Azure instance failed to start when an abort signal is recieved, err: %v", err)
-			}
+		log.Info("[Abort]: Waiting for the Azure instance to start")
+		err := azureStatus.WaitForAzureComputeUp(experimentsDetails.Timeout, experimentsDetails.Delay, experimentsDetails.IsScaleSet, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup, vmName)
+		if err != nil {
+			log.Errorf("Azure instance failed to start when an abort signal is recieved, err: %v", err)
 		}
 	}
 	log.Infof("[Abort]: Chaos Revert Completed")

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,7 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTg
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7RHGAyAK3EP2EsNk=
 github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=

--- a/pkg/azure/instance-stop/environment/environment.go
+++ b/pkg/azure/instance-stop/environment/environment.go
@@ -20,7 +20,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.AppKind = common.Getenv("APP_KIND", "")
 	experimentDetails.AuxiliaryAppInfo = common.Getenv("AUXILIARY_APPINFO", "")
 	experimentDetails.ChaosDuration, _ = strconv.Atoi(common.Getenv("TOTAL_CHAOS_DURATION", "30"))
-	experimentDetails.ChaosInterval, _ = strconv.Atoi(common.Getenv("CHAOS_INTERVAL", "10"))
+	experimentDetails.ChaosInterval, _ = strconv.Atoi(common.Getenv("CHAOS_INTERVAL", "30"))
 	experimentDetails.RampTime, _ = strconv.Atoi(common.Getenv("RAMP_TIME", "0"))
 	experimentDetails.ChaosLib = common.Getenv("LIB", "litmus")
 	experimentDetails.ChaosUID = clientTypes.UID(common.Getenv("CHAOS_UID", ""))
@@ -28,9 +28,9 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.ChaosPodName = common.Getenv("POD_NAME", "")
 	experimentDetails.Delay, _ = strconv.Atoi(common.Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(common.Getenv("STATUS_CHECK_TIMEOUT", "180"))
-	experimentDetails.AzureInstanceName = common.Getenv("AZURE_INSTANCE_NAME", "aks-agentpool-12981678-vmss_0,aks-agentpool-12981678-vmss_1")
-	experimentDetails.ResourceGroup = common.Getenv("RESOURCE_GROUP", "MC_litmus_test2_eastus2")
-	experimentDetails.IsScaleSet = common.Getenv("IS_SCALE_SET", "true")
+	experimentDetails.AzureInstanceName = common.Getenv("AZURE_INSTANCE_NAME", "")
+	experimentDetails.ResourceGroup = common.Getenv("RESOURCE_GROUP", "")
+	experimentDetails.IsScaleSet = common.Getenv("IS_SCALE_SET", "false")
 	experimentDetails.Sequence = common.Getenv("SEQUENCE", "parallel")
 }
 

--- a/pkg/azure/instance-stop/environment/environment.go
+++ b/pkg/azure/instance-stop/environment/environment.go
@@ -20,7 +20,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.AppKind = common.Getenv("APP_KIND", "")
 	experimentDetails.AuxiliaryAppInfo = common.Getenv("AUXILIARY_APPINFO", "")
 	experimentDetails.ChaosDuration, _ = strconv.Atoi(common.Getenv("TOTAL_CHAOS_DURATION", "30"))
-	experimentDetails.ChaosInterval, _ = strconv.Atoi(common.Getenv("CHAOS_INTERVAL", "30"))
+	experimentDetails.ChaosInterval, _ = strconv.Atoi(common.Getenv("CHAOS_INTERVAL", "10"))
 	experimentDetails.RampTime, _ = strconv.Atoi(common.Getenv("RAMP_TIME", "0"))
 	experimentDetails.ChaosLib = common.Getenv("LIB", "litmus")
 	experimentDetails.ChaosUID = clientTypes.UID(common.Getenv("CHAOS_UID", ""))
@@ -28,8 +28,9 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.ChaosPodName = common.Getenv("POD_NAME", "")
 	experimentDetails.Delay, _ = strconv.Atoi(common.Getenv("STATUS_CHECK_DELAY", "2"))
 	experimentDetails.Timeout, _ = strconv.Atoi(common.Getenv("STATUS_CHECK_TIMEOUT", "180"))
-	experimentDetails.AzureInstanceName = common.Getenv("AZURE_INSTANCE_NAME", "")
-	experimentDetails.ResourceGroup = common.Getenv("RESOURCE_GROUP", "")
+	experimentDetails.AzureInstanceName = common.Getenv("AZURE_INSTANCE_NAME", "aks-agentpool-12981678-vmss_0,aks-agentpool-12981678-vmss_1")
+	experimentDetails.ResourceGroup = common.Getenv("RESOURCE_GROUP", "MC_litmus_test2_eastus2")
+	experimentDetails.IsScaleSet = common.Getenv("IS_SCALE_SET", "true")
 	experimentDetails.Sequence = common.Getenv("SEQUENCE", "parallel")
 }
 

--- a/pkg/azure/instance-stop/environment/environment.go
+++ b/pkg/azure/instance-stop/environment/environment.go
@@ -30,7 +30,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.Timeout, _ = strconv.Atoi(common.Getenv("STATUS_CHECK_TIMEOUT", "180"))
 	experimentDetails.AzureInstanceName = common.Getenv("AZURE_INSTANCE_NAME", "")
 	experimentDetails.ResourceGroup = common.Getenv("RESOURCE_GROUP", "")
-	experimentDetails.IsScaleSet = common.Getenv("IS_SCALE_SET", "false")
+	experimentDetails.ScaleSet = common.Getenv("SCALE_SET", "disable")
 	experimentDetails.Sequence = common.Getenv("SEQUENCE", "parallel")
 }
 

--- a/pkg/azure/instance-stop/types/types.go
+++ b/pkg/azure/instance-stop/types/types.go
@@ -25,7 +25,7 @@ type ExperimentDetails struct {
 	AzureInstanceName  string
 	ResourceGroup      string
 	SubscriptionID     string
-	IsScaleSet         string
+	ScaleSet           string
 	LIBImagePullPolicy string
 	Sequence           string
 }

--- a/pkg/azure/instance-stop/types/types.go
+++ b/pkg/azure/instance-stop/types/types.go
@@ -15,7 +15,7 @@ type ExperimentDetails struct {
 	AuxiliaryAppInfo   string
 	ChaosLib           string
 	ChaosDuration      int
-	ChaosInterval	   int
+	ChaosInterval      int
 	ChaosUID           clientTypes.UID
 	InstanceID         string
 	ChaosNamespace     string
@@ -25,6 +25,7 @@ type ExperimentDetails struct {
 	AzureInstanceName  string
 	ResourceGroup      string
 	SubscriptionID     string
+	IsScaleSet         string
 	LIBImagePullPolicy string
-	Sequence		   string
+	Sequence           string
 }

--- a/pkg/cloud/azure/azure-instance-status.go
+++ b/pkg/cloud/azure/azure-instance-status.go
@@ -105,8 +105,8 @@ func InstanceStatusCheckByName(experimentsDetails *experimentTypes.ExperimentDet
 		return errors.Errorf("no instance found to check the status")
 	}
 	log.Infof("[Info]: The instance under chaos(IUC) are: %v", instanceNameList)
-	switch experimentsDetails.IsScaleSet {
-	case "true":
+	switch experimentsDetails.ScaleSet {
+	case "enable":
 		return ScaleSetInstanceStatusCheck(instanceNameList, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup)
 	default:
 		return InstanceStatusCheck(instanceNameList, experimentsDetails.SubscriptionID, experimentsDetails.ResourceGroup)

--- a/pkg/cloud/azure/azure-instance-status.go
+++ b/pkg/cloud/azure/azure-instance-status.go
@@ -102,7 +102,7 @@ func SetupSubscriptionID(experimentsDetails *experimentTypes.ExperimentDetails) 
 func InstanceStatusCheckByName(experimentsDetails *experimentTypes.ExperimentDetails) error {
 	instanceNameList := strings.Split(experimentsDetails.AzureInstanceName, ",")
 	if len(instanceNameList) == 0 {
-		return errors.Errorf("no instance found to check status")
+		return errors.Errorf("no instance found to check the status")
 	}
 	log.Infof("[Info]: The instance under chaos(IUC) are: %v", instanceNameList)
 	switch experimentsDetails.IsScaleSet {
@@ -113,7 +113,7 @@ func InstanceStatusCheckByName(experimentsDetails *experimentTypes.ExperimentDet
 	}
 }
 
-// InstanceStatusCheckByName is used to check the instance status of given list of instances
+// InstanceStatusCheck is used to check the instance status of given list of instances
 func InstanceStatusCheck(targetInstanceNameList []string, subscriptionID, resourceGroup string) error {
 
 	for _, vmName := range targetInstanceNameList {
@@ -128,7 +128,7 @@ func InstanceStatusCheck(targetInstanceNameList []string, subscriptionID, resour
 	return nil
 }
 
-// InstanceStatusCheckByName is used to check the instance status of given list of instances
+// ScaleSetInstanceStatusCheck is used to check the instance status of given list of instances belonging to scale set
 func ScaleSetInstanceStatusCheck(targetInstanceNameList []string, subscriptionID, resourceGroup string) error {
 
 	for _, instanceName := range targetInstanceNameList {

--- a/pkg/cloud/azure/azure-operations.go
+++ b/pkg/cloud/azure/azure-operations.go
@@ -116,7 +116,7 @@ func WaitForAzureComputeDown(timeout, delay int, isScaleSet, subscriptionID, res
 				return errors.Errorf("failed to get the instance status")
 			}
 			if instanceState != "VM stopped" {
-				log.Infof("The instance state is %v", instanceState)
+				// log.Infof("The instance state is %v", instanceState)
 				return errors.Errorf("instance is not yet in stopped state")
 			}
 			// log.Infof("The instance state is %v", instanceState)
@@ -147,7 +147,7 @@ func WaitForAzureComputeUp(timeout, delay int, isScaleSet, subscriptionID, resou
 				return errors.Errorf("failed to get instance status")
 			}
 			if instanceState != "VM running" {
-				log.Infof("The instance state is %v", instanceState)
+				// log.Infof("The instance state is %v", instanceState)
 				return errors.Errorf("instance is not yet in running state")
 			}
 			// log.Infof("The instance state is %v", instanceState)

--- a/pkg/cloud/azure/azure-operations.go
+++ b/pkg/cloud/azure/azure-operations.go
@@ -96,7 +96,7 @@ func AzureScaleSetInstanceStart(timeout, delay int, subscriptionID, resourceGrou
 }
 
 //WaitForAzureComputeDown will wait for the azure compute instance to get in stopped state
-func WaitForAzureComputeDown(timeout, delay int, isScaleSet, subscriptionID, resourceGroup, azureInstanceName string) error {
+func WaitForAzureComputeDown(timeout, delay int, scaleSet, subscriptionID, resourceGroup, azureInstanceName string) error {
 
 	var instanceState string
 	var err error
@@ -106,7 +106,7 @@ func WaitForAzureComputeDown(timeout, delay int, isScaleSet, subscriptionID, res
 		Times(uint(timeout / delay)).
 		Wait(time.Duration(delay) * time.Second).
 		Try(func(attempt uint) error {
-			if isScaleSet == "true" {
+			if scaleSet == "enable" {
 				scaleSetName, vmId := GetScaleSetNameAndInstanceId(azureInstanceName)
 				instanceState, err = GetAzureScaleSetInstanceStatus(subscriptionID, resourceGroup, scaleSetName, vmId)
 			} else {
@@ -123,7 +123,7 @@ func WaitForAzureComputeDown(timeout, delay int, isScaleSet, subscriptionID, res
 }
 
 //WaitForAzureComputeUp will wait for the azure compute instance to get in running state
-func WaitForAzureComputeUp(timeout, delay int, isScaleSet, subscriptionID, resourceGroup, azureInstanceName string) error {
+func WaitForAzureComputeUp(timeout, delay int, scaleSet, subscriptionID, resourceGroup, azureInstanceName string) error {
 
 	var instanceState string
 	var err error
@@ -134,8 +134,8 @@ func WaitForAzureComputeUp(timeout, delay int, isScaleSet, subscriptionID, resou
 		Wait(time.Duration(delay) * time.Second).
 		Try(func(attempt uint) error {
 
-			switch isScaleSet {
-			case "true":
+			switch scaleSet {
+			case "enable":
 				scaleSetName, vmId := GetScaleSetNameAndInstanceId(azureInstanceName)
 				instanceState, err = GetAzureScaleSetInstanceStatus(subscriptionID, resourceGroup, scaleSetName, vmId)
 			default:

--- a/pkg/cloud/azure/azure-operations.go
+++ b/pkg/cloud/azure/azure-operations.go
@@ -116,10 +116,8 @@ func WaitForAzureComputeDown(timeout, delay int, isScaleSet, subscriptionID, res
 				return errors.Errorf("failed to get the instance status")
 			}
 			if instanceState != "VM stopped" {
-				// log.Infof("The instance state is %v", instanceState)
 				return errors.Errorf("instance is not yet in stopped state")
 			}
-			// log.Infof("The instance state is %v", instanceState)
 			return nil
 		})
 }
@@ -147,10 +145,8 @@ func WaitForAzureComputeUp(timeout, delay int, isScaleSet, subscriptionID, resou
 				return errors.Errorf("failed to get instance status")
 			}
 			if instanceState != "VM running" {
-				// log.Infof("The instance state is %v", instanceState)
 				return errors.Errorf("instance is not yet in running state")
 			}
-			// log.Infof("The instance state is %v", instanceState)
 			return nil
 		})
 }

--- a/pkg/cloud/azure/azure-operations.go
+++ b/pkg/cloud/azure/azure-operations.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// AzureInstanceStop poweroff the target instance
+// AzureInstanceStop stops the target instance
 func AzureInstanceStop(timeout, delay int, subscriptionID, resourceGroup, azureInstanceName string) error {
 	vmClient := compute.NewVirtualMachinesClient(subscriptionID)
 
@@ -23,7 +23,7 @@ func AzureInstanceStop(timeout, delay int, subscriptionID, resourceGroup, azureI
 		return errors.Errorf("fail to setup authorization, err: %v")
 	}
 
-	log.Info("[Info]: Starting powerOff the instance")
+	log.Info("[Info]: Stopping the instance")
 	_, err = vmClient.PowerOff(context.TODO(), resourceGroup, azureInstanceName, &vmClient.SkipResourceProviderRegistration)
 	if err != nil {
 		return errors.Errorf("fail to stop the %v instance, err: %v", azureInstanceName, err)
@@ -53,7 +53,7 @@ func AzureInstanceStart(timeout, delay int, subscriptionID, resourceGroup, azure
 	return nil
 }
 
-// AzureScaleSetInstanceStop poweroff the target instance in the scale set
+// AzureScaleSetInstanceStop stops the target instance in the scale set
 func AzureScaleSetInstanceStop(timeout, delay int, subscriptionID, resourceGroup, azureInstanceName string) error {
 	vmssClient := compute.NewVirtualMachineScaleSetVMsClient(subscriptionID)
 
@@ -65,7 +65,7 @@ func AzureScaleSetInstanceStop(timeout, delay int, subscriptionID, resourceGroup
 	}
 	virtualMachineScaleSetName, virtualMachineId := GetScaleSetNameAndInstanceId(azureInstanceName)
 
-	log.Info("[Info]: Starting powerOff the instance")
+	log.Info("[Info]: Stopping the instance")
 	_, err = vmssClient.PowerOff(context.TODO(), resourceGroup, virtualMachineScaleSetName, virtualMachineId, &vmssClient.SkipResourceProviderRegistration)
 	if err != nil {
 		return errors.Errorf("fail to stop the %v_%v instance, err: %v", virtualMachineScaleSetName, virtualMachineId, err)

--- a/pkg/cloud/azure/azure-operations.go
+++ b/pkg/cloud/azure/azure-operations.go
@@ -34,6 +34,7 @@ func AzureInstanceStop(timeout, delay int, subscriptionID, resourceGroup, azureI
 
 // AzureInstanceStart starts the target instance
 func AzureInstanceStart(timeout, delay int, subscriptionID, resourceGroup, azureInstanceName string) error {
+
 	vmClient := compute.NewVirtualMachinesClient(subscriptionID)
 
 	authorizer, err := auth.NewAuthorizerFromFile(azure.PublicCloud.ResourceManagerEndpoint)
@@ -52,16 +53,65 @@ func AzureInstanceStart(timeout, delay int, subscriptionID, resourceGroup, azure
 	return nil
 }
 
+// AzureScaleSetInstanceStop poweroff the target instance in the scale set
+func AzureScaleSetInstanceStop(timeout, delay int, subscriptionID, resourceGroup, azureInstanceName string) error {
+	vmssClient := compute.NewVirtualMachineScaleSetVMsClient(subscriptionID)
+
+	authorizer, err := auth.NewAuthorizerFromFile(azure.PublicCloud.ResourceManagerEndpoint)
+	if err == nil {
+		vmssClient.Authorizer = authorizer
+	} else {
+		return errors.Errorf("fail to setup authorization, err: %v")
+	}
+	virtualMachineScaleSetName, virtualMachineId := GetScaleSetNameAndInstanceId(azureInstanceName)
+
+	log.Info("[Info]: Starting powerOff the instance")
+	_, err = vmssClient.PowerOff(context.TODO(), resourceGroup, virtualMachineScaleSetName, virtualMachineId, &vmssClient.SkipResourceProviderRegistration)
+	if err != nil {
+		return errors.Errorf("fail to stop the %v_%v instance, err: %v", virtualMachineScaleSetName, virtualMachineId, err)
+	}
+
+	return nil
+}
+
+// AzureScaleSetInstanceStart starts the target instance in the scale set
+func AzureScaleSetInstanceStart(timeout, delay int, subscriptionID, resourceGroup, azureInstanceName string) error {
+	vmssClient := compute.NewVirtualMachineScaleSetVMsClient(subscriptionID)
+
+	authorizer, err := auth.NewAuthorizerFromFile(azure.PublicCloud.ResourceManagerEndpoint)
+	if err == nil {
+		vmssClient.Authorizer = authorizer
+	} else {
+		return errors.Errorf("fail to setup authorization, err: %v")
+	}
+	virtualMachineScaleSetName, virtualMachineId := GetScaleSetNameAndInstanceId(azureInstanceName)
+
+	log.Info("[Info]: Starting back the instance to running state")
+	_, err = vmssClient.Start(context.TODO(), resourceGroup, virtualMachineScaleSetName, virtualMachineId)
+	if err != nil {
+		return errors.Errorf("fail to start the %v_%v instance, err: %v", virtualMachineScaleSetName, virtualMachineId, err)
+	}
+
+	return nil
+}
+
 //WaitForAzureComputeDown will wait for the azure compute instance to get in stopped state
-func WaitForAzureComputeDown(timeout, delay int, subscriptionID, resourceGroup, azureInstanceName string) error {
+func WaitForAzureComputeDown(timeout, delay int, isScaleSet, subscriptionID, resourceGroup, azureInstanceName string) error {
+
+	var instanceState string
+	var err error
 
 	log.Info("[Status]: Checking Azure instance status")
 	return retry.
 		Times(uint(timeout / delay)).
 		Wait(time.Duration(delay) * time.Second).
 		Try(func(attempt uint) error {
-
-			instanceState, err := GetAzureInstanceStatus(subscriptionID, resourceGroup, azureInstanceName)
+			if isScaleSet == "true" {
+				scaleSetName, vmId := GetScaleSetNameAndInstanceId(azureInstanceName)
+				instanceState, err = GetAzureScaleSetInstanceStatus(subscriptionID, resourceGroup, scaleSetName, vmId)
+			} else {
+				instanceState, err = GetAzureInstanceStatus(subscriptionID, resourceGroup, azureInstanceName)
+			}
 			if err != nil {
 				return errors.Errorf("failed to get the instance status")
 			}
@@ -69,13 +119,16 @@ func WaitForAzureComputeDown(timeout, delay int, subscriptionID, resourceGroup, 
 				log.Infof("The instance state is %v", instanceState)
 				return errors.Errorf("instance is not yet in stopped state")
 			}
-			log.Infof("The instance state is %v", instanceState)
+			// log.Infof("The instance state is %v", instanceState)
 			return nil
 		})
 }
 
 //WaitForAzureComputeUp will wait for the azure compute instance to get in running state
-func WaitForAzureComputeUp(timeout, delay int, subscriptionID, resourceGroup, azureInstanceName string) error {
+func WaitForAzureComputeUp(timeout, delay int, isScaleSet, subscriptionID, resourceGroup, azureInstanceName string) error {
+
+	var instanceState string
+	var err error
 
 	log.Info("[Status]: Checking Azure instance status")
 	return retry.
@@ -83,7 +136,13 @@ func WaitForAzureComputeUp(timeout, delay int, subscriptionID, resourceGroup, az
 		Wait(time.Duration(delay) * time.Second).
 		Try(func(attempt uint) error {
 
-			instanceState, err := GetAzureInstanceStatus(subscriptionID, resourceGroup, azureInstanceName)
+			switch isScaleSet {
+			case "true":
+				scaleSetName, vmId := GetScaleSetNameAndInstanceId(azureInstanceName)
+				instanceState, err = GetAzureScaleSetInstanceStatus(subscriptionID, resourceGroup, scaleSetName, vmId)
+			default:
+				instanceState, err = GetAzureInstanceStatus(subscriptionID, resourceGroup, azureInstanceName)
+			}
 			if err != nil {
 				return errors.Errorf("failed to get instance status")
 			}
@@ -91,7 +150,7 @@ func WaitForAzureComputeUp(timeout, delay int, subscriptionID, resourceGroup, az
 				log.Infof("The instance state is %v", instanceState)
 				return errors.Errorf("instance is not yet in running state")
 			}
-			log.Infof("The instance state is %v", instanceState)
+			// log.Infof("The instance state is %v", instanceState)
 			return nil
 		})
 }


### PR DESCRIPTION
Signed-off-by: Akash Shrivastava <akash@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds the support for virtual machine scale sets in the azure instance stop experiment. Currently the instance stop experiment only works for VM instances, with this PR we can run the experiment for AKS nodes as well.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
