### PR TITLE
Add ChaosToolkit-CloudFoundry into litmus library

### DIFF
--- a/bin/experiment/experiment.go
+++ b/bin/experiment/experiment.go
@@ -17,6 +17,7 @@ import (
 	azureInstanceStop "github.com/litmuschaos/litmus-go/experiments/azure/instance-stop/experiment"
 	redfishNodeRestart "github.com/litmuschaos/litmus-go/experiments/baremetal/redfish-node-restart/experiment"
 	cassandraPodDelete "github.com/litmuschaos/litmus-go/experiments/cassandra/pod-delete/experiment"
+	chaosToolkit "github.com/litmuschaos/litmus-go/experiments/chaos-toolkit/experiment"
 	gcpVMDiskLoss "github.com/litmuschaos/litmus-go/experiments/gcp/gcp-vm-disk-loss/experiment"
 	gcpVMInstanceStop "github.com/litmuschaos/litmus-go/experiments/gcp/gcp-vm-instance-stop/experiment"
 	containerKill "github.com/litmuschaos/litmus-go/experiments/generic/container-kill/experiment"
@@ -82,6 +83,8 @@ func main() {
 
 	// invoke the corresponding experiment based on the the (-name) flag
 	switch *experimentName {
+	case "chaos-toolkit":
+		chaosToolkit.ChaosToolkit(clients)
 	case "container-kill":
 		containerKill.ContainerKill(clients)
 	case "disk-fill":

--- a/bin/helper/helper.go
+++ b/bin/helper/helper.go
@@ -11,6 +11,8 @@ import (
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/openstack"
 
+	chaosToolkit "github.com/litmuschaos/litmus-go/chaoslib/chaos-toolkit/helper"
+
 	containerKill "github.com/litmuschaos/litmus-go/chaoslib/litmus/container-kill/helper"
 	diskFill "github.com/litmuschaos/litmus-go/chaoslib/litmus/disk-fill/helper"
 	networkChaos "github.com/litmuschaos/litmus-go/chaoslib/litmus/network-chaos/helper"
@@ -58,7 +60,8 @@ func main() {
 		stressChaos.Helper(clients)
 	case "network-chaos":
 		networkChaos.Helper(clients)
-
+	case "chaos-toolkit":
+		chaosToolkit.Helper(clients)
 	default:
 		log.Errorf("Unsupported -name %v, please provide the correct value of -name args", *helperName)
 		return

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,12 +5,14 @@ FROM golang:alpine AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH
 
-ADD . /litmus-go
-WORKDIR /litmus-go
-
 RUN export GOOS=${TARGETOS} && \
     export GOARCH=${TARGETARCH}
 
+COPY go.mod go.sum /litmus-go/
+WORKDIR /litmus-go
+RUN go mod download
+
+ADD . /litmus-go
 RUN CGO_ENABLED=0 go build -o /output/experiments ./bin/experiment
 RUN CGO_ENABLED=0 go build -o /output/helpers ./bin/helper
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -36,3 +36,4 @@ COPY --from=dep /sbin/tc /sbin/
 
 #Copying Necessary Files
 COPY ./pkg/cloud/aws/common/ssm-docs/LitmusChaos-AWS-SSM-Docs.yml ./litmus/LitmusChaos-AWS-SSM-Docs.yml
+ADD build/chaos-experiments/ .

--- a/build/chaos-experiments/app-stats.json
+++ b/build/chaos-experiments/app-stats.json
@@ -1,0 +1,56 @@
+{
+  "version": "1.0.0",
+  "title": "stat app",
+  "description": "Ce test permet de récupérer les stats d'une app",
+  "tags": [],
+  "configuration": {
+    "cf_api_url": {
+      "type": "env",
+      "key": "CLOUD_FOUNDRY_URL"
+    },
+    "app_name": {
+      "type": "env",
+      "key": "APP_NAME"
+    },
+    "org_name": {
+      "type": "env",
+      "key": "ORG_NAME"
+    },
+    "space_name": {
+      "type": "env",
+      "key": "SPACE_NAME"
+    },
+    "cf_verify_ssl": false
+  },
+  "secrets": {
+    "cloudfoundry": {
+      "cf_username": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_USERNAME"
+      },
+      "cf_password": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_PASSWORD"
+      }
+    }
+  },
+  "method": [
+    {
+      "type": "probe",
+      "name": "get_app_stats",
+      "provider": {
+        "type": "python",
+        "secrets": [
+          "cloudfoundry"
+        ],
+        "module": "chaoscf.probes",
+        "func": "get_app_stats",
+        "arguments": {
+          "app_name": "${app_name}",
+          "org_name": "${org_name}",
+          "space_name": "${space_name}"
+        }
+      }
+    }
+  ]
+}

--- a/build/chaos-experiments/kill-app-instance.json
+++ b/build/chaos-experiments/kill-app-instance.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0.0",
+  "title": "Arrêt d'une instance d'une app",
+  "description": "Ce test consiste à stopper l'instance d'une app",
+  "tags": [],
+  "configuration": {
+    "cf_api_url": {
+      "type": "env",
+      "key": "CLOUD_FOUNDRY_URL"
+    },
+    "app_name": {
+      "type": "env",
+      "key": "APP_NAME"
+    },
+    "org_name": {
+      "type": "env",
+      "key": "ORG_NAME"
+    },
+    "space_name": {
+      "type": "env",
+      "key": "SPACE_NAME"
+    },
+    "cf_verify_ssl": false
+  },
+  "secrets": {
+    "cloudfoundry": {
+      "cf_username": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_USERNAME"
+      },
+      "cf_password": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_PASSWORD"
+      }
+    }
+  },
+  "method": [
+    {
+      "type": "action",
+      "name": "terminate_app_instance",
+      "provider": {
+        "type": "python",
+        "secrets": [
+          "cloudfoundry"
+        ],
+        "module": "chaoscf.actions",
+        "func": "terminate_app_instance",
+        "arguments": {
+          "app_name": "${app_name}",
+          "instance_index": 0,
+          "org_name": "${org_name}",
+          "space_name": "${space_name}"
+        }
+      }
+    }
+  ]
+}

