### PR TITLE
fix(helper): removing job-name label from the helper pod

### DIFF
--- a/pkg/utils/common/pods.go
+++ b/pkg/utils/common/pods.go
@@ -96,6 +96,7 @@ func SetHelperData(chaosDetails *types.ChaosDetails, clients clients.ClientSets)
 	// Get Labels
 	labels := pod.ObjectMeta.Labels
 	delete(labels, "controller-uid")
+	delete(labels, "job-name")
 	chaosDetails.Labels = labels
 
 	// Get Resource Requirements


### PR DESCRIPTION
Signed-off-by: shubham chaudhary <shubham@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

Removing `job-name` label from the helper pod as chaos-runner is using  `job-name` label to watch experiment pod/job. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
