### PR TITLE
feat: add fault injection span for pod-autoscaler experiment

### DIFF
--- a/chaoslib/litmus/pod-autoscaler/lib/pod-autoscaler.go
+++ b/chaoslib/litmus/pod-autoscaler/lib/pod-autoscaler.go
@@ -161,6 +161,8 @@ func getStatefulsetDetails(experimentsDetails *experimentTypes.ExperimentDetails
 
 // podAutoscalerChaosInDeployment scales up the replicas of deployment and verify the status
 func podAutoscalerChaosInDeployment(ctx context.Context, experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, appsUnderTest []experimentTypes.ApplicationUnderTest, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+	ctx, span := otel.Tracer(telemetry.TracerName).Start(ctx, "InjectPodAutoscalerInDeploymentFault")
+	defer span.End()
 
 	// Scale Application
 	retryErr := retries.RetryOnConflict(retries.DefaultRetry, func() error {
@@ -192,6 +194,8 @@ func podAutoscalerChaosInDeployment(ctx context.Context, experimentsDetails *exp
 
 // podAutoscalerChaosInStatefulset scales up the replicas of statefulset and verify the status
 func podAutoscalerChaosInStatefulset(ctx context.Context, experimentsDetails *experimentTypes.ExperimentDetails, clients clients.ClientSets, appsUnderTest []experimentTypes.ApplicationUnderTest, resultDetails *types.ResultDetails, eventsDetails *types.EventDetails, chaosDetails *types.ChaosDetails) error {
+	ctx, span := otel.Tracer(telemetry.TracerName).Start(ctx, "InjectPodAutoscalerInStatefulsetFault")
+	defer span.End()
 
 	// Scale Application
 	retryErr := retries.RetryOnConflict(retries.DefaultRetry, func() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:  
This PR adds fault injection spans to the pod-autoscaler experiment. The added spans are `InjectPodAutoscalerInDeploymentFault` and `InjectPodAutoscalerInStatefulsetFault`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
