### PR TITLE
feat: improve document okteto version not latest

### DIFF
--- a/contribute/developer-guide/README.md
+++ b/contribute/developer-guide/README.md
@@ -204,7 +204,7 @@ Follow the steps provided below to setup okteto & test the experiment execution.
 - Install the Okteto CLI 
 
   ```
-  curl https://get.okteto.com -sSfL | sh
+  curl https://get.okteto.com -sSfL | OKTETO_VERSION=2.31.0 sh
   ```
 
 - (Optional) Create a sample nginx deployment that can be used as the application under test (AUT).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

If you currently use the latest version of okteto, you cannot run okteto normally.

So, I applied it to the document to download the most recent version among the 2.x.x versions.

```shell
$ curl https://get.okteto.com -sSfL | OKTETO_VERSION=2.31.0 sh
> Using Release Channel: stable
> Using Version: 2.31.0
> Downloading https://downloads.okteto.com/cli/stable/2.31.0/okteto-Darwin-arm64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 79.4M  100 79.4M    0     0  12.3M      0  0:00:06  0:00:06 --:--:-- 18.2M
> Installing /usr/local/bin/okteto
> Okteto successfully installed!
```

<img width="597" alt="GoLand 2024-11-09 13 51 58" src="https://github.com/user-attachments/assets/03cb2a40-060b-4636-a117-a27026a6783c">

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