--- a/build/chaos-experiments/random-kill-app-instance.json
+++ b/build/chaos-experiments/random-kill-app-instance.json
@@ -1,0 +1,56 @@
+{
+  "version": "1.0.0",
+  "title": "Arrêt aléatoire de certaines instances d'une",
+  "description": "Ce test consiste à stopper certaines instances de façon aléatoire dans une app",
+  "tags": [],
+  "configuration": {
+    "cf_api_url": {
+      "type": "env",
+      "key": "CLOUD_FOUNDRY_URL"
+    },
+    "app_name": {
+      "type": "env",
+      "key": "APP_NAME"
+    },
+    "org_name": {
+      "type": "env",
+      "key": "ORG_NAME"
+    },
+    "space_name": {
+      "type": "env",
+      "key": "SPACE_NAME"
+    },
+    "cf_verify_ssl": false
+  },
+  "secrets": {
+    "cloudfoundry": {
+      "cf_username": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_USERNAME"
+      },
+      "cf_password": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_PASSWORD"
+      }
+    }
+  },
+  "method": [
+    {
+      "type": "action",
+      "name": "terminate_some_random_instance",
+      "provider": {
+        "type": "python",
+        "secrets": [
+          "cloudfoundry"
+        ],
+        "module": "chaoscf.actions",
+        "func": "terminate_some_random_instance",
+        "arguments": {
+          "app_name": "${app_name}",
+          "org_name": "${org_name}",
+          "space_name": "${space_name}"
+        }
+      }
+    }
+  ]
+}

--- a/build/chaos-experiments/stop-all-apps.json
+++ b/build/chaos-experiments/stop-all-apps.json
@@ -1,0 +1,55 @@
+{
+  "version": "1.0.0",
+  "title": "Arrêt de toutes les apps d'un space",
+  "description": "Ce test consiste à stopper toutes les apps d'un space",
+  "tags": [],
+  "configuration": {
+    "cf_api_url": {
+      "type": "env",
+      "key": "CLOUD_FOUNDRY_URL"
+    },
+    "app_name": {
+      "type": "env",
+      "key": "APP_NAME"
+    },
+    "org_name": {
+      "type": "env",
+      "key": "ORG_NAME"
+    },
+    "space_name": {
+      "type": "env",
+      "key": "SPACE_NAME"
+    },
+    "cf_verify_ssl": false
+  },
+  "secrets": {
+    "cloudfoundry": {
+      "cf_username": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_USERNAME"
+      },
+      "cf_password": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_PASSWORD"
+      }
+    }
+  },
+  "method": [
+    {
+      "type": "action",
+      "name": "stop_all_apps",
+      "provider": {
+        "type": "python",
+        "secrets": [
+          "cloudfoundry"
+        ],
+        "module": "chaoscf.actions",
+        "func": "stop_all_apps",
+        "arguments": {
+          "org_name": "${org_name}",
+          "space_name": "${space_name}"
+        }
+      }
+    }
+  ]
+}

