### PR TITLE
Skip uncordon the not exist node after node drain experiment

### DIFF
--- a/chaoslib/litmus/node-drain/lib/node-drain.go
+++ b/chaoslib/litmus/node-drain/lib/node-drain.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -19,6 +20,8 @@ import (
 	"github.com/litmuschaos/litmus-go/pkg/utils/common"
 	"github.com/litmuschaos/litmus-go/pkg/utils/retry"
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -149,29 +152,50 @@ func drainNode(experimentsDetails *experimentTypes.ExperimentDetails, clients cl
 // uncordonNode uncordon the application node
 func uncordonNode(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, chaosDetails *types.ChaosDetails) error {
 
-	log.Infof("[Recover]: Uncordon the %v node", experimentsDetails.TargetNode)
+	targetNodes := strings.Split(experimentsDetails.TargetNode, ",")
+	for _, targetNode := range targetNodes {
 
-	command := exec.Command("kubectl", "uncordon", experimentsDetails.TargetNode)
-	var out, stderr bytes.Buffer
-	command.Stdout = &out
-	command.Stderr = &stderr
-	if err := command.Run(); err != nil {
-		log.Infof("Error String: %v", stderr.String())
-		return errors.Errorf("unable to uncordon the %v node, err: %v", experimentsDetails.TargetNode, err)
+		//Check node exist before uncordon the node
+		_, err := clients.KubeClient.CoreV1().Nodes().Get(targetNode, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Infof("[Info]: The %v node is no longer exist, skip uncordon the node", targetNode)
+				common.SetTargets(targetNode, "noLongerExist", "node", chaosDetails)
+				continue
+			} else {
+				return errors.Errorf("unable to get the %v node, err: %v", targetNode, err)
+			}
+		}
+
+		log.Infof("[Recover]: Uncordon the %v node", targetNode)
+		command := exec.Command("kubectl", "uncordon", targetNode)
+		var out, stderr bytes.Buffer
+		command.Stdout = &out
+		command.Stderr = &stderr
+		if err := command.Run(); err != nil {
+			log.Infof("Error String: %v", stderr.String())
+			return errors.Errorf("unable to uncordon the %v node, err: %v", targetNode, err)
+		}
+		common.SetTargets(targetNode, "reverted", "node", chaosDetails)
 	}
-
-	common.SetTargets(experimentsDetails.TargetNode, "reverted", "node", chaosDetails)
 
 	return retry.
 		Times(uint(experimentsDetails.Timeout / experimentsDetails.Delay)).
 		Wait(time.Duration(experimentsDetails.Delay) * time.Second).
 		Try(func(attempt uint) error {
-			nodeSpec, err := clients.KubeClient.CoreV1().Nodes().Get(experimentsDetails.TargetNode, v1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			if nodeSpec.Spec.Unschedulable {
-				return errors.Errorf("%v node is in unschedulable state", experimentsDetails.TargetNode)
+			targetNodes := strings.Split(experimentsDetails.TargetNode, ",")
+			for _, targetNode := range targetNodes {
+				nodeSpec, err := clients.KubeClient.CoreV1().Nodes().Get(targetNode, v1.GetOptions{})
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						continue
+					} else {
+						return err
+					}
+				}
+				if nodeSpec.Spec.Unschedulable {
+					return errors.Errorf("%v node is in unschedulable state", experimentsDetails.TargetNode)
+				}
 			}
 			return nil
 		})

--- a/pkg/status/nodes.go
+++ b/pkg/status/nodes.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	logrus "github.com/sirupsen/logrus"
 	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,7 +27,12 @@ func CheckNodeStatus(nodes string, timeout, delay int, clients clients.ClientSet
 				for index := range targetNodes {
 					node, err := clients.KubeClient.CoreV1().Nodes().Get(targetNodes[index], metav1.GetOptions{})
 					if err != nil {
-						return err
+						if apierrors.IsNotFound(err) {
+							log.Infof("[Info]: The %v node is not exist", targetNodes[index])
+							continue
+						} else {
+							return err
+						}
 					}
 					nodeList.Items = append(nodeList.Items, *node)
 				}


### PR DESCRIPTION
Signed-off-by: Andrew Hu <andrew.hu@hcl.com>

**What this PR does / why we need it**:
In the node drain experiment, the node will be deleted after draining the node if we enable the autoscaling for the node pool on the cloud provider. And it will cause an error when litmus-go trying to uncordon the non exist node. In this PR, it will check if the node still exists before uncordon the node.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/litmuschaos/litmus/issues/3350


**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #3350
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
