### PR TITLE
Chore(stress-chaos): Run CPU chaos with percentage of cpu cores

### DIFF
--- a/chaoslib/litmus/node-cpu-hog/lib/node-cpu-hog.go
+++ b/chaoslib/litmus/node-cpu-hog/lib/node-cpu-hog.go
@@ -244,6 +244,8 @@ func createHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, chao
 					Args: []string{
 						"--cpu",
 						strconv.Itoa(experimentsDetails.NodeCPUcores),
+						"--cpu-load",
+						strconv.Itoa(experimentsDetails.CPULoad),
 						"--timeout",
 						strconv.Itoa(experimentsDetails.ChaosDuration),
 					},

--- a/chaoslib/litmus/stress-chaos/helper/stress-helper.go
+++ b/chaoslib/litmus/stress-chaos/helper/stress-helper.go
@@ -237,7 +237,8 @@ func prepareStressor(experimentDetails *experimentTypes.ExperimentDetails) []str
 			"CPU Core": experimentDetails.CPUcores,
 			"Timeout":  experimentDetails.ChaosDuration,
 		})
-		stressArgs = append(stressArgs, "--cpu "+strconv.Itoa(experimentDetails.CPUcores)+" --cpu-load "+strconv.Itoa(experimentDetails.CPULoad))
+		stressArgs = append(stressArgs, "--cpu "+strconv.Itoa(experimentDetails.CPUcores))
+		stressArgs = append(stressArgs, " --cpu-load "+strconv.Itoa(experimentDetails.CPULoad))
 
 	case "pod-memory-stress":
 

--- a/chaoslib/litmus/stress-chaos/helper/stress-helper.go
+++ b/chaoslib/litmus/stress-chaos/helper/stress-helper.go
@@ -237,7 +237,7 @@ func prepareStressor(experimentDetails *experimentTypes.ExperimentDetails) []str
 			"CPU Core": experimentDetails.CPUcores,
 			"Timeout":  experimentDetails.ChaosDuration,
 		})
-		stressArgs = append(stressArgs, "--cpu "+strconv.Itoa(experimentDetails.CPUcores))
+		stressArgs = append(stressArgs, "--cpu "+strconv.Itoa(experimentDetails.CPUcores)+" --cpu-load "+strconv.Itoa(experimentDetails.CPULoad))
 
 	case "pod-memory-stress":
 
@@ -510,6 +510,7 @@ func getENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.ContainerRuntime = types.Getenv("CONTAINER_RUNTIME", "")
 	experimentDetails.SocketPath = types.Getenv("SOCKET_PATH", "")
 	experimentDetails.CPUcores, _ = strconv.Atoi(types.Getenv("CPU_CORES", ""))
+	experimentDetails.CPULoad, _ = strconv.Atoi(types.Getenv("CPU_LOAD", ""))
 	experimentDetails.FilesystemUtilizationPercentage, _ = strconv.Atoi(types.Getenv("FILESYSTEM_UTILIZATION_PERCENTAGE", ""))
 	experimentDetails.FilesystemUtilizationBytes, _ = strconv.Atoi(types.Getenv("FILESYSTEM_UTILIZATION_BYTES", ""))
 	experimentDetails.NumberOfWorkers, _ = strconv.Atoi(types.Getenv("NUMBER_OF_WORKERS", ""))

