### PR TITLE
 Fix vulnerability found in kubernetes library to fix the trivy scan check (#510)

### DIFF
--- a/chaoslib/litmus/gcp-vm-instance-stop/lib/gcp-vm-instance-stop.go
+++ b/chaoslib/litmus/gcp-vm-instance-stop/lib/gcp-vm-instance-stop.go
@@ -24,7 +24,7 @@ var (
 	inject, abort chan os.Signal
 )
 
-//PrepareVMStop contains the prepration and injection steps for the experiment
+// PrepareVMStop contains the prepration and injection steps for the experiment
 func PrepareVMStop(computeService *compute.Service, experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
 	// inject channel is used to transmit signal notifications.
@@ -45,19 +45,9 @@ func PrepareVMStop(computeService *compute.Service, experimentsDetails *experime
 
 	// get the instance name or list of instance names
 	instanceNamesList := strings.Split(experimentsDetails.VMInstanceName, ",")
-	if len(instanceNamesList) == 0 {
-		return errors.Errorf("no instance name found to stop")
-	}
 
 	// get the zone name or list of corresponding zones for the instances
 	instanceZonesList := strings.Split(experimentsDetails.InstanceZone, ",")
-	if len(instanceZonesList) == 0 {
-		return errors.Errorf("no corresponding zones found for the instances")
-	}
-
-	if len(instanceNamesList) != len(instanceZonesList) {
-		return errors.Errorf("number of instances is not equal to the number of zones")
-	}
 
 	go abortWatcher(computeService, experimentsDetails, instanceNamesList, instanceZonesList, chaosDetails)
 
@@ -83,7 +73,7 @@ func PrepareVMStop(computeService *compute.Service, experimentsDetails *experime
 	return nil
 }
 
-//injectChaosInSerialMode stops VM instances in serial mode i.e. one after the other
+// injectChaosInSerialMode stops VM instances in serial mode i.e. one after the other
 func injectChaosInSerialMode(computeService *compute.Service, experimentsDetails *experimentTypes.ExperimentDetails, instanceNamesList []string, instanceZonesList []string, clients clients.ClientSets, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
 
 	select {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
-	k8s.io/kubernetes v1.18.19
+	k8s.io/kubernetes v1.25.2
 )
 
 require (


### PR DESCRIPTION
 Fix vulnerability found in kubernetes library to fix the trivy scan check (#510)

    **What this PR does / why we need it**:  *Updated the Kubernetes package version

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #510 

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
