### PR TITLE
feat(experiment): derive parent name in pod-delete only

### DIFF
--- a/chaoslib/litmus/kafka-broker-pod-failure/lib/pod-delete.go
+++ b/chaoslib/litmus/kafka-broker-pod-failure/lib/pod-delete.go
@@ -12,6 +12,7 @@ import (
 	"github.com/litmuschaos/litmus-go/pkg/probe"
 	"github.com/litmuschaos/litmus-go/pkg/status"
 	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/litmuschaos/litmus-go/pkg/utils/annotation"
 	"github.com/litmuschaos/litmus-go/pkg/utils/common"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -74,8 +75,18 @@ func injectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 			return err
 		}
 
-		for _, target := range chaosDetails.ParentsResources {
-			common.SetTargets(target, "targeted", chaosDetails.AppDetail.Kind, chaosDetails)
+		// deriving the parent name of the target resources
+		if chaosDetails.AppDetail.Kind != "" {
+			for _, pod := range targetPodList.Items {
+				parentName, err := annotation.GetParentName(clients, pod, chaosDetails)
+				if err != nil {
+					return err
+				}
+				common.SetParentName(parentName, chaosDetails)
+			}
+			for _, target := range chaosDetails.ParentsResources {
+				common.SetTargets(target, "targeted", chaosDetails.AppDetail.Kind, chaosDetails)
+			}
 		}
 
 		if experimentsDetails.ChaoslibDetail.EngineName != "" {
@@ -152,8 +163,18 @@ func injectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 			return err
 		}
 
-		for _, target := range chaosDetails.ParentsResources {
-			common.SetTargets(target, "targeted", chaosDetails.AppDetail.Kind, chaosDetails)
+		// deriving the parent name of the target resources
+		if chaosDetails.AppDetail.Kind != "" {
+			for _, pod := range targetPodList.Items {
+				parentName, err := annotation.GetParentName(clients, pod, chaosDetails)
+				if err != nil {
+					return err
+				}
+				common.SetParentName(parentName, chaosDetails)
+			}
+			for _, target := range chaosDetails.ParentsResources {
+				common.SetTargets(target, "targeted", chaosDetails.AppDetail.Kind, chaosDetails)
+			}
 		}
 
 		if experimentsDetails.ChaoslibDetail.EngineName != "" {

--- a/chaoslib/litmus/pod-delete/lib/pod-delete.go
+++ b/chaoslib/litmus/pod-delete/lib/pod-delete.go
@@ -12,6 +12,7 @@ import (
 	"github.com/litmuschaos/litmus-go/pkg/probe"
 	"github.com/litmuschaos/litmus-go/pkg/status"
 	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/litmuschaos/litmus-go/pkg/utils/annotation"
 	"github.com/litmuschaos/litmus-go/pkg/utils/common"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -74,15 +75,25 @@ func injectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetai
 			return err
 		}
 
+		// deriving the parent name of the target resources
+		if chaosDetails.AppDetail.Kind != "" {
+			for _, pod := range targetPodList.Items {
+				parentName, err := annotation.GetParentName(clients, pod, chaosDetails)
+				if err != nil {
+					return err
+				}
+				common.SetParentName(parentName, chaosDetails)
+			}
+			for _, target := range chaosDetails.ParentsResources {
+				common.SetTargets(target, "targeted", chaosDetails.AppDetail.Kind, chaosDetails)
+			}
+		}
+
 		podNames := []string{}
 		for _, pod := range targetPodList.Items {
 			podNames = append(podNames, pod.Name)
 		}
 		log.Infof("Target pods list: %v", podNames)
-
-		for _, target := range chaosDetails.ParentsResources {
-			common.SetTargets(target, "targeted", chaosDetails.AppDetail.Kind, chaosDetails)
-		}
 
 		if experimentsDetails.EngineName != "" {
 			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
@@ -161,15 +172,25 @@ func injectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 			return err
 		}
 
+		// deriving the parent name of the target resources
+		if chaosDetails.AppDetail.Kind != "" {
+			for _, pod := range targetPodList.Items {
+				parentName, err := annotation.GetParentName(clients, pod, chaosDetails)
+				if err != nil {
+					return err
+				}
+				common.SetParentName(parentName, chaosDetails)
+			}
+			for _, target := range chaosDetails.ParentsResources {
+				common.SetTargets(target, "targeted", chaosDetails.AppDetail.Kind, chaosDetails)
+			}
+		}
+
 		podNames := []string{}
 		for _, pod := range targetPodList.Items {
 			podNames = append(podNames, pod.Name)
 		}
 		log.Infof("Target pods list: %v", podNames)
-
-		for _, target := range chaosDetails.ParentsResources {
-			common.SetTargets(target, "targeted", chaosDetails.AppDetail.Kind, chaosDetails)
-		}
 
 		if experimentsDetails.EngineName != "" {
 			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"

--- a/pkg/cassandra/pod-delete/environment/environment.go
+++ b/pkg/cassandra/pod-delete/environment/environment.go
@@ -66,5 +66,4 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, cassandraDetails
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.ProbeImagePullPolicy = cassandraDetails.ChaoslibDetail.LIBImagePullPolicy
 	chaosDetails.Randomness, _ = strconv.ParseBool(common.Getenv("RANDOMNESS", "false"))
-	chaosDetails.ParentsResources = []string{}
 }

--- a/pkg/generic/container-kill/environment/environment.go
+++ b/pkg/generic/container-kill/environment/environment.go
@@ -61,6 +61,5 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetail
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.JobCleanupPolicy = common.Getenv("JOB_CLEANUP_POLICY", "retain")
 	chaosDetails.ProbeImagePullPolicy = experimentDetails.LIBImagePullPolicy
-	chaosDetails.ParentsResources = []string{}
 	chaosDetails.Targets = []v1alpha1.TargetDetails{}
 }

--- a/pkg/generic/disk-fill/environment/environment.go
+++ b/pkg/generic/disk-fill/environment/environment.go
@@ -61,5 +61,4 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetail
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.JobCleanupPolicy = common.Getenv("JOB_CLEANUP_POLICY", "retain")
 	chaosDetails.ProbeImagePullPolicy = experimentDetails.LIBImagePullPolicy
-	chaosDetails.ParentsResources = []string{}
 }

--- a/pkg/generic/network-chaos/environment/environment.go
+++ b/pkg/generic/network-chaos/environment/environment.go
@@ -68,6 +68,5 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetail
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.JobCleanupPolicy = common.Getenv("JOB_CLEANUP_POLICY", "retain")
 	chaosDetails.ProbeImagePullPolicy = experimentDetails.LIBImagePullPolicy
-	chaosDetails.ParentsResources = []string{}
 	chaosDetails.Targets = []v1alpha1.TargetDetails{}
 }