--- a/build/chaos-experiments/stop-apps.json
+++ b/build/chaos-experiments/stop-apps.json
@@ -1,0 +1,56 @@
+{
+  "version": "1.0.0",
+  "title": "Arrêt de d'une app",
+  "description": "Ce test consiste à stopper une app",
+  "tags": [],
+  "configuration": {
+    "cf_api_url": {
+      "type": "env",
+      "key": "CLOUD_FOUNDRY_URL"
+    },
+    "app_name": {
+      "type": "env",
+      "key": "APP_NAME"
+    },
+    "org_name": {
+      "type": "env",
+      "key": "ORG_NAME"
+    },
+    "space_name": {
+      "type": "env",
+      "key": "SPACE_NAME"
+    },
+    "cf_verify_ssl": false
+  },
+  "secrets": {
+    "cloudfoundry": {
+      "cf_username": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_USERNAME"
+      },
+      "cf_password": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_PASSWORD"
+      }
+    }
+  },
+  "method": [
+    {
+      "type": "action",
+      "name": "stop_app",
+      "provider": {
+        "type": "python",
+        "secrets": [
+          "cloudfoundry"
+        ],
+        "module": "chaoscf.actions",
+        "func": "stop_app",
+        "arguments": {
+          "app_name": "${app_name}",
+          "org_name": "${org_name}",
+          "space_name": "${space_name}"
+        }
+      }
+    }
+  ]
+}

--- a/build/chaos-experiments/unbind-apps.json
+++ b/build/chaos-experiments/unbind-apps.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0.0",
+  "title": "unbind d'un service d'une app",
+  "description": "Ce test consiste à unbind un service d'une app",
+  "tags": [],
+  "configuration": {
+    "cf_api_url": {
+      "type": "env",
+      "key": "CLOUD_FOUNDRY_URL"
+    },
+    "app_name": {
+      "type": "env",
+      "key": "APP_NAME"
+    },
+    "org_name": {
+      "type": "env",
+      "key": "ORG_NAME"
+    },
+    "space_name": {
+      "type": "env",
+      "key": "SPACE_NAME"
+    },
+    "cf_verify_ssl": false
+  },
+  "secrets": {
+    "cloudfoundry": {
+      "cf_username": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_USERNAME"
+      },
+      "cf_password": {
+        "type": "env",
+        "key": "CLOUD_FOUNDRY_PASSWORD"
+      }
+    }
+  },
+  "method": [
+    {
+      "type": "action",
+      "name": "unbind_service_from_app",
+      "provider": {
+        "type": "python",
+        "secrets": [
+          "cloudfoundry"
+        ],
+        "module": "chaoscf.actions",
+        "func": "unbind_service_from_app",
+        "arguments": {
+          "bind_name": "null",
+          "app_name": "${app_name}",
+          "org_name": "${org_name}",
+          "space_name": "${space_name}"
+        }
+      }
+    }
+  ]
+}