--- a/chaoslib/litmus/stress-chaos/lib/stress-chaos.go
+++ b/chaoslib/litmus/stress-chaos/lib/stress-chaos.go
@@ -291,6 +291,7 @@ func getPodEnv(experimentsDetails *experimentTypes.ExperimentDetails, podName st
 		SetEnv("EXPERIMENT_NAME", experimentsDetails.ExperimentName).
 		SetEnv("SOCKET_PATH", experimentsDetails.SocketPath).
 		SetEnv("CPU_CORES", strconv.Itoa(experimentsDetails.CPUcores)).
+		SetEnv("CPU_LOAD", strconv.Itoa(experimentsDetails.CPULoad)).
 		SetEnv("FILESYSTEM_UTILIZATION_PERCENTAGE", strconv.Itoa(experimentsDetails.FilesystemUtilizationPercentage)).
 		SetEnv("FILESYSTEM_UTILIZATION_BYTES", strconv.Itoa(experimentsDetails.FilesystemUtilizationBytes)).
 		SetEnv("NUMBER_OF_WORKERS", strconv.Itoa(experimentsDetails.NumberOfWorkers)).

--- a/pkg/generic/node-cpu-hog/environment/environment.go
+++ b/pkg/generic/node-cpu-hog/environment/environment.go
@@ -23,6 +23,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.InstanceID = types.Getenv("INSTANCE_ID", "")
 	experimentDetails.ChaosPodName = types.Getenv("POD_NAME", "")
 	experimentDetails.NodeCPUcores, _ = strconv.Atoi(types.Getenv("NODE_CPU_CORE", "0"))
+	experimentDetails.CPULoad, _ = strconv.Atoi(types.Getenv("CPU_LOAD", "100"))
 	experimentDetails.LIBImage = types.Getenv("LIB_IMAGE", "litmuschaos/go-runner:latest")
 	experimentDetails.LIBImagePullPolicy = types.Getenv("LIB_IMAGE_PULL_POLICY", "Always")
 	experimentDetails.AuxiliaryAppInfo = types.Getenv("AUXILIARY_APPINFO", "")

--- a/pkg/generic/node-cpu-hog/types/types.go
+++ b/pkg/generic/node-cpu-hog/types/types.go
@@ -20,6 +20,7 @@ type ExperimentDetails struct {
 	ChaosNamespace                string
 	ChaosPodName                  string
 	NodeCPUcores                  int
+	CPULoad                       int
 	RunID                         string
 	LIBImage                      string
 	LIBImagePullPolicy            string

--- a/pkg/generic/stress-chaos/environment/environment.go
+++ b/pkg/generic/stress-chaos/environment/environment.go
@@ -38,7 +38,8 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 
 	switch expName {
 	case "pod-cpu-hog":
-		experimentDetails.CPUcores, _ = strconv.Atoi(types.Getenv("CPU_CORES", "1"))
+		experimentDetails.CPUcores, _ = strconv.Atoi(types.Getenv("CPU_CORES", "0"))
+		experimentDetails.CPULoad, _ = strconv.Atoi(types.Getenv("CPU_LOAD", "100"))
 		experimentDetails.StressType = "pod-cpu-stress"
 
 	case "pod-memory-hog":

--- a/pkg/generic/stress-chaos/types/types.go
+++ b/pkg/generic/stress-chaos/types/types.go
@@ -33,6 +33,7 @@ type ExperimentDetails struct {
 	Sequence                        string
 	TerminationGracePeriodSeconds   int
 	CPUcores                        int
+	CPULoad                         int
 	FilesystemUtilizationPercentage int
 	FilesystemUtilizationBytes      int
 	NumberOfWorkers                 int


### PR DESCRIPTION
Signed-off-by: uditgaurav <udit@chaosnative.com>

**What this PR does / why we need it**:

- Add capability to run CPU chaos with the percentage of CPU cores. The enhancement will be added to pod-cpu-hog and node-cpu-hog experiments.

- This makes use of `--cpu-load` flag in the stress-ng command. The details are here:

#### Explanation

```
       -l P, --cpu-load P
              load  CPU  with  P  percent  loading for the CPU stress workers. 0 is effectively a
              sleep (no load) and 100 is full loading.  The loading loop is broken  into  compute
              time (load%) and sleep time (100% - load%). Accuracy depends on the overall load of
              the processor and the responsiveness of the scheduler, so the actual  load  may  be
              different  from  the desired load.  Note that the number of bogo CPU operations may
              not be linearly scaled with the load as some systems employ CPU  frequency  scaling
              and  so  heavier  loads  produce  an  increased  CPU frequency and greater CPU bogo
              operations.

              Note: This option only applies to the --cpu stressor option and not to all  of  the
              cpu class of stressors.
```


#### Example Command

```
stress-ng --cpu 0 --timeout 200s --cpu-load 90

one can specify 0 for the number of stressor processes to match the number of on-line CPUs, 
so to load each cpu at say 90%
```



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