--- a/pkg/generic/pod-cpu-hog-exec/environment/environment.go
+++ b/pkg/generic/pod-cpu-hog-exec/environment/environment.go
@@ -57,6 +57,5 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetail
 	chaosDetails.Delay = experimentDetails.Delay
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.ProbeImagePullPolicy = experimentDetails.LIBImagePullPolicy
-	chaosDetails.ParentsResources = []string{}
 	chaosDetails.Targets = []v1alpha1.TargetDetails{}
 }

--- a/pkg/generic/pod-delete/environment/environment.go
+++ b/pkg/generic/pod-delete/environment/environment.go
@@ -58,5 +58,4 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetail
 	chaosDetails.ProbeImagePullPolicy = experimentDetails.LIBImagePullPolicy
 	chaosDetails.Randomness, _ = strconv.ParseBool(common.Getenv("RANDOMNESS", "false"))
 	chaosDetails.Targets = []v1alpha1.TargetDetails{}
-	chaosDetails.ParentsResources = []string{}
 }

--- a/pkg/generic/pod-dns-chaos/environment/environment.go
+++ b/pkg/generic/pod-dns-chaos/environment/environment.go
@@ -79,5 +79,4 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetail
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.JobCleanupPolicy = common.Getenv("JOB_CLEANUP_POLICY", "retain")
 	chaosDetails.ProbeImagePullPolicy = experimentDetails.LIBImagePullPolicy
