### PR TITLE
Auxiliary Application Check for node-memory-hog Experiment and Multiple Target Node Functionality Fix for three Node-Level Experiments

### DIFF
--- a/experiments/generic/node-memory-hog/experiment/node-memory-hog.go
+++ b/experiments/generic/node-memory-hog/experiment/node-memory-hog.go
@@ -83,6 +83,17 @@ func NodeMemoryHog(clients clients.ClientSets) {
 		return
 	}
 
+	//PRE-CHAOS AUXILIARY APPLICATION STATUS CHECK
+	if experimentsDetails.AuxiliaryAppInfo != "" {
+		log.Info("[Status]: Verify that the Auxiliary Applications are running (pre-chaos)")
+		if err := status.CheckAuxiliaryApplicationStatus(experimentsDetails.AuxiliaryAppInfo, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
+			log.Errorf("Auxiliary Application status check failed, err: %v", err)
+			failStep := "Verify that the Auxiliary Applications are running (pre-chaos)"
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+	}
+
 	// Checking the status of target nodes
 	log.Info("[Status]: Getting the status of target nodes")
 	if err := status.CheckNodeStatus(experimentsDetails.TargetNodes, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
@@ -141,6 +152,17 @@ func NodeMemoryHog(clients clients.ClientSets) {
 		failStep := "Verify that the AUT (Application Under Test) is running (post-chaos)"
 		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 		return
+	}
+
+	//POST-CHAOS AUXILIARY APPLICATION STATUS CHECK
+	if experimentsDetails.AuxiliaryAppInfo != "" {
+		log.Info("[Status]: Verify that the Auxiliary Applications are running (post-chaos)")
+		if err := status.CheckAuxiliaryApplicationStatus(experimentsDetails.AuxiliaryAppInfo, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
+			log.Errorf("Auxiliary Application status check failed, err: %v", err)
+			failStep := "Verify that the Auxiliary Applications are running (post-chaos)"
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
 	}
 
 	if experimentsDetails.EngineName != "" {

--- a/pkg/utils/common/nodes.go
+++ b/pkg/utils/common/nodes.go
@@ -3,6 +3,7 @@ package common
 import (
 	"math/rand"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/litmuschaos/litmus-go/pkg/clients"
@@ -19,14 +20,14 @@ var err error
 
 //GetNodeList check for the availibilty of the application node for the chaos execution
 // if the application node is not defined it will derive the random target node list using node affected percentage
-func GetNodeList(nodeName, nodeLabel string, nodeAffPerc int, clients clients.ClientSets) ([]string, error) {
+func GetNodeList(nodeNames, nodeLabel string, nodeAffPerc int, clients clients.ClientSets) ([]string, error) {
 
 	var nodeList []string
 	var nodes *apiv1.NodeList
 
-	if nodeName != "" {
-		nodeList = append(nodeList, nodeName)
-		return nodeList, nil
+	if nodeNames != "" {
+		targetNodesList := strings.Split(nodeNames, ",")
+		return targetNodesList, nil
 	}
 
 	switch nodeLabel {


### PR DESCRIPTION
**What this PR does / why we need it**
1. Adds auxiliary application check functionality to the node-memory-hog experiment
2. Fixes the functionality of specifying multiple target nodes as comma-separated-values in for `node-cpu-hog`, `node-memory-hog`, and `node-io-stress` experiment.

**Which issue this PR fixes**
fixes #423 