### PR TITLE
Rename env to EC2_INSTANCE_TAG

### DIFF
--- a/chaoslib/litmus/ec2-terminate-by-tag/lib/ec2-terminate-by-tag.go
+++ b/chaoslib/litmus/ec2-terminate-by-tag/lib/ec2-terminate-by-tag.go
@@ -221,14 +221,14 @@ func injectChaosInParallelMode(experimentsDetails *experimentTypes.ExperimentDet
 // SetTargetInstance will select the target instance which are in running state and filtered from the given instance tag
 func SetTargetInstance(experimentsDetails *experimentTypes.ExperimentDetails) error {
 
-	instanceIDList, err := awslib.GetInstanceList(experimentsDetails.InstanceTag, experimentsDetails.Region)
+	instanceIDList, err := awslib.GetInstanceList(experimentsDetails.Ec2InstanceTag, experimentsDetails.Region)
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to get the instance id list")
 	}
 	if len(instanceIDList) == 0 {
 		return cerrors.Error{
 			ErrorCode: cerrors.ErrorTypeTargetSelection,
-			Reason:    fmt.Sprintf("no instance found with the given tag %v, in region %v", experimentsDetails.InstanceTag, experimentsDetails.Region),
+			Reason:    fmt.Sprintf("no instance found with the given tag %v, in region %v", experimentsDetails.Ec2InstanceTag, experimentsDetails.Region),
 		}
 	}
 
@@ -246,7 +246,7 @@ func SetTargetInstance(experimentsDetails *experimentTypes.ExperimentDetails) er
 		return cerrors.Error{
 			ErrorCode: cerrors.ErrorTypeChaosInject,
 			Reason:    "failed to get any running instance",
-			Target:    fmt.Sprintf("EC2 Instance Tag: %v", experimentsDetails.InstanceTag)}
+			Target:    fmt.Sprintf("EC2 Instance Tag: %v", experimentsDetails.Ec2InstanceTag)}
 	}
 
 	log.InfoWithValues("[Info]: Targeting the running instances filtered from instance tag", logrus.Fields{

--- a/experiments/kube-aws/ec2-terminate-by-tag/experiment/ec2-terminate-tag.go
+++ b/experiments/kube-aws/ec2-terminate-by-tag/experiment/ec2-terminate-tag.go
@@ -71,7 +71,7 @@ func EC2TerminateByTag(clients clients.ClientSets) {
 	log.InfoWithValues("The instance information is as follows", logrus.Fields{
 		"Chaos Duration":               experimentsDetails.ChaosDuration,
 		"Chaos Namespace":              experimentsDetails.ChaosNamespace,
-		"Instance Tag":                 experimentsDetails.InstanceTag,
+		"Instance Tag":                 experimentsDetails.Ec2InstanceTag,
 		"Instance Affected Percentage": experimentsDetails.InstanceAffectedPerc,
 		"Sequence":                     experimentsDetails.Sequence,
 	})

--- a/experiments/kube-aws/ec2-terminate-by-tag/test/test.yml
+++ b/experiments/kube-aws/ec2-terminate-by-tag/test/test.yml
@@ -22,7 +22,7 @@ spec:
           - "3600"
         env:
           # value: key:value ex: team:devops
-          - name: INSTANCE_TAG
+          - name: EC2_INSTANCE_TAG
             value: ''
 
           - name: CHAOS_NAMESPACE

--- a/pkg/kube-aws/ec2-terminate-by-tag/environment/environment.go
+++ b/pkg/kube-aws/ec2-terminate-by-tag/environment/environment.go
@@ -25,7 +25,7 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.Timeout, _ = strconv.Atoi(types.Getenv("STATUS_CHECK_TIMEOUT", "180"))
 	experimentDetails.Region = types.Getenv("REGION", "")
 	experimentDetails.ManagedNodegroup = types.Getenv("MANAGED_NODEGROUP", "disable")
-	experimentDetails.InstanceTag = strings.TrimSpace(types.Getenv("INSTANCE_TAG", ""))
+	experimentDetails.Ec2InstanceTag = strings.TrimSpace(types.Getenv("EC2_INSTANCE_TAG", ""))
 	experimentDetails.InstanceAffectedPerc, _ = strconv.Atoi(types.Getenv("INSTANCE_AFFECTED_PERC", "0"))
 	experimentDetails.Sequence = types.Getenv("SEQUENCE", "parallel")
 }

--- a/pkg/kube-aws/ec2-terminate-by-tag/types/types.go
+++ b/pkg/kube-aws/ec2-terminate-by-tag/types/types.go
@@ -17,7 +17,7 @@ type ExperimentDetails struct {
 	ChaosPodName         string
 	Timeout              int
 	Delay                int
-	InstanceTag          string
+	Ec2InstanceTag       string
 	Region               string
 	InstanceAffectedPerc int
 	ManagedNodegroup     string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

**Proposed changes:**

Related issue https://github.com/litmuschaos/litmus/issues/4807#issuecomment-2271358440

This PR fixes an issue where the [ec2-stop-by-tag](https://litmuschaos.github.io/litmus/experiments/categories/aws/ec2-stop-by-tag/) experiment fails to target the intended EC2 instance.

The [ec2-stop-by-tag](https://litmuschaos.github.io/litmus/experiments/categories/aws/ec2-stop-by-tag/) experiment encounters a `TARGET_SELECTION_ERROR` due to an incorrect retrieval of the `EC2_INSTANCE_TAG` environment variable.

```
Fault Summary:
TARGET_SELECTION_ERROR
{"errorCode":"TARGET_SELECTION_ERROR","phase":"PreChaos","reason":"failed to get the instance tag, invalid instance tag","target":"{EC2 Instance Tag: , Region: ap-northeast-2}"}
```

By correctly renaming the environment variable from `INSTANCE_TAG` to `EC2_INSTANCE_TAG`, we can accurately target the intended EC2 instance.

**Special notes for your reviewer**:

cc. @namkyu1999 

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
