### PR TITLE
Include error message from stderr if container-kill fails (#740)

### DIFF
--- a/chaoslib/litmus/container-kill/helper/container-kill.go
+++ b/chaoslib/litmus/container-kill/helper/container-kill.go
@@ -1,14 +1,14 @@
 package helper
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"github.com/litmuschaos/litmus-go/pkg/telemetry"
-	"go.opentelemetry.io/otel"
 	"os/exec"
 	"strconv"
 	"time"
+
+	"github.com/litmuschaos/litmus-go/pkg/telemetry"
+	"go.opentelemetry.io/otel"
 
 	"github.com/litmuschaos/litmus-go/pkg/cerrors"
 	"github.com/litmuschaos/litmus-go/pkg/result"
@@ -187,27 +187,14 @@ func stopContainerdContainer(containerIDs []string, socketPath, signal, source s
 		cmd.Args = append(cmd.Args, "--timeout=0")
 	}
 	cmd.Args = append(cmd.Args, containerIDs...)
-
-	var errOut, out bytes.Buffer
-	cmd.Stderr = &errOut
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return cerrors.Error{ErrorCode: cerrors.ErrorTypeChaosInject, Source: source, Reason: fmt.Sprintf("failed to stop container :%s", out.String())}
-	}
-	return nil
+	return common.RunCLICommands(cmd, source, "", "failed to stop container", cerrors.ErrorTypeChaosInject)
 }
 
 // stopDockerContainer kill the application container
 func stopDockerContainer(containerIDs []string, socketPath, signal, source string) error {
-	var errOut, out bytes.Buffer
 	cmd := exec.Command("sudo", "docker", "--host", fmt.Sprintf("unix://%s", socketPath), "kill", "--signal", signal)
 	cmd.Args = append(cmd.Args, containerIDs...)
-	cmd.Stderr = &errOut
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return cerrors.Error{ErrorCode: cerrors.ErrorTypeChaosInject, Source: source, Reason: fmt.Sprintf("failed to stop container :%s", out.String())}
-	}
-	return nil
+	return common.RunCLICommands(cmd, source, "", "failed to stop container", cerrors.ErrorTypeChaosInject)
 }
 
 // getRestartCount return the restart count of target container


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Should the container-kill experiment fail with an error, the error message is not logged and it is not included included in the fault summary of the experiment run. This would happen if the command used to kill the container returns an exit code other than 0. It makes it hard to troubleshoot container-kill, if it isn't working as intended.

The problem is that text added to the error the description is taken from the stdout of the command rather than stderr. 

To fix this I have used the common.RunCLICommand function to execute the command. This will use the output from stderr to be included the error message instead of stdout.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #740 

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes #740 
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
