### PR TITLE
Chore(ssm): Update the ssm file path in the Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -33,4 +33,4 @@ COPY --from=dep /usr/bin/sudo /usr/bin/
 COPY --from=dep /sbin/tc /sbin/
 
 #Copying Necessary Files
-COPY ./pkg/cloud/aws/common/ssm-docs/LitmusChaos-AWS-SSM-Docs.yml ./litmus/LitmusChaos-AWS-SSM-Docs.yml
+COPY ./pkg/cloud/aws/common/ssm-docs/LitmusChaos-AWS-SSM-Docs.yml .


### PR DESCRIPTION
Signed-off-by: uditgaurav <udit@chaosnative.com>

**What this PR does / why we need it**:

- This PR changes the directory of the SSM file - it is done so because now the base image is having a default directory of /litmus so we don't need to copy the SSM docs now in /litmus otherwise it will result in the directory structure as follow: /litmus/litmus/SSM-Chaos 

- The changes are according to the default SSM values and docs.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