--- a/chaoslib/chaos-toolkit/helper/chaostoolkit.go
+++ b/chaoslib/chaos-toolkit/helper/chaostoolkit.go
@@ -1,0 +1,114 @@
+package helper
+
+import (
+	"bytes"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/litmuschaos/litmus-go/pkg/clients"
+	"github.com/litmuschaos/litmus-go/pkg/events"
+
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/chaos-toolkit/types"
+
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/result"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/litmuschaos/litmus-go/pkg/utils/common"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	clientTypes "k8s.io/apimachinery/pkg/types"
+)
+
+// Helper injects the container-kill chaos
+func Helper(clients clients.ClientSets) {
+
+	experimentsDetails := experimentTypes.ExperimentDetails{}
+	eventsDetails := types.EventDetails{}
+	chaosDetails := types.ChaosDetails{}
+	resultDetails := types.ResultDetails{}
+
+	//Fetching all the ENV passed in the helper pod
+	log.Info("[PreReq]: Getting the ENV variables")
+	getENV(&experimentsDetails)
+
+	// Intialise the chaos attributes
+	types.InitialiseChaosVariables(&chaosDetails)
+
+	// Intialise Chaos Result Parameters
+	types.SetResultAttributes(&resultDetails, chaosDetails)
+
+	err := execChaosToolkit(&experimentsDetails, clients, &eventsDetails, &chaosDetails, &resultDetails)
+	if err != nil {
+		log.Fatalf("helper pod failed, err: %v", err)
+	}
+}
+
+// killContainer kill the random application container
+// it will kill the container till the chaos duration
+// the execution will stop after timestamp passes the given chaos duration
+func execChaosToolkit(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails, resultDetails *types.ResultDetails) error {
+
+	//ChaosStartTimeStamp contains the start timestamp, when the chaos injection begin
+	ChaosStartTimeStamp := time.Now()
+	duration := int(time.Since(ChaosStartTimeStamp).Seconds())
+
+	for duration < experimentsDetails.ChaosDuration {
+
+		log.InfoWithValues("[Info]: Details of application under chaos injection", logrus.Fields{
+			"AppName":   experimentsDetails.AppName,
+			"OrgName":   experimentsDetails.OrgName,
+			"SpaceName": experimentsDetails.SpaceName,
+		})
+
+		// record the event inside chaosengine
+		if experimentsDetails.EngineName != "" {
+			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
+			types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
+			events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+		}
+
+		if err := execChaosToolkitCmd(experimentsDetails.ExperimentName); err != nil {
+			return err
+		}
+		//Waiting for the chaos interval after chaos injection
+		if experimentsDetails.ChaosInterval != 0 {
+			log.Infof("[Wait]: Wait for the chaos interval %vs", experimentsDetails.ChaosInterval)
+			common.WaitForDuration(experimentsDetails.ChaosInterval)
+		}
+
+		duration = int(time.Since(ChaosStartTimeStamp).Seconds())
+	}
+	if err := result.AnnotateChaosResult(resultDetails.Name, chaosDetails.ChaosNamespace, "targeted", "pod", experimentsDetails.AppName); err != nil {
+		return err
+	}
+	log.Infof("[Completion]: %v chaos has been completed", experimentsDetails.ExperimentName)
+	return nil
+}
+
+//stopDockerContainer kill the application container
+func execChaosToolkitCmd(experimentName string) error {
+	var errOut bytes.Buffer
+	cmd := exec.Command("chaos", "run", experimentName+".json")
+	cmd.Stderr = &errOut
+	if err := cmd.Run(); err != nil {
+		return errors.Errorf("Unable to run command, err: %v; error output: %v", err, errOut.String())
+	}
+	return nil
+}
+
+//getENV fetches all the env variables from the runner pod
+func getENV(experimentDetails *experimentTypes.ExperimentDetails) {
+	experimentDetails.ChaosDuration, _ = strconv.Atoi(types.Getenv("TOTAL_CHAOS_DURATION", "30"))
+	experimentDetails.ChaosNamespace = types.Getenv("CHAOS_NAMESPACE", "")
+	experimentDetails.EngineName = types.Getenv("CHAOSENGINE", "")
+	experimentDetails.ChaosUID = clientTypes.UID(types.Getenv("CHAOS_UID", ""))
+	experimentDetails.ChaosInterval, _ = strconv.Atoi(types.Getenv("CHAOS_INTERVAL", "10"))
+	experimentDetails.Delay, _ = strconv.Atoi(types.Getenv("STATUS_CHECK_DELAY", "30"))
+	experimentDetails.Timeout, _ = strconv.Atoi(types.Getenv("STATUS_CHECK_TIMEOUT", "180"))
+	experimentDetails.ExperimentName = types.Getenv("EXPERIMENT_NAME", "")
+	experimentDetails.ChaosNamespace = types.Getenv("INSTANCE_ID", "")
+	experimentDetails.AppName = types.Getenv("APP_NAME", "")
+	experimentDetails.OrgName = types.Getenv("ORG_NAME", "")
+	experimentDetails.SpaceName = types.Getenv("SPACE_NAME", "")
+}

