### PR TITLE
fix: update Dockerfile (iptables-libs RPM path) 

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -33,7 +33,7 @@ RUN yum install -y https://dl.rockylinux.org/pub/rocky/9/devel/$(uname -m)/os/Pa
 RUN yum install -y https://dl.rockylinux.org/pub/rocky/9/devel/$(uname -m)/os/Packages/i/iproute-tc-6.2.0-6.el9_4.$(uname -m).rpm 
     
 # iptables
-RUN yum install -y https://dl.rockylinux.org/pub/rocky/9/devel/$(uname -m)/os/Packages/i/iptables-libs-1.8.10-2.el9.$(uname -m).rpm
+RUN yum install -y https://dl.rockylinux.org/vault/rocky/9.4/devel/$(uname -m)/os/Packages/i/iptables-libs-1.8.10-2.el9.$(uname -m).rpm
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/9/Everything/$(uname -m)/Packages/i/iptables-legacy-libs-1.8.10-2.2.el9.$(uname -m).rpm
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/9/Everything/$(uname -m)/Packages/i/iptables-legacy-1.8.10-2.2.el9.$(uname -m).rpm
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR updates the Dockerfile to use the archived `iptables-libs` RPM , which resolves the build failure caused by the missing RPM package.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #713 

**Special notes for your reviewer**:
This PR updates the RPM file path to `/vault/rocky/9.4/devel`. If there are any issues with this path (for example, if a different version of Rocky is preferred), I will fix it.

**Checklist:**
-   [x] Fixes #<issue number>
-   [x] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
