### PR TITLE
Chore[Fix]: Node uncordon when app status check failed inside lib

### DIFF
--- a/chaoslib/litmus/node-drain/lib/node-drain.go
+++ b/chaoslib/litmus/node-drain/lib/node-drain.go
@@ -81,6 +81,9 @@ func PrepareNodeDrain(experimentsDetails *experimentTypes.ExperimentDetails, cli
 	// Verify the status of AUT after reschedule
 	log.Info("[Status]: Verify the status of AUT after reschedule")
 	if err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
+		if err := uncordonNode(experimentsDetails, clients, chaosDetails); err != nil {
+			log.Errorf("Unable to uncordon the node, err: %v", err)
+		}
 		return errors.Errorf("application status check failed, err: %v", err)
 	}
 
@@ -88,6 +91,9 @@ func PrepareNodeDrain(experimentsDetails *experimentTypes.ExperimentDetails, cli
 	if experimentsDetails.AuxiliaryAppInfo != "" {
 		log.Info("[Status]: Verify that the Auxiliary Applications are running")
 		if err = status.CheckAuxiliaryApplicationStatus(experimentsDetails.AuxiliaryAppInfo, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
+			if err := uncordonNode(experimentsDetails, clients, chaosDetails); err != nil {
+				log.Errorf("Unable to uncordon the node, err: %v", err)
+			}
 			return errors.Errorf("auxiliary Applications status check failed, err: %v", err)
 		}
 	}

--- a/chaoslib/litmus/node-drain/lib/node-drain.go
+++ b/chaoslib/litmus/node-drain/lib/node-drain.go
@@ -80,7 +80,7 @@ func PrepareNodeDrain(experimentsDetails *experimentTypes.ExperimentDetails, cli
 	// Verify the status of AUT after reschedule
 	log.Info("[Status]: Verify the status of AUT after reschedule")
 	if err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
-		log.Info("Reverting chaos because application status check failed")
+		log.Info("[Revert]: Reverting chaos because application status check failed")
 		if uncordonErr := uncordonNode(experimentsDetails, clients, chaosDetails); uncordonErr != nil {
 			log.Errorf("Unable to uncordon the node, err: %v", uncordonErr)
 		}
@@ -91,7 +91,7 @@ func PrepareNodeDrain(experimentsDetails *experimentTypes.ExperimentDetails, cli
 	if experimentsDetails.AuxiliaryAppInfo != "" {
 		log.Info("[Status]: Verify that the Auxiliary Applications are running")
 		if err = status.CheckAuxiliaryApplicationStatus(experimentsDetails.AuxiliaryAppInfo, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
-			log.Info("Reverting chaos because auxiliary application status check failed")
+			log.Info("[Revert]: Reverting chaos because auxiliary application status check failed")
 			if uncordonErr := uncordonNode(experimentsDetails, clients, chaosDetails); uncordonErr != nil {
 				log.Errorf("Unable to uncordon the node, err: %v", uncordonErr)
 			}

--- a/chaoslib/litmus/node-drain/lib/node-drain.go
+++ b/chaoslib/litmus/node-drain/lib/node-drain.go
@@ -21,7 +21,6 @@ import (
 	"github.com/litmuschaos/litmus-go/pkg/utils/retry"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -81,6 +80,7 @@ func PrepareNodeDrain(experimentsDetails *experimentTypes.ExperimentDetails, cli
 	// Verify the status of AUT after reschedule
 	log.Info("[Status]: Verify the status of AUT after reschedule")
 	if err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
+		log.Info("Reverting chaos because application status check failed")
 		if uncordonErr := uncordonNode(experimentsDetails, clients, chaosDetails); uncordonErr != nil {
 			log.Errorf("Unable to uncordon the node, err: %v", uncordonErr)
 		}
@@ -91,6 +91,7 @@ func PrepareNodeDrain(experimentsDetails *experimentTypes.ExperimentDetails, cli
 	if experimentsDetails.AuxiliaryAppInfo != "" {
 		log.Info("[Status]: Verify that the Auxiliary Applications are running")
 		if err = status.CheckAuxiliaryApplicationStatus(experimentsDetails.AuxiliaryAppInfo, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
+			log.Info("Reverting chaos because auxiliary application status check failed")
 			if uncordonErr := uncordonNode(experimentsDetails, clients, chaosDetails); uncordonErr != nil {
 				log.Errorf("Unable to uncordon the node, err: %v", uncordonErr)
 			}
@@ -162,7 +163,7 @@ func uncordonNode(experimentsDetails *experimentTypes.ExperimentDetails, clients
 	for _, targetNode := range targetNodes {
 
 		//Check node exist before uncordon the node
-		_, err := clients.KubeClient.CoreV1().Nodes().Get(targetNode, metav1.GetOptions{})
+		_, err := clients.KubeClient.CoreV1().Nodes().Get(targetNode, v1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				log.Infof("[Info]: The %v node is no longer exist, skip uncordon the node", targetNode)

--- a/chaoslib/litmus/node-drain/lib/node-drain.go
+++ b/chaoslib/litmus/node-drain/lib/node-drain.go
@@ -81,8 +81,8 @@ func PrepareNodeDrain(experimentsDetails *experimentTypes.ExperimentDetails, cli
 	// Verify the status of AUT after reschedule
 	log.Info("[Status]: Verify the status of AUT after reschedule")
 	if err = status.CheckApplicationStatus(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
-		if err := uncordonNode(experimentsDetails, clients, chaosDetails); err != nil {
-			log.Errorf("Unable to uncordon the node, err: %v", err)
+		if uncordonErr := uncordonNode(experimentsDetails, clients, chaosDetails); uncordonErr != nil {
+			log.Errorf("Unable to uncordon the node, err: %v", uncordonErr)
 		}
 		return errors.Errorf("application status check failed, err: %v", err)
 	}
@@ -91,8 +91,8 @@ func PrepareNodeDrain(experimentsDetails *experimentTypes.ExperimentDetails, cli
 	if experimentsDetails.AuxiliaryAppInfo != "" {
 		log.Info("[Status]: Verify that the Auxiliary Applications are running")
 		if err = status.CheckAuxiliaryApplicationStatus(experimentsDetails.AuxiliaryAppInfo, experimentsDetails.Timeout, experimentsDetails.Delay, clients); err != nil {
-			if err := uncordonNode(experimentsDetails, clients, chaosDetails); err != nil {
-				log.Errorf("Unable to uncordon the node, err: %v", err)
+			if uncordonErr := uncordonNode(experimentsDetails, clients, chaosDetails); uncordonErr != nil {
+				log.Errorf("Unable to uncordon the node, err: %v", uncordonErr)
 			}
 			return errors.Errorf("auxiliary Applications status check failed, err: %v", err)
 		}
@@ -127,7 +127,7 @@ func drainNode(experimentsDetails *experimentTypes.ExperimentDetails, clients cl
 	default:
 		log.Infof("[Inject]: Draining the %v node", experimentsDetails.TargetNode)
 
-		command := exec.Command("kubectl", "drain", experimentsDetails.TargetNode, "--ignore-daemonsets", "--delete-local-data", "--force", "--timeout", strconv.Itoa(experimentsDetails.ChaosDuration)+"s")
+		command := exec.Command("kubectl", "drain", experimentsDetails.TargetNode, "--ignore-daemonsets", "--delete-emptydir-data", "--force", "--timeout", strconv.Itoa(experimentsDetails.ChaosDuration)+"s")
 		var out, stderr bytes.Buffer
 		command.Stdout = &out
 		command.Stderr = &stderr


### PR DESCRIPTION
Signed-off-by: Akash Shrivastava <as86414@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
After draining the node, if the app and aux-app status check failed, the node wasn't being uncordoned as part of the revert. This PR fixes that issue by adding the uncordon node step if the app status check fails.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #520


**Checklist:**
-   [x] Fixes #520
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
