### PR TITLE
Add missing return to AnnotatedApplicationsStatusCheck

### DIFF
--- a/pkg/status/application.go
+++ b/pkg/status/application.go
@@ -55,7 +55,7 @@ func AnnotatedApplicationsStatusCheck(appNs, appLabel, containerName string, tim
 			if err != nil {
 				return errors.Errorf("Unable to find the pods with matching labels, err: %v", err)
 			} else if len(podList.Items) == 0 {
-				errors.Errorf("Unable to find the pods with matching labels")
+				return errors.Errorf("Unable to find the pods with matching labels")
 			}
 			for _, pod := range podList.Items {
 				parentName, err := annotation.GetParentName(clients, pod, chaosDetails)


### PR DESCRIPTION
Signed-off-by: Gonzalo Reyero Ferreras <greyerof@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Return statement missing on function AnnotatedApplicationsStatusCheck(). Otherwise, the function will do the `return nil` (line 103), making the Try function to (wrongly) succeed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] Commit has unit tests
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
