### PR TITLE
Chore(Fix): `msg` variable assigned return value of `GetStatusMessage`

### DIFF
--- a/experiments/generic/disk-fill/experiment/disk-fill.go
+++ b/experiments/generic/disk-fill/experiment/disk-fill.go
@@ -112,7 +112,7 @@ func DiskFill(clients clients.ClientSets) {
 				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 				return
 			}
-			common.GetStatusMessage(chaosDetails.DefaultHealthCheck, "AUT: Running", "Successful")
+			msg = common.GetStatusMessage(chaosDetails.DefaultHealthCheck, "AUT: Running", "Successful")
 		}
 		// generating the events for the pre-chaos check
 		types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Normal", &chaosDetails)
@@ -177,7 +177,7 @@ func DiskFill(clients clients.ClientSets) {
 				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 				return
 			}
-			common.GetStatusMessage(chaosDetails.DefaultHealthCheck, "AUT: Running", "Successful")
+			msg = common.GetStatusMessage(chaosDetails.DefaultHealthCheck, "AUT: Running", "Successful")
 		}
 
 		// generating post chaos event

--- a/experiments/generic/pod-delete/experiment/pod-delete.go
+++ b/experiments/generic/pod-delete/experiment/pod-delete.go
@@ -101,7 +101,7 @@ func PodDelete(clients clients.ClientSets) {
 				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 				return
 			}
-			common.GetStatusMessage(chaosDetails.DefaultHealthCheck, "AUT: Running", "Successful")
+			msg = common.GetStatusMessage(chaosDetails.DefaultHealthCheck, "AUT: Running", "Successful")
 		}
 		// generating the events for the pre-chaos check
 		types.SetEngineEventAttributes(&eventsDetails, types.PreChaosCheck, msg, "Normal", &chaosDetails)
@@ -162,7 +162,7 @@ func PodDelete(clients clients.ClientSets) {
 				result.RecordAfterFailure(&chaosDetails, &resultDetails, failStep, clients, &eventsDetails)
 				return
 			}
-			common.GetStatusMessage(chaosDetails.DefaultHealthCheck, "AUT: Running", "Successful")
+			msg = common.GetStatusMessage(chaosDetails.DefaultHealthCheck, "AUT: Running", "Successful")
 		}
 
 		// generating post chaos event


### PR DESCRIPTION
Signed-off-by: Akash Shrivastava <akash.shrivastava@harness.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
For the `pod-delete` and `disk-fill` experiments, the result of `GetStatusMessage` wasn't assigned to the `msg` variable for updating at some places. This PR will fix that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages have breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