--- a/chaoslib/chaos-toolkit/lib/chaos-toolkit.go
+++ b/chaoslib/chaos-toolkit/lib/chaos-toolkit.go
@@ -1,0 +1,191 @@
+package lib
+
+import (
+	"strconv"
+	"strings"
+
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/chaos-toolkit/types"
+	clients "github.com/litmuschaos/litmus-go/pkg/clients"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/probe"
+	"github.com/litmuschaos/litmus-go/pkg/status"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/litmuschaos/litmus-go/pkg/utils/common"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//PrepareChaosToolkit contains the prepration steps before chaos injection
+func PrepareChaosToolkit(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+	var err error
+	//Waiting for the ramp time before chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time before injecting chaos", experimentsDetails.RampTime)
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+
+	// Getting the serviceAccountName, need permission inside helper pod to create the events
+	if experimentsDetails.ChaosServiceAccount == "" {
+		experimentsDetails.ChaosServiceAccount, err = common.GetServiceAccount(experimentsDetails.ChaosNamespace, experimentsDetails.ChaosPodName, clients)
+		if err != nil {
+			return errors.Errorf("unable to get the serviceAccountName, err: %v", err)
+		}
+	}
+
+	switch strings.ToLower(experimentsDetails.Sequence) {
+	case "serial":
+		if err = injectChaosInSerialMode(experimentsDetails, clients, chaosDetails, resultDetails, eventsDetails); err != nil {
+			return err
+		}
+		//	case "parallel":
+		//		if err = injectChaosInParallelMode(experimentsDetails, targetPodList, clients, chaosDetails, resultDetails, eventsDetails); err != nil {
+		//			return err
+		//		}
+	default:
+		return errors.Errorf("%v sequence is not supported", experimentsDetails.Sequence)
+	}
+
+	//Waiting for the ramp time after chaos injection
+	if experimentsDetails.RampTime != 0 {
+		log.Infof("[Ramp]: Waiting for the %vs ramp time after injecting chaos", experimentsDetails.RampTime)
+		common.WaitForDuration(experimentsDetails.RampTime)
+	}
+	return nil
+}
+
+// injectChaosInSerialMode kill the container of all target application serially (one by one)
+func injectChaosInSerialMode(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, chaosDetails *types.ChaosDetails, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails) error {
+
+	labelSuffix := common.GetRunID()
+
+	// run the probes during chaos
+	if len(resultDetails.ProbeDetails) != 0 {
+		if err := probe.RunProbes(chaosDetails, clients, resultDetails, "DuringChaos", eventsDetails); err != nil {
+			return err
+		}
+	}
+
+	log.InfoWithValues("[Info]: Details of application under chaos injection", logrus.Fields{
+		"AppName":   experimentsDetails.AppName,
+		"OrgName":   experimentsDetails.OrgName,
+		"SpaceName": experimentsDetails.SpaceName,
+	})
+
+	runID := common.GetRunID()
+	if err := createHelperPod(experimentsDetails, clients, chaosDetails, runID, labelSuffix); err != nil {
+		return errors.Errorf("unable to create the helper pod, err: %v", err)
+	}
+
+	appLabel := "name=" + experimentsDetails.ExperimentName + "-helper-" + runID
+
+	//checking the status of the helper pods, wait till the pod comes to running state else fail the experiment
+	log.Info("[Status]: Checking the status of the helper pods")
+	if err := status.CheckHelperStatus(experimentsDetails.ChaosNamespace, appLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
+		common.DeleteHelperPodBasedOnJobCleanupPolicy(experimentsDetails.ExperimentName+"-helper-"+runID, appLabel, chaosDetails, clients)
+		return errors.Errorf("helper pods are not in running state, err: %v", err)
+	}
+
+	// Wait till the completion of the helper pod
+	// set an upper limit for the waiting time
+	log.Info("[Wait]: waiting till the completion of the helper pod")
+	podStatus, err := status.WaitForCompletion(experimentsDetails.ChaosNamespace, appLabel, clients, experimentsDetails.ChaosDuration+experimentsDetails.Timeout, experimentsDetails.ExperimentName)
+	if err != nil || podStatus == "Failed" {
+		common.DeleteHelperPodBasedOnJobCleanupPolicy(experimentsDetails.ExperimentName+"-helper-"+runID, appLabel, chaosDetails, clients)
+		return common.HelperFailedError(err)
+	}
+
+	/*
+		//Deleting all the helper pod for container-kill chaos
+		log.Info("[Cleanup]: Deleting all the helper pods")
+		if err = common.DeletePod(experimentsDetails.ExperimentName+"-helper-"+runID, appLabel, experimentsDetails.ChaosNamespace, chaosDetails.Timeout, chaosDetails.Delay, clients); err != nil {
+			return errors.Errorf("unable to delete the helper pod, err: %v", err)
+		}
+	*/
+	return nil
+}
+
+// createHelperPod derive the attributes for helper pod and create the helper pod
+func createHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, chaosDetails *types.ChaosDetails, runID, labelSuffix string) error {
+
+	chaosDetails.Labels = make(map[string]string, 2)
+
+	privilegedEnable := false
+	terminationGracePeriodSeconds := int64(experimentsDetails.TerminationGracePeriodSeconds)
+
+	helperPod := &apiv1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        experimentsDetails.ExperimentName + "-helper-" + runID,
+			Namespace:   experimentsDetails.ChaosNamespace,
+			Labels:      common.GetHelperLabels(chaosDetails.Labels, runID, labelSuffix, experimentsDetails.ExperimentName),
+			Annotations: chaosDetails.Annotations,
+		},
+		Spec: apiv1.PodSpec{
+			ServiceAccountName:            experimentsDetails.ChaosServiceAccount,
+			ImagePullSecrets:              chaosDetails.ImagePullSecrets,
+			RestartPolicy:                 apiv1.RestartPolicyNever,
+			TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
+			Containers: []apiv1.Container{
+				{
+					Name:            experimentsDetails.ExperimentName,
+					Image:           experimentsDetails.LIBImage,
+					ImagePullPolicy: apiv1.PullPolicy(experimentsDetails.LIBImagePullPolicy),
+					Command: []string{
+						"/bin/bash",
+					},
+					Args: []string{
+						"-c",
+						"./helpers -name chaos-toolkit",
+					},
+					/*					Command: []string{
+											"chaos",
+										},
+										Args: []string{
+											"run",
+											experimentsDetails.ExperimentName+".json",
+										},
+					*/
+					Resources: chaosDetails.Resources,
+					Env:       getPodEnv(experimentsDetails),
+					EnvFrom: []apiv1.EnvFromSource{
+						{
+							SecretRef: &apiv1.SecretEnvSource{
+								LocalObjectReference: apiv1.LocalObjectReference{
+									Name: experimentsDetails.CredentialsSecretName,
+								},
+							},
+						},
+					},
+					SecurityContext: &apiv1.SecurityContext{
+						Privileged: &privilegedEnable,
+					},
+				},
+			},
+		},
+	}
+
+	_, err := clients.KubeClient.CoreV1().Pods(experimentsDetails.ChaosNamespace).Create(helperPod)
+	return err
+}
+
+// getPodEnv derive all the env required for the helper pod
+func getPodEnv(experimentsDetails *experimentTypes.ExperimentDetails) []apiv1.EnvVar {
+
+	var envDetails common.ENVDetails
+	envDetails.SetEnv("TOTAL_CHAOS_DURATION", strconv.Itoa(experimentsDetails.ChaosDuration)).
+		SetEnv("CHAOS_NAMESPACE", experimentsDetails.ChaosNamespace).
+		SetEnv("CHAOSENGINE", experimentsDetails.EngineName).
+		SetEnv("CHAOS_UID", string(experimentsDetails.ChaosUID)).
+		SetEnv("CHAOS_INTERVAL", strconv.Itoa(experimentsDetails.ChaosInterval)).
+		SetEnv("STATUS_CHECK_DELAY", strconv.Itoa(experimentsDetails.Delay)).
+		SetEnv("STATUS_CHECK_TIMEOUT", strconv.Itoa(experimentsDetails.Timeout)).
+		SetEnv("EXPERIMENT_NAME", experimentsDetails.ExperimentName).
+		SetEnv("INSTANCE_ID", experimentsDetails.InstanceID).
+		SetEnv("APP_NAME", experimentsDetails.AppName).
+		SetEnv("ORG_NAME", experimentsDetails.OrgName).
+		SetEnv("SPACE_NAME", experimentsDetails.SpaceName).
+		SetEnvFromDownwardAPI("v1", "metadata.name")
+
+	return envDetails.ENV
+}

