### PR TITLE
fix(probe): Converting probeStatus to enum and add mode and description

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.38.59
 	github.com/containerd/cgroups v1.0.1
 	github.com/kyokomi/emoji v2.2.4+incompatible
-	github.com/litmuschaos/chaos-operator v0.0.0-20220824040614-88dbe3eb960c
+	github.com/litmuschaos/chaos-operator v0.0.0-20220920112443-591193ec22c9
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -712,8 +712,8 @@ github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/litmuschaos/chaos-operator v0.0.0-20210610071657-a58dbd939e73/go.mod h1:QMjfAVIfwcpj/P1jikyz5+C5vWICiUXsFZMR7Ihnzro=
-github.com/litmuschaos/chaos-operator v0.0.0-20220824040614-88dbe3eb960c h1:rZuxZxYMa0Oqlqtq1AfExJhXxLaMr4GKqj4ZLMSARzE=
-github.com/litmuschaos/chaos-operator v0.0.0-20220824040614-88dbe3eb960c/go.mod h1:TxsfFIIjM3/atf2fLm3AYVtoUucBQK46EJvLwRITnE4=
+github.com/litmuschaos/chaos-operator v0.0.0-20220920112443-591193ec22c9 h1:3Y0TFhyc0PafkxkmbS5HRO5trnW96vGQnQmstRigBlk=
+github.com/litmuschaos/chaos-operator v0.0.0-20220920112443-591193ec22c9/go.mod h1:TxsfFIIjM3/atf2fLm3AYVtoUucBQK46EJvLwRITnE4=
 github.com/litmuschaos/elves v0.0.0-20201107015738-552d74669e3c/go.mod h1:DsbHGNUq/78NZozWVVI9Q6eBei4I+JjlkkD5aibJ3MQ=
 github.com/litmuschaos/litmus-go v0.0.0-20210705063441-babf0c4aa57d/go.mod h1:MNO+1u4jBPjLtFO56bckIv87EhwTkppJxDf8+6PbLRY=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -53,9 +53,10 @@ type RegisterDetails struct {
 // ProbeDetails is for collecting all the probe details
 type ProbeDetails struct {
 	Name                   string
-	Phase                  string
 	Type                   string
-	Status                 map[string]string
+	Mode                   string
+	Phase                  string
+	Status                 v1alpha1.ProbeStatus
 	IsProbeFailedWithError error
 	RunID                  string
 	RunCount               int


### PR DESCRIPTION
Signed-off-by: Shubham Chaudhary <shubham.chaudhary@harness.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Probe Statuses**

```yaml
{
  "probeStatuses": [
    {
      "mode": "SOT",
      "name": "probe1",
      "status": {
        "description": "Probe didn't met the passing criteria",
        "verdict": "Failed"
      },
      "type": "httpProbe"
    },
    {
      "mode": "Continuous",
      "name": "probe2",
      "status": {
        "description": "either probe is not executed or not evaluated",
        "verdict": "N/A"
      },
      "type": "httpProbe"
    }
  ]
}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
