### PR TITLE
Chore[New exp]: HTTP Reset Peer experiment for K8s

### DIFF
--- a/bin/experiment/experiment.go
+++ b/bin/experiment/experiment.go
@@ -39,6 +39,7 @@ import (
 	podDNSSpoof "github.com/litmuschaos/litmus-go/experiments/generic/pod-dns-spoof/experiment"
 	podFioStress "github.com/litmuschaos/litmus-go/experiments/generic/pod-fio-stress/experiment"
 	podHttpLatency "github.com/litmuschaos/litmus-go/experiments/generic/pod-http-latency/experiment"
+	podHttpResetPeer "github.com/litmuschaos/litmus-go/experiments/generic/pod-http-reset-peer/experiment"
 	podIOStress "github.com/litmuschaos/litmus-go/experiments/generic/pod-io-stress/experiment"
 	podMemoryHogExec "github.com/litmuschaos/litmus-go/experiments/generic/pod-memory-hog-exec/experiment"
 	podMemoryHog "github.com/litmuschaos/litmus-go/experiments/generic/pod-memory-hog/experiment"
@@ -151,6 +152,8 @@ func main() {
 		podDNSSpoof.PodDNSSpoof(clients)
 	case "pod-http-latency":
 		podHttpLatency.PodHttpLatency(clients)
+	case "pod-http-reset-peer":
+		podHttpResetPeer.PodHttpResetPeer(clients)
 	case "vm-poweroff":
 		vmpoweroff.VMPoweroff(clients)
 	case "azure-instance-stop":

--- a/chaoslib/litmus/http-chaos/helper/http-helper.go
+++ b/chaoslib/litmus/http-chaos/helper/http-helper.go
@@ -155,18 +155,13 @@ func revertChaos(experimentDetails *experimentTypes.ExperimentDetails, pid int) 
 // and execute the proxy related command inside it.
 func startProxy(experimentDetails *experimentTypes.ExperimentDetails, pid int) error {
 
-	toxicCommands := os.Getenv("TOXIC_COMMAND")
+	toxics := os.Getenv("TOXIC_COMMAND")
 
 	// starting toxiproxy server inside the target container
 	startProxyServerCommand := fmt.Sprintf("(sudo nsenter -t %d -n toxiproxy-server -host=0.0.0.0 > /dev/null 2>&1 &)", pid)
 	// Creating a proxy for the targetted service in the target container
 	createProxyCommand := fmt.Sprintf("(sudo nsenter -t %d -n toxiproxy-cli create -l 0.0.0.0:%d -u 0.0.0.0:%d proxy)", pid, experimentDetails.ProxyPort, experimentDetails.TargetServicePort)
-	createToxicCommand := ""
-	switch experimentDetails.ExperimentName {
-	// preparing command for toxic addition based on HttpChaosType chosen by user
-	case "pod-http-latency":
-		createToxicCommand = fmt.Sprintf("(sudo nsenter -t %d -n toxiproxy-cli toxic add %s proxy)", pid, toxicCommands)
-	}
+	createToxicCommand := fmt.Sprintf("(sudo nsenter -t %d -n toxiproxy-cli toxic add %s proxy)", pid, toxics)
 
 	// sleep 10 is added for proxy-server to be ready for creating proxy and adding toxics
 	chaosCommand := fmt.Sprintf("%s && sleep 10 && %s && %s", startProxyServerCommand, createProxyCommand, createToxicCommand)

--- a/chaoslib/litmus/http-chaos/lib/http-chaos.go
+++ b/chaoslib/litmus/http-chaos/lib/http-chaos.go
@@ -42,6 +42,8 @@ func PrepareAndInjectChaos(experimentsDetails *experimentTypes.ExperimentDetails
 
 	case "pod-http-latency":
 		log.Infof("[Info]: Latency=%v", strconv.Itoa(experimentsDetails.Latency))
+	case "pod-http-reset-peer":
+		log.Infof("[Info]: Reset Timeout=%v", strconv.Itoa(experimentsDetails.ResetTimeout))
 	}
 	podsAffectedPerc, _ = strconv.Atoi(experimentsDetails.PodsAffectedPerc)
 	if experimentsDetails.NodeLabel == "" {

--- a/chaoslib/litmus/http-chaos/lib/reset/reset.go
+++ b/chaoslib/litmus/http-chaos/lib/reset/reset.go
@@ -1,0 +1,17 @@
+package reset
+
+import (
+	"strconv"
+
+	http_chaos "github.com/litmuschaos/litmus-go/chaoslib/litmus/http-chaos/lib"
+	clients "github.com/litmuschaos/litmus-go/pkg/clients"
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/generic/http-chaos/types"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+)
+
+//PodHttpResetPeerChaos contains the steps to prepare and inject http latency chaos
+func PodHttpResetPeerChaos(experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+
+	args := "-t reset_peer -a timeout=" + strconv.Itoa(experimentsDetails.ResetTimeout)
+	return http_chaos.PrepareAndInjectChaos(experimentsDetails, clients, resultDetails, eventsDetails, chaosDetails, args)
+}

--- a/experiments/generic/pod-http-reset-peer/README.md
+++ b/experiments/generic/pod-http-reset-peer/README.md
@@ -1,0 +1,14 @@
+## Experiment Metadata
+
+<table>
+<tr>
+<th> Name </th>
+<th> Description </th>
+<th> Documentation Link </th>
+</tr>
+<tr>
+ <td> Pod HTTP Reset Peer </td>
+ <td>This experiment causes tcp reset in http request on the specified container by starting a proxy server and then redirecting the traffic to the proxy server. It Can test the application's resilience to lossy/flaky requests to dependant services.</td>
+ <td>  <a href="https://litmuschaos.github.io/litmus/experiments/categories/pods/pod-http-reset-peer/"> Here </a> </td>
+ </tr>
+ </table>

--- a/experiments/generic/pod-http-reset-peer/experiment/pod-http-reset-peer.go
+++ b/experiments/generic/pod-http-reset-peer/experiment/pod-http-reset-peer.go
@@ -18,8 +18,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Experiment contains steps to inject chaos
-func Experiment(clients clients.ClientSets) {
+// PodHttpResetPeer contains steps to inject chaos
+func PodHttpResetPeer(clients clients.ClientSets) {
 
 	experimentsDetails := experimentTypes.ExperimentDetails{}
 	resultDetails := types.ResultDetails{}

--- a/experiments/generic/pod-http-reset-peer/experiment/pod-http-reset-peer.go
+++ b/experiments/generic/pod-http-reset-peer/experiment/pod-http-reset-peer.go
@@ -1,0 +1,190 @@
+package experiment
+
+import (
+	"os"
+
+	"github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+	litmusLIB "github.com/litmuschaos/litmus-go/chaoslib/litmus/http-chaos/lib/reset"
+	clients "github.com/litmuschaos/litmus-go/pkg/clients"
+	"github.com/litmuschaos/litmus-go/pkg/events"
+	experimentEnv "github.com/litmuschaos/litmus-go/pkg/generic/http-chaos/environment"
+	experimentTypes "github.com/litmuschaos/litmus-go/pkg/generic/http-chaos/types"
+	"github.com/litmuschaos/litmus-go/pkg/log"
+	"github.com/litmuschaos/litmus-go/pkg/probe"
+	"github.com/litmuschaos/litmus-go/pkg/result"
+	"github.com/litmuschaos/litmus-go/pkg/status"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/litmuschaos/litmus-go/pkg/utils/common"
+	"github.com/sirupsen/logrus"
+)
+
+// Experiment contains steps to inject chaos
+func Experiment(clients clients.ClientSets) {
+
+	experimentsDetails := experimentTypes.ExperimentDetails{}
+	resultDetails := types.ResultDetails{}
+	eventsDetails := types.EventDetails{}
+	chaosDetails := types.ChaosDetails{}
+
+	//Fetching all the ENV passed from the runner pod
+	log.Infof("[PreReq]: Getting the ENV for the %v experiment", os.Getenv("EXPERIMENT_NAME"))
+	experimentEnv.GetENV(&experimentsDetails, "pod-http-reset-peer")
+
+	// Initialize the chaos attributes
+	types.InitialiseChaosVariables(&chaosDetails)
+
+	// Initialize Chaos Result Parameters
+	types.SetResultAttributes(&resultDetails, chaosDetails)
+
+	if experimentsDetails.EngineName != "" {
+		// Initialize the probe details. Bail out upon error, as we haven't entered exp business logic yet
+		if err := probe.InitializeProbesInChaosResultDetails(&chaosDetails, clients, &resultDetails); err != nil {
+			log.Errorf("Unable to initialize the probes, err: %v", err)
+			return
+		}
+	}
+
+	//Updating the chaos result in the beginning of experiment
+	log.Infof("[PreReq]: Updating the chaos result of %v experiment (SOT)", experimentsDetails.ExperimentName)
+	if err := result.ChaosResult(&chaosDetails, clients, &resultDetails, "SOT"); err != nil {
+		log.Errorf("Unable to Create the Chaos Result, err: %v", err)
+		failStep := "[pre-chaos]: Failed to update the chaos result of pod-delete experiment (SOT), err: " + err.Error()
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	// Set the chaos result uid
+	result.SetResultUID(&resultDetails, clients, &chaosDetails)
+
+	// generating the event in chaosresult to marked the verdict as awaited
+	msg := "experiment: " + experimentsDetails.ExperimentName + ", Result: Awaited"
+	types.SetResultEventAttributes(&eventsDetails, types.AwaitedVerdict, msg, "Normal", &resultDetails)
+	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
+
+	//DISPLAY THE APP INFORMATION
+	log.InfoWithValues("[Info]: The application information is as follows", logrus.Fields{
+		"Namespace":      experimentsDetails.AppNS,
+		"Label":          experimentsDetails.AppLabel,
+		"Chaos Duration": experimentsDetails.ChaosDuration,
+	})
+
+	// Calling AbortWatcher go routine, it will continuously watch for the abort signal and generate the required events and result
+	go common.AbortWatcher(experimentsDetails.ExperimentName, clients, &resultDetails, &chaosDetails, &eventsDetails)
+
+	//PRE-CHAOS APPLICATION STATUS CHECK
+	if chaosDetails.DefaultAppHealthCheck {
+		log.Info("[Status]: Verify that the AUT (Application Under Test) is running (pre-chaos)")
+		if err := status.AUTStatusCheck(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.TargetContainer, experimentsDetails.Timeout, experimentsDetails.Delay, clients, &chaosDetails); err != nil {
+			log.Errorf("Application status check failed, err: %v", err)
+			failStep := "[pre-chaos]: Failed to verify that the AUT (Application Under Test) is in running state, err: " + err.Error()
+			types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, "AUT: Not Running", "Warning", &chaosDetails)
+			events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+	}
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := "AUT: Running"
+
+		// run the probes in the pre-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+
+			if err := probe.RunProbes(&chaosDetails, clients, &resultDetails, "PreChaos", &eventsDetails); err != nil {
+				log.Errorf("Probe Failed, err: %v", err)
+				failStep := "[pre-chaos]: Failed while running probes, err: " + err.Error()
+				msg := "AUT: Running, Probes: Unsuccessful"
+				types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = "AUT: Running, Probes: Successful"
+		}
+		// generating the events for the pre-chaos check
+		types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	// Including the litmus lib
+	switch experimentsDetails.ChaosLib {
+	case "litmus":
+		if err := litmusLIB.PodHttpResetPeerChaos(&experimentsDetails, clients, &resultDetails, &eventsDetails, &chaosDetails); err != nil {
+			log.Errorf("Chaos injection failed, err: %v", err)
+			failStep := "[chaos]: Failed inside the chaoslib, err: " + err.Error()
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+	default:
+		log.Error("[Invalid]: Please Provide the correct LIB")
+		failStep := "[chaos]: no match found for specified lib"
+		result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+		return
+	}
+
+	log.Infof("[Confirmation]: %v chaos has been injected successfully", experimentsDetails.ExperimentName)
+	resultDetails.Verdict = v1alpha1.ResultVerdictPassed
+
+	// @TODO: user POST-CHAOS-CHECK
+
+	//POST-CHAOS APPLICATION STATUS CHECK
+	if chaosDetails.DefaultAppHealthCheck {
+		log.Info("[Status]: Verify that the AUT (Application Under Test) is running (post-chaos)")
+		if err := status.AUTStatusCheck(experimentsDetails.AppNS, experimentsDetails.AppLabel, experimentsDetails.TargetContainer, experimentsDetails.Timeout, experimentsDetails.Delay, clients, &chaosDetails); err != nil {
+			log.Errorf("Application status check failed, err: %v", err)
+			failStep := "[post-chaos]: Failed to verify that the AUT (Application Under Test) is running, err: " + err.Error()
+			types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, "AUT: Not Running", "Warning", &chaosDetails)
+			events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+			return
+		}
+	}
+
+	if experimentsDetails.EngineName != "" {
+		// marking AUT as running, as we already checked the status of application under test
+		msg := "AUT: Running"
+
+		// run the probes in the post-chaos check
+		if len(resultDetails.ProbeDetails) != 0 {
+			if err := probe.RunProbes(&chaosDetails, clients, &resultDetails, "PostChaos", &eventsDetails); err != nil {
+				log.Errorf("Probes Failed, err: %v", err)
+				failStep := "[post-chaos]: Failed while running probes, err: " + err.Error()
+				msg := "AUT: Running, Probes: Unsuccessful"
+				types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Warning", &chaosDetails)
+				events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
+				return
+			}
+			msg = "AUT: Running, Probes: Successful"
+		}
+
+		// generating post chaos event
+		types.SetEngineEventAttributes(&eventsDetails, types.PostChaosCheck, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+
+	//Updating the chaosResult in the end of experiment
+	log.Infof("[The End]: Updating the chaos result of %v experiment (EOT)", experimentsDetails.ExperimentName)
+	if err := result.ChaosResult(&chaosDetails, clients, &resultDetails, "EOT"); err != nil {
+		log.Errorf("Unable to Update the Chaos Result, err: %v", err)
+		return
+	}
+
+	// generating the event in chaosresult to marked the verdict as pass/fail
+	msg = "experiment: " + experimentsDetails.ExperimentName + ", Result: " + string(resultDetails.Verdict)
+	reason := types.PassVerdict
+	eventType := "Normal"
+	if resultDetails.Verdict != "Pass" {
+		reason = types.FailVerdict
+		eventType = "Warning"
+	}
+	types.SetResultEventAttributes(&eventsDetails, reason, msg, eventType, &resultDetails)
+	events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult")
+
+	if experimentsDetails.EngineName != "" {
+		msg := experimentsDetails.ExperimentName + " experiment has been " + string(resultDetails.Verdict) + "ed"
+		types.SetEngineEventAttributes(&eventsDetails, types.Summary, msg, "Normal", &chaosDetails)
+		events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosEngine")
+	}
+}

--- a/experiments/generic/pod-http-reset-peer/rbac.yaml
+++ b/experiments/generic/pod-http-reset-peer/rbac.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-http-reset-peer-sa
+  namespace: default
+  labels:
+    name: pod-http-reset-peer-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-http-reset-peer-sa
+  namespace: default
+  labels:
+    name: pod-http-reset-peer-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+  # Create and monitor the experiment & helper pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+  # Performs CRUD operations on the events inside chaosengine and chaosresult
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","get","list","patch","update"]
+  # Fetch configmaps details and mount it to the experiment pod (if specified)
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get","list",]
+  # Track and get the runner, experiment, and helper pods log 
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get","list","watch"]  
+  # for creating and managing to execute comands inside target container
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get","list","create"]
+  # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+  - apiGroups: ["apps"]
+    resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)  
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: [""]
+    resources: ["replicationcontrollers"]
+    verbs: ["get","list"]
+  # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
+    verbs: ["list","get"]
+  # for configuring and monitor the experiment job by the chaos-runner pod
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create","list","get","delete","deletecollection"]
+  # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosengines","chaosexperiments","chaosresults"]
+    verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-http-reset-peer-sa
+  namespace: default
+  labels:
+    name: pod-http-reset-peer-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-http-reset-peer-sa
+subjects:
+- kind: ServiceAccount
+  name: pod-http-reset-peer-sa
+  namespace: default

--- a/experiments/generic/pod-http-reset-peer/test/test.yml
+++ b/experiments/generic/pod-http-reset-peer/test/test.yml
@@ -5,20 +5,20 @@ metadata:
   name: litmus-experiment
 spec:
   replicas: 1
-  selector: 
+  selector:
     matchLabels:
       app: litmus-experiment
   template:
     metadata:
-      labels:
+      labels: 
         app: litmus-experiment
     spec:
-      serviceAccountName: pod-http-latency-sa
+      serviceAccountName: pod-http-reset-peer-sa
       containers:
       - name: gotest
-        image: busybox
-        command:
-          - sleep 
+        image: busybox 
+        command: 
+          - sleep
           - "3600"
         env:
           # provide application namespace
@@ -31,6 +31,9 @@ spec:
  
           # provide application kind
           - name: APP_KIND
+            value: '' 
+
+          - name: TOTAL_CHAOS_DURATION
             value: ''
 
           # provide auxiliary application details - namespace and labels of the applications
@@ -38,10 +41,14 @@ spec:
           - name: AUXILIARY_APPINFO
             value: ''
           
+          ## Period to wait before injection of chaos in sec
+          - name: RAMP_TIME
+            value: ''
+
           # provide the chaos namespace
           - name: CHAOS_NAMESPACE
             value: ''
-
+          
           - name: TARGET_CONTAINER
             value: ''
 
@@ -49,8 +56,8 @@ spec:
           - name: LIB_IMAGE
             value: 'litmuschaos/go-runner:latest' 
 
-          - name: LATENCY
-            value: '2000' #in ms
+          - name: TIMEOUT
+            value: '10' #in ms
 
           # port of the target service
           - name: TARGET_SERVICE_PORT
@@ -59,13 +66,6 @@ spec:
           # port on which the proxy will listen
           - name: PROXY_PORT
             value: "2002"
-
-          - name: TOTAL_CHAOS_DURATION
-            value: '60' # in seconds
-
-          # Time period to wait before and after injection of chaos in sec
-          - name: RAMP_TIME
-            value: ''
 
           # lib can be litmus or pumba
           - name: LIB
@@ -96,13 +96,14 @@ spec:
           ## supported values: serial, parallel
           - name: SEQUENCE
             value: 'parallel'
-          
+        
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
           - name: CHAOS_SERVICE_ACCOUNT
             valueFrom:
               fieldRef:
                 fieldPath: spec.serviceAccountName
 
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name

--- a/pkg/generic/http-chaos/environment/environment.go
+++ b/pkg/generic/http-chaos/environment/environment.go
@@ -37,13 +37,13 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	experimentDetails.SetHelperData = types.Getenv("SET_HELPER_DATA", "true")
 	experimentDetails.Sequence = types.Getenv("SEQUENCE", "parallel")
 	experimentDetails.NetworkInterface = types.Getenv("NETWORK_INTERFACE", "eth0")
-	experimentDetails.TargetServicePort, _ = strconv.Atoi(types.Getenv("TARGET_SERVICE_PORT", "8080"))
-	experimentDetails.ProxyPort, _ = strconv.Atoi(types.Getenv("PROXY_PORT", "8081"))
+	experimentDetails.TargetServicePort, _ = strconv.Atoi(types.Getenv("TARGET_SERVICE_PORT", "80"))
+	experimentDetails.ProxyPort, _ = strconv.Atoi(types.Getenv("PROXY_PORT", "20000"))
 
 	switch expName {
 	case "pod-http-latency":
 		experimentDetails.Latency, _ = strconv.Atoi(types.Getenv("LATENCY", "6000"))
 	case "pod-http-reset-peer":
-		experimentDetails.ResetTimeout, _ = strconv.Atoi(types.Getenv("RESET_TIMEOUT", "10"))
+		experimentDetails.ResetTimeout, _ = strconv.Atoi(types.Getenv("RESET_TIMEOUT", "0"))
 	}
 }

--- a/pkg/generic/http-chaos/environment/environment.go
+++ b/pkg/generic/http-chaos/environment/environment.go
@@ -43,5 +43,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 	switch expName {
 	case "pod-http-latency":
 		experimentDetails.Latency, _ = strconv.Atoi(types.Getenv("LATENCY", "6000"))
+	case "pod-http-reset-peer":
+		experimentDetails.ResetTimeout, _ = strconv.Atoi(types.Getenv("RESET_TIMEOUT", "10"))
 	}
 }

--- a/pkg/generic/http-chaos/types/types.go
+++ b/pkg/generic/http-chaos/types/types.go
@@ -38,4 +38,5 @@ type ExperimentDetails struct {
 	TargetServicePort             int
 	ProxyPort                     int
 	Latency                       int
+	ResetTimeout                  int
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds the HTTP Chaos Latency experiment for K8s. HTTP Chaos will add the functionality to modify HTTP requests/responses. Currently only adding latency is supported
The current implementation is to use nsenter to run two commands

First is to start toxiproxy proxy server and then add the toxic for the provided target host and port.
Next is to add a ruleset in IPtables to direct the request coming for the target port to the proxy port. This will remove the requirement to change the ports manually.

**Special notes for your reviewer**:
Related PRs:
Docs:
Chaos Charts: 

### Experiment Pod logs
```
time="2022-06-23T11:01:36Z" level=info msg="Experiment Name: pod-http-reset-peer"
time="2022-06-23T11:01:36Z" level=info msg="[PreReq]: Getting the ENV for the pod-http-reset-peer experiment"
time="2022-06-23T11:01:38Z" level=info msg="[PreReq]: Updating the chaos result of pod-http-reset-peer experiment (SOT)"
time="2022-06-23T11:01:40Z" level=info msg="[Info]: The application information is as follows" Namespace=default Label="app=nginx" Chaos Duration=60
time="2022-06-23T11:01:40Z" level=info msg="[Status]: Verify that the AUT (Application Under Test) is running (pre-chaos)"
time="2022-06-23T11:01:40Z" level=info msg="[Status]: Checking whether application containers are in ready state"
time="2022-06-23T11:01:40Z" level=info msg="[Status]: The Container status are as follows" Pod=nginx-deployment-66b6c48dd5-8fq2p Readiness=true container=nginx
time="2022-06-23T11:01:42Z" level=info msg="[Status]: Checking whether application pods are in running state"
time="2022-06-23T11:01:42Z" level=info msg="[Status]: The status of Pods are as follows" Pod=nginx-deployment-66b6c48dd5-8fq2p Status=Running
time="2022-06-23T11:01:44Z" level=info msg="[Info]: The chaos tunables are:" Sequence=parallel PodsAffectedPerc=100 Target Port=80 Listen Port=2002
time="2022-06-23T11:01:44Z" level=info msg="[Info]: Reset Timeout=0"
time="2022-06-23T11:01:44Z" level=info msg="[Chaos]:Number of pods targeted: 1"
time="2022-06-23T11:01:44Z" level=info msg="[Info]: Target pods list for chaos, [nginx-deployment-66b6c48dd5-8fq2p]"
time="2022-06-23T11:01:44Z" level=info msg="[Info]: Details of application under chaos injection" PodName=nginx-deployment-66b6c48dd5-8fq2p NodeName=gke-hce-test-plan-re-default-pool-f2bec7be-podj ContainerName=nginx
time="2022-06-23T11:01:44Z" level=info msg="[Status]: Checking the status of the helper pods"
time="2022-06-23T11:01:46Z" level=info msg="pod-http-reset-peer-helper-cjjxmm helper pod is in Running state"
time="2022-06-23T11:01:48Z" level=info msg="[Wait]: waiting till the completion of the helper pod"
time="2022-06-23T11:01:48Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:01:49Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:01:50Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:01:51Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:01:52Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:01:53Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:01:54Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:01:55Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:01:56Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:01:57Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:01:58Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:01:59Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:00Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:01Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:02Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:03Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:04Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:05Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:06Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:07Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:08Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:09Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:10Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:11Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:12Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:13Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:14Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:15Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:16Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:17Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:18Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:19Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:20Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:21Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:22Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:23Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:24Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:25Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:26Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:27Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:28Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:29Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:30Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:31Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:32Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:33Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:34Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:35Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:36Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:37Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:38Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:39Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:40Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:41Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:42Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:43Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:44Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:46Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:47Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:48Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:49Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:50Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:51Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:52Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:53Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:54Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:55Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:56Z" level=info msg="helper pod status: Running"
time="2022-06-23T11:02:57Z" level=info msg="helper pod status: Succeeded"
time="2022-06-23T11:02:57Z" level=info msg="[Status]: The running status of Pods are as follows" Pod=pod-http-reset-peer-helper-cjjxmm Status=Succeeded
time="2022-06-23T11:02:58Z" level=info msg="[Cleanup]: Deleting all the helper pod"
time="2022-06-23T11:03:00Z" level=info msg="[Confirmation]: pod-http-reset-peer chaos has been injected successfully"
time="2022-06-23T11:03:00Z" level=info msg="[Status]: Verify that the AUT (Application Under Test) is running (post-chaos)"
time="2022-06-23T11:03:00Z" level=info msg="[Status]: Checking whether application containers are in ready state"
time="2022-06-23T11:03:00Z" level=info msg="[Status]: The Container status are as follows" container=nginx Pod=nginx-deployment-66b6c48dd5-8fq2p Readiness=true
time="2022-06-23T11:03:02Z" level=info msg="[Status]: Checking whether application pods are in running state"
time="2022-06-23T11:03:02Z" level=info msg="[Status]: The status of Pods are as follows" Status=Running Pod=nginx-deployment-66b6c48dd5-8fq2p
time="2022-06-23T11:03:04Z" level=info msg="[The End]: Updating the chaos result of pod-http-reset-peer experiment (EOT)"
```

### Helper Pod logs
```
time="2022-06-23T11:01:45Z" level=info msg="Helper Name: http-chaos"
time="2022-06-23T11:01:45Z" level=info msg="[PreReq]: Getting the ENV variables"
time="2022-06-23T11:01:45Z" level=info msg="container ID of nginx container, containerID: 29ece247dfa41579ae8b3b72040219035fc2db00672862479799dba20a5ce91a"
time="2022-06-23T11:01:45Z" level=info msg="Container ID: 29ece247dfa41579ae8b3b72040219035fc2db00672862479799dba20a5ce91a"
time="2022-06-23T11:01:45Z" level=info msg="[Info]: Container ID=29ece247dfa41579ae8b3b72040219035fc2db00672862479799dba20a5ce91a has process PID=1929809"
time="2022-06-23T11:01:45Z" level=info msg="[Chaos]: Starting proxy server: /bin/bash -c (sudo nsenter -t 1929809 -n toxiproxy-server -host=0.0.0.0 > /dev/null 2>&1 &) && sleep 10 && (sudo nsenter -t 1929809 -n toxiproxy-cli create -l 0.0.0.0:2002 -u 0.0.0.0:80 proxy) && (sudo nsenter -t 1929809 -n toxiproxy-cli toxic add -t reset_peer -a timeout=0 proxy)"
time="2022-06-23T11:01:55Z" level=info msg="[Info]: Proxy started successfully"
time="2022-06-23T11:01:55Z" level=info msg="[Chaos]: Adding IPtables ruleset: /bin/bash -c (sudo nsenter -t 1929809 -n iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 2002)"
time="2022-06-23T11:01:55Z" level=info msg="[Info]: IP rule set added successfully"
time="2022-06-23T11:01:56Z" level=info msg="[Chaos]: Waiting for 60s"
time="2022-06-23T11:02:56Z" level=info msg="[Chaos]: Stopping the experiment"
time="2022-06-23T11:02:56Z" level=info msg="[Chaos]: Removing IPtables ruleset: /bin/bash -c sudo nsenter -t 1929809 -n iptables -t nat -D PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 2002"
time="2022-06-23T11:02:56Z" level=info msg="[Info]: IP rule set removed successfully"
time="2022-06-23T11:02:56Z" level=info msg="[Chaos]: Stopping proxy server: /bin/bash -c sudo nsenter -t 1929809 -n sudo kill -9 $(ps aux | grep [t]oxiproxy | awk 'FNR==1{print $1}')"
time="2022-06-23T11:02:56Z" level=info msg="[Info]: Proxy stopped successfully"
```