### PR TITLE
Fix issue with empty Kind field in ParentResource

### DIFF
--- a/pkg/workloads/workloads.go
+++ b/pkg/workloads/workloads.go
@@ -73,6 +73,7 @@ func getPodsFromWorkload(target types.AppDetails, allPods *kcorev1.PodList, dyna
 func GetPodOwnerTypeAndName(pod *kcorev1.Pod, dynamicClient dynamic.Interface) (parentType, parentName string, err error) {
 	for _, owner := range pod.GetOwnerReferences() {
 		parentName = owner.Name
+		parentType = strings.ToLower(owner.Kind)
 		if owner.Kind == "StatefulSet" || owner.Kind == "DaemonSet" {
 			return strings.ToLower(owner.Kind), parentName, nil
 		}


### PR DESCRIPTION
Fix issue with empty Kind field in ParentResource

When pod kind is NOT one of [StatefulSet, DaemonSet, ReplicaSet, ReplicaController] then method workloads.GetPodOwnerTypeAndName will return empty kind, but not empty name
https://github.com/litmuschaos/litmus-go/blob/master/pkg/workloads/workloads.go#L75

fixes #698