### PR TITLE
DNS Chaos - Format TargetHostnames String For dns_interceptor Binary

### DIFF
--- a/chaoslib/litmus/pod-dns-chaos/helper/dnschaos.go
+++ b/chaoslib/litmus/pod-dns-chaos/helper/dnschaos.go
@@ -4,10 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/litmuschaos/litmus-go/pkg/cerrors"
-	"github.com/litmuschaos/litmus-go/pkg/telemetry"
-	"github.com/palantir/stacktrace"
-	"go.opentelemetry.io/otel"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -16,6 +12,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/litmuschaos/litmus-go/pkg/cerrors"
+	"github.com/litmuschaos/litmus-go/pkg/telemetry"
+	"github.com/palantir/stacktrace"
+	"go.opentelemetry.io/otel"
+
 	clients "github.com/litmuschaos/litmus-go/pkg/clients"
 	"github.com/litmuschaos/litmus-go/pkg/events"
 	experimentTypes "github.com/litmuschaos/litmus-go/pkg/generic/pod-dns-chaos/types"
@@ -23,6 +24,7 @@ import (
 	"github.com/litmuschaos/litmus-go/pkg/result"
 	"github.com/litmuschaos/litmus-go/pkg/types"
 	"github.com/litmuschaos/litmus-go/pkg/utils/common"
+	"github.com/litmuschaos/litmus-go/pkg/utils/stringutils"
 	clientTypes "k8s.io/apimachinery/pkg/types"
 )
 
@@ -212,7 +214,7 @@ func injectChaos(experimentsDetails *experimentTypes.ExperimentDetails, t target
 
 	// prepare dns interceptor
 	var out bytes.Buffer
-	commandTemplate := fmt.Sprintf("sudo TARGET_PID=%d CHAOS_TYPE=%s SPOOF_MAP='%s' TARGET_HOSTNAMES='%s' CHAOS_DURATION=%d MATCH_SCHEME=%s nsutil -p -n -t %d -- dns_interceptor", t.Pid, experimentsDetails.ChaosType, experimentsDetails.SpoofMap, experimentsDetails.TargetHostNames, experimentsDetails.ChaosDuration, experimentsDetails.MatchScheme, t.Pid)
+	commandTemplate := fmt.Sprintf("sudo TARGET_PID=%d CHAOS_TYPE=%s SPOOF_MAP='%s' TARGET_HOSTNAMES='%s' CHAOS_DURATION=%d MATCH_SCHEME=%s nsutil -p -n -t %d -- dns_interceptor", t.Pid, experimentsDetails.ChaosType, experimentsDetails.SpoofMap, stringutils.FormatHostnames(experimentsDetails.TargetHostNames), experimentsDetails.ChaosDuration, experimentsDetails.MatchScheme, t.Pid)
 	cmd := exec.Command("/bin/bash", "-c", commandTemplate)
 	log.Info(cmd.String())
 	cmd.Stdout = &out

--- a/pkg/utils/stringutils/string.go
+++ b/pkg/utils/stringutils/string.go
@@ -3,6 +3,8 @@ package stringutils
 import (
 	"math/rand"
 	"time"
+	"strings"
+	"fmt"
 )
 
 const (
@@ -32,4 +34,13 @@ func RandStringBytesMask(n int, src rand.Source) string {
 	}
 
 	return string(b)
+}
+
+func FormatHostnames(input string) string {
+	// Split the input by comma and trim spaces
+	parts := strings.Split(input, ",")
+	for i, name := range parts {
+		parts[i] = fmt.Sprintf("\"%s\"", strings.TrimSpace(name))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(parts, ", "))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR creates a function under stringutils which takes comma separated targetHostnames string as input and return formatted string which is expected by dns_interceptor binary

This removes manual effort from the user to enter a string with correct formatting

For example

experiment.targetHostnames = "Alice, Bob, Charlie" (string entered by user)
FormatHostnames(experiment.targetHostnames) = "["Alice", "Bob", "Charlie"]" (as expected by dns_interceptor binary)

As of now the experiment fails when a comma separated string value is passed from ChaosCenter.



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
