### PR TITLE
Fixing alpine's 40 CVEs by upgrading the version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage docker build
 # Build stage
-FROM golang:alpine AS builder
+FROM golang:1.16 AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH
@@ -14,7 +14,7 @@ RUN export GOOS=${TARGETOS} && \
 RUN CGO_ENABLED=0 go build -o /output/experiments ./bin/experiment
 RUN CGO_ENABLED=0 go build -o /output/helpers ./bin/helper
 
-FROM alpine:3.14.2 AS dep
+FROM alpine:3.15.0 AS dep
 
 # Install generally useful things
 RUN apk --update add \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Fixing alpine CVEs by upgrading the version

Docker scan

```
Organization:      imrajdas
Package manager:   apk
Project name:      docker-image|litmuschaos/litmus-go
Docker image:      litmuschaos/litmus-go:ci
Platform:          linux/amd64
Base image:        alpine:3.12.0
Licenses:          enabled

Tested 23 dependencies for known issues, found 40 issues.

Base Image     Vulnerabilities  Severity
alpine:3.12.0  22               2 critical, 14 high, 5 medium, 1 low

Recommendations for base image upgrade:

Minor upgrades
Base Image   Vulnerabilities  Severity
alpine:3.14  0                0 critical, 0 high, 0 medium, 0 low

```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
