### PR TITLE
Add --stress-image for stressArgs for pumba lib

### DIFF
--- a/chaoslib/pumba/pod-io-stress/lib/pod-io-stress.go
+++ b/chaoslib/pumba/pod-io-stress/lib/pod-io-stress.go
@@ -291,6 +291,8 @@ func getContainerArguments(experimentsDetails *experimentTypes.ExperimentDetails
 		"stress",
 		"--duration",
 		strconv.Itoa(experimentsDetails.ChaosDuration) + "s",
+		"--stress-image",
+		experimentsDetails.StressImage,
 		"--stressors",
 	}
 	args := stressArgs


### PR DESCRIPTION
Signed-off-by: Jimmy Zhang <zhang.artur@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

Add --stress-image for stressArgs when calling pumba lib

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

fixes #3610
https://github.com/litmuschaos/litmus/issues/3610 

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
