### PR TITLE
Bug(Experiment Generator): Add AuxiliaryAppInfo to template

### DIFF
--- a/contribute/developer-guide/templates/environment.tmpl
+++ b/contribute/developer-guide/templates/environment.tmpl
@@ -25,6 +25,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.AppNS = common.Getenv("APP_NAMESPACE", "")
 	experimentDetails.AppLabel = common.Getenv("APP_LABEL", "")
 	experimentDetails.AppKind = common.Getenv("APP_KIND", "")
+	experimentDetails.AuxiliaryAppInfo = common.Getenv("AUXILIARY_APPINFO",""))
 	experimentDetails.ChaosUID = clientTypes.UID(common.Getenv("CHAOS_UID", ""))
 	experimentDetails.InstanceID = common.Getenv("INSTANCE_ID", "")
 	experimentDetails.ChaosPodName = common.Getenv("POD_NAME", "")

--- a/contribute/developer-guide/templates/types.tmpl
+++ b/contribute/developer-guide/templates/types.tmpl
@@ -18,6 +18,7 @@ type ExperimentDetails struct {
 	AppNS               string
 	AppLabel            string
 	AppKind             string
+	AuxiliaryAppInfo    string
 	ChaosUID            clientTypes.UID
 	InstanceID          string
 	ChaosNamespace      string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- In experiment generator, the generated experiments did not contain AuxilaryAppInfo structure field

**Which issue this PR fixes** :  litmuschaos/litmus#3272

**Checklist:**
-   [x] Fixes litmuschaos/litmus#3272
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
