### PR TITLE
Chore(cgroup): Add support for cgroup version2 in stress-chaos experiment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,12 +41,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/golang@master
+      - uses: snyk/actions/setup@master
+      - run: |
+          export SNYK_TOKEN=${{ secrets.SNYK_TOKEN }}
+          snyk auth
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.17'
+      - name: Snyk monitor
+        run: snyk test
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --severity-threshold=high     
+
+      # - uses: actions/checkout@master
+      # - name: Run Snyk to check for vulnerabilities
+      #   uses: snyk/actions/golang@master
+      #   env:
+      #     SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      #   with:
+      #     args: --severity-threshold=high     
+
 
   build:
     needs: pre-checks

--- a/chaoslib/litmus/stress-chaos/helper/stress-helper.go
+++ b/chaoslib/litmus/stress-chaos/helper/stress-helper.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/containerd/cgroups"
+	cgroupsv2 "github.com/containerd/cgroups/v2"
 	clients "github.com/litmuschaos/litmus-go/pkg/clients"
 	"github.com/litmuschaos/litmus-go/pkg/events"
 	experimentTypes "github.com/litmuschaos/litmus-go/pkg/generic/stress-chaos/types"
@@ -108,17 +109,9 @@ func prepareStressChaos(experimentsDetails *experimentTypes.ExperimentDetails, c
 			events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
 		}
 
-		//get the pid path and check cgroup
-		path := pidPath(targetPID)
-		cgroup, err := findValidCgroup(path, containerID)
+		cgroupManager, err := getCGroupManager(int(targetPID), containerID)
 		if err != nil {
-			return errors.Errorf("fail to get cgroup, err: %v", err)
-		}
-
-		// load the existing cgroup
-		control, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(cgroup))
-		if err != nil {
-			return errors.Errorf("fail to load the cgroup, err: %v", err)
+			return errors.Errorf("fail to get the cgroup manager, err: %v", err)
 		}
 
 		// get stressors in list format
@@ -143,7 +136,7 @@ func prepareStressChaos(experimentsDetails *experimentTypes.ExperimentDetails, c
 		go abortWatcher(cmd.Process.Pid, resultDetails.Name, chaosDetails.ChaosNamespace, experimentsDetails.TargetPods)
 
 		// add the stress process to the cgroup of target container
-		if err = control.Add(cgroups.Process{Pid: cmd.Process.Pid}); err != nil {
+		if err = addProcessToCgroup(cmd.Process.Pid, cgroupManager); err != nil {
 			if killErr := cmd.Process.Kill(); killErr != nil {
 				return errors.Errorf("stressors failed killing %v process, err: %v", cmd.Process.Pid, killErr)
 			}
@@ -541,4 +534,42 @@ func abortWatcher(targetPID int, resultName, chaosNS, targetPodName string) {
 	}
 	log.Info("[Abort]: Chaos Revert Completed")
 	os.Exit(1)
+}
+
+// getCGroupManager will return the cgroup for the given pid of the process
+func getCGroupManager(pid int, containerID string) (interface{}, error) {
+	if cgroups.Mode() == cgroups.Unified {
+		groupPath, err := cgroupsv2.PidGroupPath(pid)
+		if err != nil {
+			return nil, errors.Errorf("Error in getting groupPath, %v", err)
+		}
+
+		cgroup2, err := cgroupsv2.LoadManager("/sys/fs/cgroup", groupPath)
+		if err != nil {
+			return nil, errors.Errorf("Error loading cgroup v2 manager, %v", err)
+		}
+		return cgroup2, nil
+	}
+	path := pidPath(pid)
+	cgroup, err := findValidCgroup(path, containerID)
+	if err != nil {
+		return nil, errors.Errorf("fail to get cgroup, err: %v", err)
+	}
+	cgroup1, err := cgroups.Load(cgroups.V1, cgroups.StaticPath(cgroup))
+	if err != nil {
+		return nil, errors.Errorf("fail to load the cgroup, err: %v", err)
+	}
+
+	return cgroup1, nil
+}
+
+// addProcessToCgroup will add the process to cgroup
+// By default it will add to v1 cgroup
+func addProcessToCgroup(pid int, control interface{}) error {
+	if cgroups.Mode() == cgroups.Unified {
+		var cgroup1 = control.(*cgroupsv2.Manager)
+		return cgroup1.AddProc(uint64(pid))
+	}
+	var cgroup1 = control.(cgroups.Cgroup)
+	return cgroup1.Add(cgroups.Process{Pid: pid})
 }

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,7 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.0.0-20191025125908-95b36a581eed/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
+github.com/cilium/ebpf v0.4.0 h1:QlHdikaxALkqWasW8hAC1mfR0jdmvbfaBdBPFmRSglA=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cfssl v0.0.0-20180726162950-56268a613adf/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
@@ -307,6 +308,7 @@ github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7RHGAyAK3EP2EsNk=


### PR DESCRIPTION
Signed-off-by: uditgaurav <udit@chaosnative.com>

**What this PR does / why we need it**:

- The current cgroup in the stress chaos experiment only supports version v1. This PR will add support for the containers that are running with cgroup version v2.
- Get more details here about cgroup version 2- https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
- Now by default for running stress chaos the experiment looks for containers with cgroup of version v1 but has a check to support v2 as well.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