--- a/experiments/chaos-toolkit/README.md
+++ b/experiments/chaos-toolkit/README.md
@@ -1,0 +1,15 @@
+## Experiment Metadata
+
+<table>
+<tr>
+<th> Name </th>
+<th> Description </th>
+<th> Documentation Link </th>
+</tr>
+<tr>
+ <td> Chaos-Toolkit </td>
+ <td> This experiment executes experiments from chaos-toolkit cloud-foundry plugins. </td>
+ <td> <a href="https://litmuschaos.github.io/litmus/experiments/categories/chaostoolkit/"> Here </a> </td>
+ </tr>
+ </table>
+

--- a/experiments/chaos-toolkit/experiment/chaos-toolkit.go
+++ b/experiments/chaos-toolkit/experiment/chaos-toolkit.go
@@ -1,0 +1,163 @@
+package experiment
+
+import (
+	"os"
+
+	"github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+	litmusLIB "github.com/litmuschaos/litmus-go/chaoslib/chaos-toolkit/lib"
+	experimentEnv "github.com/litmuschaos/litmus-go/pkg/chaos-toolkit/environment"
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/chaos-toolkit/types"
+	clients "github.com/litmuschaos/litmus-go/pkg/clients"
+	"github.com/litmuschaos/litmus-go/pkg/events"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/probe"
+	"github.com/litmuschaos/litmus-go/pkg/result"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/litmuschaos/litmus-go/pkg/utils/common"
+	"github.com/sirupsen/logrus"
+)
+
+// ContainerKill inject the container-kill chaos
+func ChaosToolkit(clients clients.ClientSets) {
+
+	experimentsDetails := experimentTypes.ExperimentDetails{}
+	resultDetails := types.ResultDetails{}
+	eventsDetails := types.EventDetails{}
+	chaosDetails := types.ChaosDetails{}
+
+	//Fetching all the ENV passed from the runner pod
+	log.Infof("[PreReq]: Getting the ENV for the %v experiment", os.Getenv("EXPERIMENT_NAME"))
+	experimentEnv.GetENV(&experimentsDetails)
+
+	// Initialize the chaos attributes
+	types.InitialiseChaosVariables(&chaosDetails)
+
+	// Initialize Chaos Result Parameters
+	types.SetResultAttributes(&resultDetails, chaosDetails)
+
+	if experimentsDetails.EngineName != "" {
+		// Initialize the probe details. Bail out upon error, as we haven't entered exp business logic yet
+		if err := probe.InitializeProbesInChaosResultDetails(&chaosDetails, clients, &resultDetails); err != nil {
+			log.Errorf("Unable to initialize the probes, err: %v", err)
+			return
+		}
+	}
+
+	//Updating the chaos result in the beginning of experiment
+	log.Infof("[PreReq]: Updating the chaos result of %v experiment (SOT)", experimentsDetails.ExperimentName)
+	if err := result.ChaosResult(&chaosDetails, clients, &resultDetails, "SOT"); err != nil {
+		log.Errorf("Unable to Create the Chaos Result, err: %v", err)
+		failStep := "[pre-chaos]: Failed to update the chaos result of container-kill experiment (SOT), err: " + err.Error()
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// Set the chaos result uid
+	result.SetResultUID(&resultDetails, clients, &chaosDetails)
+
+	// generating the event in chaosresult to marked the verdict as awaited
+	msg := "experiment: " + experimentsDetails.ExperimentName + ", Result: Awaited"
+	types.SetResultEventAttributes(&eventsDetails, types.AwaitedVerdict, msg, "Normal", &resultDetails)
+	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
+
+	//DISPLAY THE APP INFORMATION
+	log.InfoWithValues("The application information is as follows", logrus.Fields{
+		"AppName":   experimentsDetails.AppName,
+		"OrgName":   experimentsDetails.OrgName,
+		"SpaceName": experimentsDetails.SpaceName,
+	})
+
+	// Calling AbortWatcher go routine, it will continuously watch for the abort signal and generate the required events and result
+	go common.AbortWatcher(experimentsDetails.ExperimentName, clients, &resultDetails, &chaosDetails, &eventsDetails)
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := common.GetStatusMessage(chaosDetails.DefaultAppHealthCheck, "AUT: Running", "")
+
+		// run the probes in the pre-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+
+			if err := probe.RunProbes(&chaosDetails, clients, &resultDetails, "PreChaos", &eventsDetails); err != nil {
+				log.Errorf("Probes Failed, err: %v", err)
+				failStep := "[pre-chaos]: Failed while running probes, err: " + err.Error()
+				msg = common.GetStatusMessage(chaosDetails.DefaultAppHealthCheck, "AUT: Running", "Unsuccessful")
+				types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = common.GetStatusMessage(chaosDetails.DefaultAppHealthCheck, "AUT: Running", "Successful")
+		}
+		// generating the events for the pre-chaos check
+		types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	// Including the litmus lib for container-kill
+	switch {
+	case experimentsDetails.ChaosLib == "litmus":
+		if err := litmusLIB.PrepareChaosToolkit(&experimentsDetails, clients, &resultDetails, &eventsDetails, &chaosDetails); err != nil {
+			failStep := "[chaos]: Failed inside the chaoslib, err: " + err.Error()
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			log.Errorf("Chaos injection failed, err: %v", err)
+			return
+		}
+	default:
+		failStep := "[chaos]: lib and container-runtime combination not supported!"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		log.Error("lib and container-runtime combination not supported, provide the correct value of lib & container-runtime")
+		return
+	}
+
+	log.Infof("[Confirmation]: %v chaos has been injected successfully", experimentsDetails.ExperimentName)
+	resultDetails.Verdict = v1alpha1.ResultVerdictPassed
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := common.GetStatusMessage(chaosDetails.DefaultAppHealthCheck, "AUT: Running", "")
+
+		// run the probes in the post-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+			if err := probe.RunProbes(&chaosDetails, clients, &resultDetails, "PostChaos", &eventsDetails); err != nil {
+				log.Errorf("Probe Failed, err: %v", err)
+				failStep := "[post-chaos]: Failed while running probes, err: " + err.Error()
+				msg = common.GetStatusMessage(chaosDetails.DefaultAppHealthCheck, "AUT: Running", "Unsuccessful")
+				types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = common.GetStatusMessage(chaosDetails.DefaultAppHealthCheck, "AUT: Running", "Successful")
+		}
+
+		// generating post chaos event
+		types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	//Updating the chaosResult in the end of experiment
+	log.Infof("[The End]: Updating the chaos result of %v experiment (EOT)", experimentsDetails.ExperimentName)
+	if err := result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT"); err != nil {
+		log.Errorf("Unable to Update the Chaos Result, err: %v", err)
+		return
+	}
+
+	// generating the event in chaosresult to marked the verdict as pass/fail
+	msg = "experiment: " + experimentsDetails.ExperimentName + ", Result: " + string(resultDetails.Verdict)
+	reason := types.PassVerdict
+	eventType := "Normal"
+	if resultDetails.Verdict != "Pass" {
+		reason = types.FailVerdict
+		eventType = "Warning"
+	}
+
+	types.SetResultEventAttributes(&eventsDetails, reason, msg, eventType, &resultDetails)
+	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
+
+	if experimentsDetails.EngineName != "" {
+		msg := experimentsDetails.ExperimentName + " experiment has been " + string(resultDetails.Verdict) + "ed"
+		types.SetEngineEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+}

