### PR TITLE
feat: export k6 results output to the OTEL collector

### DIFF
--- a/chaoslib/litmus/k6-loadgen/lib/k6-loadgen.go
+++ b/chaoslib/litmus/k6-loadgen/lib/k6-loadgen.go
@@ -119,7 +119,7 @@ func createHelperPod(ctx context.Context, experimentsDetails *experimentTypes.Ex
 		envs = []corev1.EnvVar{
 			{
 				Name:  "K6_OTEL_METRIC_PREFIX",
-				Value: "k6_",
+				Value: experimentsDetails.OTELMetricPrefix,
 			},
 			{
 				Name:  "K6_OTEL_GRPC_EXPORTER_INSECURE",

--- a/chaoslib/litmus/k6-loadgen/lib/k6-loadgen.go
+++ b/chaoslib/litmus/k6-loadgen/lib/k6-loadgen.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/litmuschaos/litmus-go/pkg/cerrors"
@@ -103,6 +104,35 @@ func createHelperPod(ctx context.Context, experimentsDetails *experimentTypes.Ex
 
 	const volumeName = "script-volume"
 	const mountPath = "/mnt"
+
+	var envs []corev1.EnvVar
+	args := []string{
+		mountPath + "/" + experimentsDetails.ScriptSecretKey,
+		"-q",
+		"--duration",
+		strconv.Itoa(experimentsDetails.ChaosDuration) + "s",
+		"--tag",
+		"trace_id=" + span.SpanContext().TraceID().String(),
+	}
+
+	if otelExporterEndpoint := os.Getenv(telemetry.OTELExporterOTLPEndpoint); otelExporterEndpoint != "" {
+		envs = []corev1.EnvVar{
+			{
+				Name:  "K6_OTEL_METRIC_PREFIX",
+				Value: "k6_",
+			},
+			{
+				Name:  "K6_OTEL_GRPC_EXPORTER_INSECURE",
+				Value: "true",
+			},
+			{
+				Name:  "K6_OTEL_GRPC_EXPORTER_ENDPOINT",
+				Value: otelExporterEndpoint,
+			},
+		}
+		args = append(args, "--out", "experimental-opentelemetry")
+	}
+
 	helperPod := &corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			GenerateName: experimentsDetails.ExperimentName + "-helper-",
@@ -122,12 +152,8 @@ func createHelperPod(ctx context.Context, experimentsDetails *experimentTypes.Ex
 						"k6",
 						"run",
 					},
-					Args: []string{
-						mountPath + "/" + experimentsDetails.ScriptSecretKey,
-						"-q",
-						"--duration",
-						strconv.Itoa(experimentsDetails.ChaosDuration) + "s",
-					},
+					Args:      args,
+					Env:       envs,
 					Resources: chaosDetails.Resources,
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/load/k6-loadgen/environment/environment.go
+++ b/pkg/load/k6-loadgen/environment/environment.go
@@ -25,5 +25,5 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.LIBImage = types.Getenv("LIB_IMAGE", "ghcr.io/grafana/k6-operator:latest-runner")
 	experimentDetails.ScriptSecretName = types.Getenv("SCRIPT_SECRET_NAME", "k6-script")
 	experimentDetails.ScriptSecretKey = types.Getenv("SCRIPT_SECRET_KEY", "script.js")
-
+	experimentDetails.OTELMetricPrefix = types.Getenv("OTEL_METRIC_PREFIX", "k6_")
 }

--- a/pkg/load/k6-loadgen/types/types.go
+++ b/pkg/load/k6-loadgen/types/types.go
@@ -18,4 +18,5 @@ type ExperimentDetails struct {
 	LIBImage           string
 	ScriptSecretName   string
 	ScriptSecretKey    string
+	OTELMetricPrefix   string
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

k6 supports exporting results output in real-time.

This PR implements exporting results output to the OTEL collector followed this [instruction](https://grafana.com/docs/k6/latest/results-output/real-time/opentelemetry
).


Here's a result. k6 [automatically converts all metric types](https://grafana.com/docs/k6/latest/results-output/real-time/opentelemetry/#metrics-mapping) to an equivalent OTEL metric type. So we don't have to do anything.

<img width="1508" alt="Screenshot 2024-11-22 at 5 23 56 PM" src="https://github.com/user-attachments/assets/337c3a54-33d7-4be6-8a10-eefc58365da8">

Also, I added tags named `trace_id` so we can filter by current trace context.

<img width="433" alt="Screenshot 2024-11-22 at 5 23 32 PM" src="https://github.com/user-attachments/assets/b4dc4436-d6e4-40c5-8e8b-98539aa0c6d7">




dependencies: https://github.com/litmuschaos/litmus-go/pull/725
fyi: [config format](https://grafana.com/docs/k6/latest/get-started/results-output/)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/litmuschaos/litmus-go/issues/724

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes https://github.com/litmuschaos/litmus-go/issues/724
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