-	chaosDetails.ParentsResources = []string{}
 }

--- a/pkg/generic/pod-memory-hog-exec/environment/environment.go
+++ b/pkg/generic/pod-memory-hog-exec/environment/environment.go
@@ -56,6 +56,5 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetail
 	chaosDetails.Delay = experimentDetails.Delay
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.ProbeImagePullPolicy = experimentDetails.LIBImagePullPolicy
-	chaosDetails.ParentsResources = []string{}
 	chaosDetails.Targets = []v1alpha1.TargetDetails{}
 }

--- a/pkg/generic/stress-chaos/environment/environment.go
+++ b/pkg/generic/stress-chaos/environment/environment.go
@@ -76,6 +76,5 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, experimentDetail
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.JobCleanupPolicy = common.Getenv("JOB_CLEANUP_POLICY", "retain")
 	chaosDetails.ProbeImagePullPolicy = experimentDetails.LIBImagePullPolicy
-	chaosDetails.ParentsResources = []string{}
 	chaosDetails.Targets = []v1alpha1.TargetDetails{}
 }

--- a/pkg/kafka/environment/environment.go
+++ b/pkg/kafka/environment/environment.go
@@ -79,6 +79,5 @@ func InitialiseChaosVariables(chaosDetails *types.ChaosDetails, kafkaDetails *ka
 	chaosDetails.AppDetail = appDetails
 	chaosDetails.ProbeImagePullPolicy = kafkaDetails.ChaoslibDetail.LIBImagePullPolicy
 	chaosDetails.Randomness, _ = strconv.ParseBool(common.Getenv("RANDOMNESS", "false"))
-	chaosDetails.ParentsResources = []string{}
 	chaosDetails.Targets = []v1alpha1.TargetDetails{}
 }

--- a/pkg/utils/common/pods.go
+++ b/pkg/utils/common/pods.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"math/rand"
-	"strconv"
 	"strings"
 	"time"
 
