### PR TITLE
fix(abort): fixing chaosresult annotation conflict while updating chaosresult for abort scenarios

### DIFF
--- a/pkg/status/application.go
+++ b/pkg/status/application.go
@@ -251,7 +251,7 @@ func WaitForCompletion(appNs, appLabel string, clients clients.ClientSets, durat
 			if err != nil {
 				return errors.Errorf("Unable to find the pods with matching labels, err: %v", err)
 			} else if len(podList.Items) == 0 {
-				errors.Errorf("Unable to find the pods with matching labels")
+				return errors.Errorf("Unable to find the pods with matching labels")
 			}
 			// it will check for the status of helper pod, if it is Succeeded and target container is completed then it will marked it as completed and return
 			// if it is still running then it will check for the target container, as we can have multiple container inside helper pod (istio)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

PR to fix
- chaosresult update conflicts for abort scenarios
- remove the duplicate targets inside the chaosresult
- fix experiment to failed if helper is evicted or manually deleted

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Issue:** 
In abort scenarios - helper pod keep annotating the chaos-result for  targets and their revert status. At the same time experiment pod is updating the chaosresult for abort in parallel
Experiment pod get and update the chaosresult  but in the mean-time helper pod updates the chaosresult for annotations, which cause the update function to fail.

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
