### PR TITLE
written test for `workload.go` in `pkg/workloads`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0
 	go.opentelemetry.io/otel/sdk v1.27.0
-	go.opentelemetry.io/otel/trace v1.27.0
+	golang.org/x/net v0.25.0
 	google.golang.org/api v0.169.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.30.1
@@ -45,6 +45,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
+	github.com/evanphx/json-patch v5.9.11+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -75,9 +76,9 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel/metric v1.27.0 // indirect
+	go.opentelemetry.io/otel/trace v1.27.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.2.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
-	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/term v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb4Z+d1UQi45df52xW8=
+github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=

--- a/pkg/workloads/workloads_test.go
+++ b/pkg/workloads/workloads_test.go
@@ -1,0 +1,297 @@
+package workloads
+
+import (
+	"testing"
+	"github.com/litmuschaos/litmus-go/pkg/types"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime" 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dfake "k8s.io/client-go/dynamic/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var fakeDynamicClient dynamic.Interface = nil 
+func Test_getPodsFromWorkload(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    types.AppDetails
+		allPods   *corev1.PodList
+		wantCount int
+		expectErr bool
+	}{
+		{
+			name: "match pod by kind and name",
+			target: types.AppDetails{
+				Kind:      "statefulset",
+				Namespace: "default",
+				Names:     []string{"my-statefulset"},
+			},
+			allPods: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "pod-1",
+							Namespace: "default",
+							OwnerReferences: []v1.OwnerReference{
+								{
+									Kind: "StatefulSet",
+									Name: "my-statefulset",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCount: 1,
+			expectErr: false,
+		},
+		{
+			name: "no matching pod",
+			target: types.AppDetails{
+				Kind:      "daemonset",
+				Namespace: "default",
+				Names:     []string{"non-existent"},
+			},
+			allPods: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "pod-2",
+							Namespace: "default",
+							OwnerReferences: []v1.OwnerReference{
+								{
+									Kind: "DaemonSet",
+									Name: "some-other-daemonset",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCount: 0,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getPodsFromWorkload(tt.target, tt.allPods, fakeDynamicClient)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("getPodsFromWorkload() error = %v, expectErr = %v", err, tt.expectErr)
+			}
+			if len(got.Items) != tt.wantCount {
+				t.Errorf("expected %d pods, got %d", tt.wantCount, len(got.Items))
+			}
+		})
+	}
+}
+
+func Test_getParent(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "replicasets",
+	}
+
+	scheme := runtime.NewScheme()
+	tests := []struct {
+		name           string
+		resourceName   string
+		namespace      string
+		owners         []metav1.OwnerReference
+		expectKind     string
+		expectName     string
+		expectError    bool
+	}{
+		{
+			name:         "has deployment owner",
+			resourceName: "my-replicaset",
+			namespace:    "default",
+			owners: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "my-deployment"},
+			},
+			expectKind:  "deployment",
+			expectName:  "my-deployment",
+			expectError: false,
+		},
+		{
+			name:         "has rollout owner",
+			resourceName: "rollout-set",
+			namespace:    "default",
+			owners: []metav1.OwnerReference{
+				{Kind: "Rollout", Name: "my-rollout"},
+			},
+			expectKind:  "rollout",
+			expectName:  "my-rollout",
+			expectError: false,
+		},
+		{
+			name:         "has deploymentconfig owner",
+			resourceName: "dc-set",
+			namespace:    "default",
+			owners: []metav1.OwnerReference{
+				{Kind: "DeploymentConfig", Name: "my-dc"},
+			},
+			expectKind:  "deploymentconfig",
+			expectName:  "my-dc",
+			expectError: false,
+		},
+		{
+			name:         "no matching owner kind",
+			resourceName: "other-set",
+			namespace:    "default",
+			owners: []metav1.OwnerReference{
+				{Kind: "StatefulSet", Name: "my-ss"},
+			},
+			expectKind:  "",
+			expectName:  "",
+			expectError: false,
+		},
+		{
+			name:         "resource not found",
+			resourceName: "missing-set",
+			namespace:    "default",
+			owners:       nil,
+			expectKind:   "",
+			expectName:   "",
+			expectError:  true,
+		},
+	}
+
+	objs := []runtime.Object{}
+	for _, tt := range tests {
+		if tt.owners != nil {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "ReplicaSet",
+			})
+			obj.SetName(tt.resourceName)
+			obj.SetNamespace(tt.namespace)
+			obj.SetOwnerReferences(tt.owners)
+			objs = append(objs, obj)
+		}
+	}
+
+	fakeDynamic := dfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		gvr: "ReplicaSetList",
+	}, objs...)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, name, err := getParent(tt.resourceName, tt.namespace, gvr, fakeDynamic)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectKind, kind)
+				assert.Equal(t, tt.expectName, name)
+			}
+		})
+	}
+}
+
+func Test_GetPodOwnerTypeAndName(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvr := schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "replicasets",
+	}
+
+	// Setup dynamic client for ReplicaSet parent
+	rsObj := &unstructured.Unstructured{}
+	rsObj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "ReplicaSet",
+	})
+	rsObj.SetName("my-replicaset")
+	rsObj.SetNamespace("default")
+	rsObj.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			Kind: "Deployment",
+			Name: "my-deployment",
+		},
+	})
+
+	fakeDynamic := dfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		gvr: "ReplicaSetList",
+	}, rsObj)
+
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		expectedKind  string
+		expectedName  string
+		expectErr     bool
+		dynamicClient dynamic.Interface
+	}{
+		{
+			name: "StatefulSet owner",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-ss",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "StatefulSet", Name: "my-ss"},
+					},
+				},
+			},
+			expectedKind:  "statefulset",
+			expectedName:  "my-ss",
+			expectErr:     false,
+			dynamicClient: nil,
+		},
+		{
+			name: "ReplicaSet with pod-template-hash match",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-rs",
+					Namespace: "default",
+					Labels: map[string]string{
+						"pod-template-hash": "my-replicaset",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "ReplicaSet", Name: "my-replicaset"},
+					},
+				},
+			},
+			expectedKind:  "deployment",
+			expectedName:  "my-deployment",
+			expectErr:     false,
+			dynamicClient: fakeDynamic,
+		},
+		{
+			name: "No owner",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "orphan-pod",
+					OwnerReferences: nil,
+				},
+			},
+			expectedKind:  "",
+			expectedName:  "",
+			expectErr:     false,
+			dynamicClient: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, name, err := GetPodOwnerTypeAndName(tt.pod, tt.dynamicClient)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedKind, kind)
+				assert.Equal(t, tt.expectedName, name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds table-driven unit tests for the utility functions in workloads.go of the Litmus Go repository. The coverage increases to **70%**.

**Which issue this PR fixes** 
fixes #763 

**Special notes for your reviewer**:
The test suite includes:
- getPodsFromWorkload
- getParent
- GetPodOwnerTypeAndName

**Checklist:**
-   [x] Fixes #763 
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [x] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