@@ -120,12 +119,7 @@ func VerifyExistanceOfPods(namespace, pods string, clients clients.ClientSets) (
 //GetPodList check for the availibilty of the target pod for the chaos execution
 // if the target pod is not defined it will derive the random target pod list using pod affected percentage
 func GetPodList(targetPods string, podAffPerc int, clients clients.ClientSets, chaosDetails *types.ChaosDetails) (core_v1.PodList, error) {
-	realpods := core_v1.PodList{}
-	podList, err := clients.KubeClient.CoreV1().Pods(chaosDetails.AppDetail.Namespace).List(v1.ListOptions{LabelSelector: chaosDetails.AppDetail.Label})
-	if err != nil || len(podList.Items) == 0 {
-		return core_v1.PodList{}, errors.Wrapf(err, "Failed to find the pod with matching labels in %v namespace", chaosDetails.AppDetail.Namespace)
-	}
-
+	finalPods := core_v1.PodList{}
 	isPodsAvailable, err := VerifyExistanceOfPods(chaosDetails.AppDetail.Namespace, targetPods, clients)
 	if err != nil {
 		return core_v1.PodList{}, err
@@ -139,17 +133,20 @@ func GetPodList(targetPods string, podAffPerc int, clients clients.ClientSets, c
 		if err != nil {
 			return core_v1.PodList{}, err
 		}
-		realpods.Items = append(realpods.Items, podList.Items...)
+		finalPods.Items = append(finalPods.Items, podList.Items...)
 	default:
-		nonChaosPods := FilterNonChaosPods(*podList, chaosDetails)
-		realpods, err = GetTargetPodsWhenTargetPodsENVNotSet(podAffPerc, clients, nonChaosPods, chaosDetails)
+		nonChaosPods, err := FilterNonChaosPods(clients, chaosDetails)
 		if err != nil {
 			return core_v1.PodList{}, err
 		}
+		podList, err := GetTargetPodsWhenTargetPodsENVNotSet(podAffPerc, clients, nonChaosPods, chaosDetails)
+		if err != nil {
+			return core_v1.PodList{}, err
+		}
+		finalPods.Items = append(finalPods.Items, podList.Items...)
 	}
-	log.Infof("[Chaos]:Number of pods targeted: %v", strconv.Itoa(len(realpods.Items)))
-
-	return realpods, nil
+	log.Infof("[Chaos]:Number of pods targeted: %v", len(finalPods.Items))
+	return finalPods, nil
 }
 
 // CheckForAvailibiltyOfPod check the availibility of the specified pod
@@ -170,7 +167,13 @@ func CheckForAvailibiltyOfPod(namespace, name string, clients clients.ClientSets
 
 //FilterNonChaosPods remove the chaos pods(operator, runner) for the podList
 // it filter when the applabels are not defined and it will select random pods from appns
-func FilterNonChaosPods(podList core_v1.PodList, chaosDetails *types.ChaosDetails) core_v1.PodList {
+func FilterNonChaosPods(clients clients.ClientSets, chaosDetails *types.ChaosDetails) (core_v1.PodList, error) {
+	podList, err := clients.KubeClient.CoreV1().Pods(chaosDetails.AppDetail.Namespace).List(v1.ListOptions{LabelSelector: chaosDetails.AppDetail.Label})
+	if err != nil {
+		return core_v1.PodList{}, err
+	} else if len(podList.Items) == 0 {
+		return core_v1.PodList{}, errors.Wrapf(err, "Failed to find the pod with matching labels in %v namespace", chaosDetails.AppDetail.Namespace)
+	}
 	nonChaosPods := core_v1.PodList{}
 	// ignore chaos pods
 	for index, pod := range podList.Items {
@@ -178,41 +181,35 @@ func FilterNonChaosPods(podList core_v1.PodList, chaosDetails *types.ChaosDetail
 			nonChaosPods.Items = append(nonChaosPods.Items, podList.Items[index])
 		}
 	}
-	return nonChaosPods
+	return nonChaosPods, nil
 }
 
 // GetTargetPodsWhenTargetPodsENVSet derive the specific target pods, if TARGET_PODS env is set
 func GetTargetPodsWhenTargetPodsENVSet(targetPods string, clients clients.ClientSets, chaosDetails *types.ChaosDetails) (core_v1.PodList, error) {
-	podList, err := clients.KubeClient.CoreV1().Pods(chaosDetails.AppDetail.Namespace).List(v1.ListOptions{LabelSelector: chaosDetails.AppDetail.Label})
-	if err != nil || len(podList.Items) == 0 {
-		return core_v1.PodList{}, errors.Wrapf(err, "Failed to find the pods with matching labels in %v namespace", chaosDetails.AppDetail.Namespace)
-	}
 
 	targetPodsList := strings.Split(targetPods, ",")
 	realPods := core_v1.PodList{}
 
-	for _, pod := range podList.Items {
-		for index := range targetPodsList {
-			if targetPodsList[index] == pod.Name {
-				parentName, err := annotation.GetParentName(clients, pod, chaosDetails)
-				if err != nil {
-					return core_v1.PodList{}, err
-				}
-				switch chaosDetails.AppDetail.AnnotationCheck {
-				case true:
-					isParentAnnotated, err := annotation.IsParentAnnotated(clients, parentName, chaosDetails)
-					if err != nil {
-						return core_v1.PodList{}, err
-					}
-					if !isParentAnnotated {
-						return core_v1.PodList{}, errors.Errorf("%v target application is not annotated", parentName)
-					}
-				}
-				realPods.Items = append(realPods.Items, pod)
-				setParentName(parentName, chaosDetails)
-				log.Infof("[Info]: chaos candidate of kind: %v, name: %v, namespace: %v", chaosDetails.AppDetail.Kind, parentName, chaosDetails.AppDetail.Namespace)
+	for index := range targetPodsList {
+		pod, err := clients.KubeClient.CoreV1().Pods(chaosDetails.AppDetail.Namespace).Get(strings.TrimSpace(targetPodsList[index]), v1.GetOptions{})
+		if err != nil {
+			return core_v1.PodList{}, errors.Wrapf(err, "Failed to get %v pod in %v namespace", targetPodsList[index], chaosDetails.AppDetail.Namespace)
+		}
+		switch chaosDetails.AppDetail.AnnotationCheck {
+		case true:
+			parentName, err := annotation.GetParentName(clients, *pod, chaosDetails)
+			if err != nil {
+				return core_v1.PodList{}, err
+			}
+			isParentAnnotated, err := annotation.IsParentAnnotated(clients, parentName, chaosDetails)
+			if err != nil {
+				return core_v1.PodList{}, err
+			}
+			if !isParentAnnotated {
+				return core_v1.PodList{}, errors.Errorf("%v target application is not annotated", parentName)
 			}
 		}
+		realPods.Items = append(realPods.Items, *pod)
 	}
 	return realPods, nil
 }
@@ -234,8 +231,8 @@ func SetTargets(target, chaosStatus, kind string, chaosDetails *types.ChaosDetai
 	chaosDetails.Targets = append(chaosDetails.Targets, newTarget)
 }
 
-// setParentName set the parent name in chaosdetails struct
-func setParentName(parentName string, chaosDetails *types.ChaosDetails) {
+// SetParentName set the parent name in chaosdetails struct
+func SetParentName(parentName string, chaosDetails *types.ChaosDetails) {
 	if chaosDetails.ParentsResources == nil {
 		chaosDetails.ParentsResources = []string{parentName}
 	} else {
@@ -253,25 +250,21 @@ func GetTargetPodsWhenTargetPodsENVNotSet(podAffPerc int, clients clients.Client
 	filteredPods := core_v1.PodList{}
 	realPods := core_v1.PodList{}
 	for _, pod := range nonChaosPods.Items {
-		parentName, err := annotation.GetParentName(clients, pod, chaosDetails)
-		if err != nil {
-			return core_v1.PodList{}, err
-		}
 		switch chaosDetails.AppDetail.AnnotationCheck {
 		case true:
+			parentName, err := annotation.GetParentName(clients, pod, chaosDetails)
+			if err != nil {
+				return core_v1.PodList{}, err
+			}
 			isParentAnnotated, err := annotation.IsParentAnnotated(clients, parentName, chaosDetails)
 			if err != nil {
 				return core_v1.PodList{}, err
 			}
 			if isParentAnnotated {
 				filteredPods.Items = append(filteredPods.Items, pod)
-				setParentName(parentName, chaosDetails)
-				log.Infof("[Info]: chaos candidate of kind: %v, name: %v, namespace: %v", chaosDetails.AppDetail.Kind, parentName, chaosDetails.AppDetail.Namespace)
 			}
 		default:
 			filteredPods.Items = append(filteredPods.Items, pod)
-			setParentName(parentName, chaosDetails)
-			log.Infof("[Info]: chaos candidate of kind: %v, name: %v, namespace: %v", chaosDetails.AppDetail.Kind, parentName, chaosDetails.AppDetail.Namespace)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: shubham chaudhary <shubham@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

In pod-delete experiments, the parent name is used to patch inside chaosresult along with chaosStatus. The derivation of parent name is limited to pod-delete experiment so deriving the parent name for pod-delete experiment only. Removed the step from the other experiments.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
