### PR TITLE
Add missing Jitter ENV input for Pod Network Chaos experiments (#563)

### DIFF
--- a/pkg/generic/network-chaos/environment/environment.go
+++ b/pkg/generic/network-chaos/environment/environment.go
@@ -8,7 +8,7 @@ import (
 	clientTypes "k8s.io/apimachinery/pkg/types"
 )
 
-//GetENV fetches all the env variables from the runner pod
+// GetENV fetches all the env variables from the runner pod
 func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string) {
 	experimentDetails.ExperimentName = types.Getenv("EXPERIMENT_NAME", "")
 	experimentDetails.ChaosNamespace = types.Getenv("CHAOS_NAMESPACE", "litmus")
@@ -47,7 +47,8 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails, expName string
 		experimentDetails.NetworkChaosType = "network-loss"
 
 	case "pod-network-latency":
-		experimentDetails.NetworkLatency, _ = strconv.Atoi(types.Getenv("NETWORK_LATENCY", "60000"))
+		experimentDetails.NetworkLatency, _ = strconv.Atoi(types.Getenv("NETWORK_LATENCY", "2000"))
+		experimentDetails.Jitter, _ = strconv.Atoi(types.Getenv("JITTER", "0"))
 		experimentDetails.NetworkChaosType = "network-latency"
 
 	case "pod-network-corruption":


### PR DESCRIPTION
Signed -off-by:  Ashis kumar Naik <ashishami2002@gmail.com>

**What this PR does / why we need it**:

*added the missing JITTER ENV for the network latency experiment to the experiment structure

*updated the default value of Network Latency to 2000 ms

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
