### PR TITLE
feat: add label intersection mode for precise pod targeting

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -156,10 +156,11 @@ type ProbeContext struct {
 
 // AppDetails contains all the application related envs
 type AppDetails struct {
-	Namespace string
-	Labels    []string
-	Kind      string
-	Names     []string
+	Namespace      string
+	Labels         []string
+	Kind           string
+	Names          []string
+	LabelMatchMode string
 }
 
 func GetTargets(targets string) []AppDetails {
@@ -171,9 +172,18 @@ func GetTargets(targets string) []AppDetails {
 	for _, k := range t {
 		val := strings.Split(strings.TrimSpace(k), ":")
 		data := AppDetails{
-			Kind:      val[0],
-			Namespace: val[1],
+			Kind:           val[0],
+			Namespace:      val[1],
+			LabelMatchMode: "union",
 		}
+		
+		if len(val) > 3 {
+			mode := strings.TrimSpace(val[3])
+			if mode == "intersection" || mode == "union" {
+				data.LabelMatchMode = mode
+			}
+		}
+		
 		if strings.Contains(val[2], "=") {
 			data.Labels = parse(val[2])
 		} else {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/litmuschaos/litmus-go/pkg/cerrors"
+	"github.com/litmuschaos/litmus-go/pkg/log"
 	"github.com/litmuschaos/litmus-go/pkg/utils/stringutils"
 
 	"github.com/litmuschaos/chaos-operator/api/litmuschaos/v1alpha1"
@@ -170,20 +171,27 @@ func GetTargets(targets string) []AppDetails {
 	}
 	t := strings.Split(targets, ";")
 	for _, k := range t {
-		val := strings.Split(strings.TrimSpace(k), ":")
+		trimmed := strings.TrimSpace(k)
+		if trimmed == "" {
+			continue
+		}
+		val := strings.Split(trimmed, ":")
+		if len(val) < 3 {
+			log.Fatalf("invalid TARGETS entry %q: expected format kind:namespace:[labels|names][:mode]", trimmed)
+		}
 		data := AppDetails{
 			Kind:           val[0],
 			Namespace:      val[1],
 			LabelMatchMode: "union",
 		}
-		
+
 		if len(val) > 3 {
 			mode := strings.TrimSpace(val[3])
 			if mode == "intersection" || mode == "union" {
 				data.LabelMatchMode = mode
 			}
 		}
-		
+
 		if strings.Contains(val[2], "=") {
 			data.Labels = parse(val[2])
 		} else {

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,140 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestGetTargets_UnionModeDefault(t *testing.T) {
+	// Test that union is the default mode when not specified
+	targets := "deployment:default:[app=nginx,tier=frontend]"
+	result := GetTargets(targets)
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 AppDetail, got %d", len(result))
+	}
+
+	if result[0].LabelMatchMode != "union" {
+		t.Errorf("Expected default LabelMatchMode to be 'union', got '%s'", result[0].LabelMatchMode)
+	}
+
+	if result[0].Kind != "deployment" {
+		t.Errorf("Expected Kind to be 'deployment', got '%s'", result[0].Kind)
+	}
+
+	if result[0].Namespace != "default" {
+		t.Errorf("Expected Namespace to be 'default', got '%s'", result[0].Namespace)
+	}
+
+	if len(result[0].Labels) != 2 {
+		t.Errorf("Expected 2 labels, got %d", len(result[0].Labels))
+	}
+}
+
+func TestGetTargets_ExplicitUnionMode(t *testing.T) {
+	// Test explicit union mode
+	targets := "statefulset:prod:[app=postgres,role=primary]:union"
+	result := GetTargets(targets)
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 AppDetail, got %d", len(result))
+	}
+
+	if result[0].LabelMatchMode != "union" {
+		t.Errorf("Expected LabelMatchMode to be 'union', got '%s'", result[0].LabelMatchMode)
+	}
+
+	if result[0].Kind != "statefulset" {
+		t.Errorf("Expected Kind to be 'statefulset', got '%s'", result[0].Kind)
+	}
+}
+
+func TestGetTargets_IntersectionMode(t *testing.T) {
+	// Test intersection mode
+	targets := "cluster:default:[cnpg.io/instanceRole=primary,cnpg.io/cluster=pg-eu]:intersection"
+	result := GetTargets(targets)
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 AppDetail, got %d", len(result))
+	}
+
+	if result[0].LabelMatchMode != "intersection" {
+		t.Errorf("Expected LabelMatchMode to be 'intersection', got '%s'", result[0].LabelMatchMode)
+	}
+
+	if result[0].Kind != "cluster" {
+		t.Errorf("Expected Kind to be 'cluster', got '%s'", result[0].Kind)
+	}
+
+	if result[0].Namespace != "default" {
+		t.Errorf("Expected Namespace to be 'default', got '%s'", result[0].Namespace)
+	}
+
+	if len(result[0].Labels) != 2 {
+		t.Errorf("Expected 2 labels, got %d", len(result[0].Labels))
+	}
+
+	expectedLabels := []string{"cnpg.io/instanceRole=primary", "cnpg.io/cluster=pg-eu"}
+	for i, label := range result[0].Labels {
+		if label != expectedLabels[i] {
+			t.Errorf("Expected label[%d] to be '%s', got '%s'", i, expectedLabels[i], label)
+		}
+	}
+}
+
+func TestGetTargets_InvalidMode(t *testing.T) {
+	// Test that invalid mode falls back to union
+	targets := "deployment:default:[app=nginx]:invalid"
+	result := GetTargets(targets)
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 AppDetail, got %d", len(result))
+	}
+
+	// Invalid mode should fall back to union
+	if result[0].LabelMatchMode != "union" {
+		t.Errorf("Expected invalid mode to fall back to 'union', got '%s'", result[0].LabelMatchMode)
+	}
+}
+
+func TestGetTargets_MultipleSemicolonSeparated(t *testing.T) {
+	// Test multiple targets with different modes
+	targets := "deployment:ns1:[app=web]:union;statefulset:ns2:[db=postgres,env=prod]:intersection"
+	result := GetTargets(targets)
+
+	if len(result) != 2 {
+		t.Errorf("Expected 2 AppDetails, got %d", len(result))
+	}
+
+	// First target - union
+	if result[0].LabelMatchMode != "union" {
+		t.Errorf("Expected first target LabelMatchMode to be 'union', got '%s'", result[0].LabelMatchMode)
+	}
+
+	// Second target - intersection
+	if result[1].LabelMatchMode != "intersection" {
+		t.Errorf("Expected second target LabelMatchMode to be 'intersection', got '%s'", result[1].LabelMatchMode)
+	}
+}
+
+func TestGetTargets_WithNames(t *testing.T) {
+	// Test that Names parsing still works with the new field
+	targets := "pod:default:[pod1,pod2,pod3]"
+	result := GetTargets(targets)
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 AppDetail, got %d", len(result))
+	}
+
+	if len(result[0].Names) != 3 {
+		t.Errorf("Expected 3 names, got %d", len(result[0].Names))
+	}
+
+	if len(result[0].Labels) != 0 {
+		t.Errorf("Expected 0 labels when Names are provided, got %d", len(result[0].Labels))
+	}
+
+	// Default mode should still be union
+	if result[0].LabelMatchMode != "union" {
+		t.Errorf("Expected default LabelMatchMode to be 'union', got '%s'", result[0].LabelMatchMode)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR adds support for **label intersection mode** when selecting target pods for chaos experiments, enabling precise pod targeting by matching ALL specified labels (AND logic) instead of the default union behavior that matches ANY label (OR logic).

**Problem:** Currently, multiple labels use UNION (OR) logic - selecting pods that match ANY label. This causes unintended pod selection when precise targeting is needed (e.g., "primary role AND specific cluster"). As noted in issue #774, when working with CloudNativePG clusters that have multiple instances with different roles, the union behavior selects too many pods.

**Solution:** Adds optional 4th parameter to TARGETS env variable:
```
TARGETS="kind:namespace:[labels]:mode"
```
Where mode can be `union` (default) or `intersection`

**Example:**
```yaml
# Union (default): Gets pods with app=web OR tier=frontend
- name: TARGETS
  value: "deployment:default:[app=web,tier=frontend]:union"

# Intersection: Gets pods with app=web AND tier=frontend
- name: TARGETS
  value: "deployment:default:[app=web,tier=frontend]:intersection"
```

**Changes:**
- Added `LabelMatchMode` field to `AppDetails` struct
- Added `getPodsWithIntersectionLabels()` function
- Updated `GetTargets()` to parse optional mode parameter
- Added comprehensive unit tests (140 lines)
- Added documentation and examples

**Backward Compatibility:** Fully compatible - defaults to union mode

**Which issue this PR fixes** : fixes #774

**Use Cases:**
- Any scenario requiring AND logic for labels

**Checklist:**
- [x] Fixes #774
- [x] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag - **Not applicable** (backward compatible)
- [ ] PR messages has breaking changes related information - **Not applicable**
- [ ] Labelled this PR & related issue with `requires-upgrade` tag - **Not applicable**
- [ ] PR messages has upgrade related information - **Not applicable**
- [x] Commit has unit tests - **Yes** (`pkg/types/types_test.go`)
- [ ] Commit has integration tests - **No** (covered by unit tests)
- [ ] E2E run Required for the changes - **Recommended** (test both union and intersection modes)