### PR TITLE
feat: JVM fault injection, phase one

### DIFF
--- a/java/MANIFEST.MF
+++ b/java/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Agent-Class: com.github.litmuschaos.litmusgo.JvmFaultInjectorAgent
+Can-Redefine-Classes: true
+Can-Retransform-Classes: true
+Main-Class: com.github.litmuschaos.litmusgo.JvmFaultInjectorMain
+

--- a/java/README.md
+++ b/java/README.md
@@ -1,0 +1,39 @@
+# JVM fault injector
+
+The JVM fault injector is a tool to inject either memory or CPU consumption into a running JVM.
+For more on the background see [JVM fault injection proposal](https://github.com/litmuschaos/litmus/blob/master/proposals/jvm-fault-injection.md)
+
+This tool is intended to be called from a helper-pod running on the same node as the targeted JVM.
+
+It accepts the following parameters
+`<process ID> <main command> <arguments>`
+
+Process ID: this is the ID of the java process.
+
+Main command: this is either `mem` for memory consumption, `cpu` for CPU consumption or `stop` to stop any ongoing fault injection.
+
+Arguments: available arguments depends on main command.
+
+## mem
+
+The mem command will fill up memory. It will run in a loop allocating memory for each iteration for a specified duration.
+
+| Option | Description |
+| --- | --- |
+| -k | Keep references to the allocated memory. This will prevent the allocated memory to be garbage collected. Without this option memory can be garbage collected. |
+| -d [integer] | Duration. The chaos will run for the number of seconds provided. Default 60 seconds.  |
+| -m  [integer] | How much memory, in mebibytes, that will be allocated for each iteration. Default is 1 MiB. (Max possible amount is 2047) |
+| -s [integer] | How many milliseconds of sleep time there will be for each iteration. Default 2000 milliseconds |
+
+## cpu
+
+The cpu command will generate CPU load for a period of time.
+
+| Option | Description |
+| --- | --- |
+| -d [integer] | Duration in seconds. Default is 60 seconds. |
+| -t [integer] | Number of concurrent threads to use. Default 1. |
+
+## stop
+
+The stop command will stop any ongoing fault injection.

--- a/java/src/com/github/litmuschaos/litmusgo/CpuLoadGenerator.java
+++ b/java/src/com/github/litmuschaos/litmusgo/CpuLoadGenerator.java
@@ -1,0 +1,14 @@
+package com.github.litmuschaos.litmusgo;
+
+public class CpuLoadGenerator {
+	private long fib0 = 0;
+	private long fib1 = 1;
+	
+
+	public void generateLoad() {
+		long fib2 = fib0 + fib1;
+		fib0 = fib1;
+		fib1 = fib2;
+	}
+}
+

--- a/java/src/com/github/litmuschaos/litmusgo/JvmFaultInjectorAgent.java
+++ b/java/src/com/github/litmuschaos/litmusgo/JvmFaultInjectorAgent.java
@@ -1,0 +1,105 @@
+package com.github.litmuschaos.litmusgo;
+
+import java.lang.instrument.Instrumentation;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class JvmFaultInjectorAgent {
+	private static AtomicBoolean alive = new AtomicBoolean(false);
+
+	// This method will be called when the jar is installed as an agent
+	public static void agentmain(String argsString, Instrumentation inst) throws Exception {
+		try {
+			String[] args = {};
+			if (argsString != null) {
+				args = argsString.split(" ");
+			}
+			final List<String> argsList = Arrays.asList(args);
+			String command = "";
+			if (args.length > 0) {
+				command = args[0];
+			}
+			if ("cpu".equals(command)) {
+				alive.set(true);
+				consumeCpu(argsList);
+			} else if ("mem".equals(command)) {
+				alive.set(true);
+				allocateMemory(argsList);
+			} else if ("stop".equals(command)) {
+				alive.set(false);
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	private static void consumeCpu(List<String> argsList) {
+		// Total duration in seconds
+		int duration = parseIntArg(argsList, "-d", 60);
+		long stopTime = System.currentTimeMillis() + (duration * 1000);
+		// Number of threads
+		int numThreads = parseIntArg(argsList, "-t", 1);
+		for (int i = 0; i < numThreads; i++) {
+			new Thread(() -> {
+				CpuLoadGenerator cpuLoadGenerator = new CpuLoadGenerator();
+				while (alive.get() && System.currentTimeMillis() < stopTime) {
+					cpuLoadGenerator.generateLoad();
+				}
+			}).start();
+		}
+	}
+
+	private static void allocateMemory(List<String> argsList) {
+		// Keep references, simulate a memory leak
+		boolean keep = argsList.contains("-k");
+		// Amount of megabytes to allocate in each iteration.
+		int memory = parseIntArg(argsList, "-m", 1);
+		if (memory > 2047) {
+			// Memory parameter cannot be more than 2047 MiB. Setting it to 2047.
+			memory = 2047;
+		}
+		int amountOfBytesToAllocate = 1024 * 1024 * memory;
+		// Time to sleep for each iteration, in milliseconds
+		int sleepMillis = parseIntArg(argsList, "-s", 2000);
+		// Total duration in seconds
+		int duration = parseIntArg(argsList, "-d", 60);
+		long stopTime = System.currentTimeMillis() + (duration * 1000);
+		ArrayList<ByteBuffer> keepReferences = new ArrayList<ByteBuffer>();
+		new Thread(() -> {
+			boolean allocateMemory = true;
+			while (alive.get() && System.currentTimeMillis() < stopTime) {
+				try {
+					if (allocateMemory) {
+						ByteBuffer bb = ByteBuffer.allocate(amountOfBytesToAllocate);
+						if (keep) {
+							keepReferences.add(bb);
+						}
+					}
+					sleep(sleepMillis);
+				} catch (OutOfMemoryError outOfMemoryError) {
+					// If an OutOfMemory occurs, we stop allocating more memory but continue the
+					// thread, keeping references until the duration is over.
+					allocateMemory = false;
+				}
+			}
+		}).start();
+	}
+
+	private static int parseIntArg(List<String> args, String argName, int defaultValue) {
+		if (args.contains(argName)) {
+			return Integer.parseInt(args.get(args.indexOf(argName) + 1));
+		}
+		return defaultValue;
+	}
+
+	private static void sleep(long time) {
+		try {
+			Thread.sleep(time);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/java/src/com/github/litmuschaos/litmusgo/JvmFaultInjectorMain.java
+++ b/java/src/com/github/litmuschaos/litmusgo/JvmFaultInjectorMain.java
@@ -1,0 +1,37 @@
+package com.github.litmuschaos.litmusgo;
+
+import java.io.File;
+
+import com.sun.tools.attach.VirtualMachine;
+
+public class JvmFaultInjectorMain {
+
+	/*
+	 * Calling this will install the jar file it belongs to as a Java Agent. 
+	 * This will call the agentmain method of the JvmFaultInjectorAgent class.
+	 */
+	public static void main(String[] args) {
+		try {
+			String jvmPid = args[0];
+			String options = null;
+			if (args.length > 1) {
+				for (int i = 1; i < args.length; i++) {
+					if (options == null) {
+						options = args[i];
+					} else {
+						options = options + " " + args[i];
+					}
+				}
+			}
+			VirtualMachine jvm = VirtualMachine.attach(jvmPid);
+			// Lookup of the path to the running JAR
+			String jarUrl = JvmFaultInjectorMain.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+			String jarPath = new File(jarUrl).getCanonicalPath();
+			jvm.loadAgent(jarPath, options);
+			jvm.detach();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+    
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This is the first pull request in a series of pull requests that will implement JVM fault injection. For more background, please read the proposal here: https://github.com/litmuschaos/litmus/blob/master/proposals/jvm-fault-injection.md

This is a java tool that can consume memory or CPU in a running JVM. See the README.md file for more details.

**Special notes for your reviewer**:

This pull request only contains the Java code part of the fault injection. The intention is to invoke this from helper-pod running in the same node as the target JVM.

Future pull requests will contain: building a jar-file and including it in the litmus-go image and the code for two experiments (cpu and memory allocation) in go code that invokes the java tool. 

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