--- a/pkg/chaos-toolkit/environment/environment.go
+++ b/pkg/chaos-toolkit/environment/environment.go
@@ -1,0 +1,41 @@
+package environment
+
+import (
+	"strconv"
+
+	clientTypes "k8s.io/apimachinery/pkg/types"
+
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/chaos-toolkit/types"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+)
+
+//GetENV fetches all the env variables from the runner pod
+func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
+	experimentDetails.ExperimentName = types.Getenv("EXPERIMENT_NAME", "")
+
+	experimentDetails.ChaosNamespace = types.Getenv("CHAOS_NAMESPACE", "")
+	experimentDetails.EngineName = types.Getenv("CHAOSENGINE", "")
+	experimentDetails.ChaosUID = clientTypes.UID(types.Getenv("CHAOS_UID", ""))
+	experimentDetails.InstanceID = types.Getenv("INSTANCE_ID", "")
+	experimentDetails.Sequence = types.Getenv("SEQUENCE", "serial")
+
+	experimentDetails.ChaosDuration, _ = strconv.Atoi(types.Getenv("TOTAL_CHAOS_DURATION", "20"))
+	experimentDetails.ChaosInterval, _ = strconv.Atoi(types.Getenv("CHAOS_INTERVAL", "10"))
+	experimentDetails.RampTime, _ = strconv.Atoi(types.Getenv("RAMP_TIME", "0"))
+
+	experimentDetails.ChaosLib = types.Getenv("LIB", "litmus")
+	experimentDetails.ChaosServiceAccount = types.Getenv("CHAOS_SERVICE_ACCOUNT", "")
+	experimentDetails.LIBImagePullPolicy = types.Getenv("LIB_IMAGE_PULL_POLICY", "Always")
+	experimentDetails.LIBImage = types.Getenv("LIB_IMAGE", "litmuschaos/go-runner:latest")
+
+	experimentDetails.Delay, _ = strconv.Atoi(types.Getenv("STATUS_CHECK_DELAY", "2"))
+	experimentDetails.Timeout, _ = strconv.Atoi(types.Getenv("STATUS_CHECK_TIMEOUT", "180"))
+	experimentDetails.TerminationGracePeriodSeconds, _ = strconv.Atoi(types.Getenv("TERMINATION_GRACE_PERIOD_SECONDS", ""))
+
+	experimentDetails.AppName = types.Getenv("APP_NAME", "")
+	experimentDetails.OrgName = types.Getenv("ORG_NAME", "")
+	experimentDetails.SpaceName = types.Getenv("SPACE_NAME", "")
+
+	experimentDetails.CredentialsSecretName = types.Getenv("SECRET_NAME", "cloud-foundry-credentials")
+
+}

