### PR TITLE
Use "ip netns exec" instead of "nsenter" to handle pod restart in network-chaos but for 2.14.X

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -35,6 +35,8 @@ COPY --from=dep /usr/bin/sudo /usr/bin/
 COPY --from=dep /usr/lib/sudo /usr/lib/sudo
 COPY --from=dep /sbin/tc /sbin/
 COPY --from=dep /sbin/iptables /sbin/
+COPY --from=dep /sbin/iptables /sbin/
+COPY --from=dep /sbin/ip /sbin/
 
 #Copying Necessary Files
 COPY ./pkg/cloud/aws/common/ssm-docs/LitmusChaos-AWS-SSM-Docs.yml .

--- a/chaoslib/litmus/network-chaos/lib/network-chaos.go
+++ b/chaoslib/litmus/network-chaos/lib/network-chaos.go
@@ -291,6 +291,14 @@ func createHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 						},
 					},
 				},
+				{
+					Name: "netns",
+					VolumeSource: apiv1.VolumeSource{
+						HostPath: &apiv1.HostPathVolumeSource{
+							Path: "/var/run/netns",
+						},
+					},
+				},
 			},
 
 			Containers: []apiv1.Container{
@@ -311,6 +319,10 @@ func createHelperPod(experimentsDetails *experimentTypes.ExperimentDetails, clie
 						{
 							Name:      "cri-socket",
 							MountPath: experimentsDetails.SocketPath,
+						},
+						{
+							Name:      "netns",
+							MountPath: "/var/run/netns",
 						},
 					},
 					SecurityContext: &apiv1.SecurityContext{


### PR DESCRIPTION
This PR is duplicate of  https://github.com/litmuschaos/litmus-go/pull/702 but for 2.14.X

- Replacing the nsenter command by ip netns exec
- Updating helper pod definition to mount the hostPath /var/run/netns
- Updating Dockerfile to add ip binary to experiments/helper pod.

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

Updating network-chaos to use the netns instead of the procedure to inject/remove chaos so the network-chaos can handle pod restart.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #591

**Special notes for your reviewer**:

I think this PR will need "requires-upgrade".

**Checklist:**
-   [X] Fixes #591
-   [ ] PR messages has document related information
-   [X] Labelled this PR & related issue with `breaking-changes` tag
-   [X] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [x] E2E run Required for the changes
