### PR TITLE
fix broken link to pod delete example chart

### DIFF
--- a/contribute/developer-guide/README.md
+++ b/contribute/developer-guide/README.md
@@ -17,7 +17,7 @@ The artifacts associated with a chaos-experiment are summarized below:
   - Experiment RBAC (holds experiment-specific ServiceAccount, Role and RoleBinding)
   - Experiment Engine (holds experiment-specific chaosengine)
 
-  Example: [pod delete experiment in chaos-charts](https://github.com/litmuschaos/chaos-charts/tree/master/charts/generic/pod-delete)
+  Example: [pod delete experiment in chaos-charts](https://github.com/litmuschaos/chaos-charts/tree/master/experiments/pod-delete)
 
 The *generate_experiment.go* script is a simple way to bootstrap your experiment, and helps create the aforementioned artifacts in the appropriate directory (i.e., as per the chaos-category) based on an attributes file provided as input by the chart-developer. The scaffolded files consist of placeholders which can then be filled as desired.  
 


### PR DESCRIPTION
Updated the broken link in the README.md to the correct URL

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This commit updates the link to point to the correct resource.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
