### PR TITLE
Added filtering VM instances by tag

### DIFF
--- a/experiments/vmware/vm-poweroff/experiment/vm-poweroff.go
+++ b/experiments/vmware/vm-poweroff/experiment/vm-poweroff.go
@@ -19,6 +19,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var err error
+
 // VMPoweroff contains steps to inject vm-power-off chaos
 func VMPoweroff(clients clients.ClientSets) {
 
@@ -61,6 +63,16 @@ func VMPoweroff(clients clients.ClientSets) {
 	types.SetResultEventAttributes(&eventsDetails, types.AwaitedVerdict, msg, "Normal", &resultDetails)
 	if eventErr := events.GenerateEvents(&eventsDetails, clients, &chaosDetails, "ChaosResult"); eventErr != nil {
 		log.Errorf("Failed to create %v event inside chaosresult", types.AwaitedVerdict)
+	}
+
+	if experimentsDetails.VMTag != "" {
+		// GET VM IDs FROM TAG
+		experimentsDetails.VMIds, err = vmware.GetVMIDFromTag(experimentsDetails.VMTag)
+		if err != nil {
+			result.RecordAfterFailure(&chaosDetails, &resultDetails, err, clients, &eventsDetails)
+			log.Errorf("Unable to get the VM ID, err: %v", err)
+			return
+		}
 	}
 
 	//DISPLAY THE VM INFORMATION

--- a/pkg/cloud/vmware/vm-tag.go
+++ b/pkg/cloud/vmware/vm-tag.go
@@ -1,0 +1,49 @@
+package vmware
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// GetVMIDFromTag will fetch the VM IDs from the tag
+func GetVMIDFromTag(tag string) (string, error) {
+
+	var vmMoids []string
+
+	command := "govc tags.attached.ls " + tag
+	stdout, err := shellout(command)
+
+	if err != nil {
+		return "", err
+	}
+	vmInstances := strings.Split(stdout, "\n")
+	for _, vm := range vmInstances {
+		if vm != "" {
+			vmMoids = append(vmMoids, cleanString(strings.Split(vm, ":")[1]))
+		}
+	}
+
+	return strings.Join(vmMoids, ","), nil
+}
+
+func shellout(command string) (string, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.Command("bash", "-c", command)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if stderr.String() != "" {
+		err = fmt.Errorf(stderr.String())
+	}
+	return stdout.String(), err
+}
+
+func cleanString(s string) string {
+	spaceRemoved := strings.Trim(s, " ")
+	newLineRemoved := strings.Trim(spaceRemoved, "\n")
+
+	return newLineRemoved
+}

--- a/pkg/vmware/vm-poweroff/environment/environment.go
+++ b/pkg/vmware/vm-poweroff/environment/environment.go
@@ -25,6 +25,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.Timeout, _ = strconv.Atoi(types.Getenv("STATUS_CHECK_TIMEOUT", "180"))
 	experimentDetails.Sequence = types.Getenv("SEQUENCE", "parallel")
 	experimentDetails.VMIds = strings.TrimSpace(types.Getenv("APP_VM_MOIDS", ""))
+	experimentDetails.VMTag = strings.TrimSpace(types.Getenv("APP_VM_TAG", ""))
 	experimentDetails.VcenterServer = types.Getenv("VCENTERSERVER", "")
 	experimentDetails.VcenterUser = types.Getenv("VCENTERUSER", "")
 	experimentDetails.VcenterPass = types.Getenv("VCENTERPASS", "")

--- a/pkg/vmware/vm-poweroff/types/types.go
+++ b/pkg/vmware/vm-poweroff/types/types.go
@@ -22,6 +22,7 @@ type ExperimentDetails struct {
 	Delay          int
 	Sequence       string
 	VMIds          string
+	VMTag          string
 	VcenterServer  string
 	VcenterUser    string
 	VcenterPass    string


### PR DESCRIPTION
Signed-off-by: Akash Shrivastava <akash.shrivastava@harness.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds support to filter Vmware VM instances by tag in the `vmware-poweroff` experiment. 
Note: Only one tag is supported.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