--- a/pkg/chaos-toolkit/types/types.go
+++ b/pkg/chaos-toolkit/types/types.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	clientTypes "k8s.io/apimachinery/pkg/types"
+)
+
+// ExperimentDetails is for collecting all the experiment-related details
+type ExperimentDetails struct {
+	ExperimentName                string
+	EngineName                    string
+	ChaosDuration                 int
+	ChaosInterval                 int
+	RampTime                      int
+	ChaosLib                      string
+	ChaosUID                      clientTypes.UID
+	TerminationGracePeriodSeconds int
+	InstanceID                    string
+	ChaosNamespace                string
+	ChaosPodName                  string
+	LIBImage                      string
+	LIBImagePullPolicy            string
+	ChaosServiceAccount           string
+	RunID                         string
+	Timeout                       int
+	Delay                         int
+	Sequence                      string
+	AppName                       string
+	OrgName                       string
+	SpaceName                     string
+	CredentialsSecretName         string
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Its add ChaosToolkit-CloudFoundry into litmus library
Its optimize Docker build using cache layer for go deps

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Its require this MR to work -> https://github.com/litmuschaos/test-tools/pull/209
Its require to create a kubernetes secret 'cloud-foundry-credentials' into litmus-agent namespace that contain :
```
apiVersion: v1
kind: Secret
type: Opaque
metadata:
  name: cloud-foundry-credentials
data:
  CLOUD_FOUNDRY_PASSWORD:  "Password Base64"
  CLOUD_FOUNDRY_URL: "URL Base64"
  CLOUD_FOUNDRY_USERNAME: "Username Base64"
``` 
**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
