### PR TITLE
fix: treat HTTP probe connection errors as failures instead of errors

### DIFF
--- a/pkg/probe/httpprobe.go
+++ b/pkg/probe/httpprobe.go
@@ -116,7 +116,9 @@ func httpGet(probe v1alpha1.ProbeAttributes, client *http.Client, resultDetails 
 			// getting the response from the given url
 			resp, err := client.Get(probe.HTTPProbeInputs.URL)
 			if err != nil {
-				if utils.HttpTimeout(err) {
+				// Treat connection errors (timeout, connection refused, network unreachable, etc.) as failures
+				// instead of errors so they can be handled with stopOnFailure config
+				if utils.HttpTimeout(err) || utils.IsConnectionError(err) {
 					return cerrors.Error{ErrorCode: cerrors.FailureTypeHttpProbe, Target: fmt.Sprintf("{name: %v}", probe.Name), Reason: err.Error()}
 				}
 				return cerrors.Error{ErrorCode: cerrors.ErrorTypeHttpProbe, Target: fmt.Sprintf("{name: %v}", probe.Name), Reason: err.Error()}
@@ -163,7 +165,9 @@ func httpPost(probe v1alpha1.ProbeAttributes, client *http.Client, resultDetails
 		Try(func(attempt uint) error {
 			resp, err := client.Post(probe.HTTPProbeInputs.URL, probe.HTTPProbeInputs.Method.Post.ContentType, strings.NewReader(body))
 			if err != nil {
-				if utils.HttpTimeout(err) {
+				// Treat connection errors (timeout, connection refused, network unreachable, etc.) as failures
+				// instead of errors so they can be handled with stopOnFailure config
+				if utils.HttpTimeout(err) || utils.IsConnectionError(err) {
 					return cerrors.Error{ErrorCode: cerrors.FailureTypeHttpProbe, Target: fmt.Sprintf("{name: %v}", probe.Name), Reason: err.Error()}
 				}
 				return cerrors.Error{ErrorCode: cerrors.ErrorTypeHttpProbe, Target: fmt.Sprintf("{name: %v}", probe.Name), Reason: err.Error()}


### PR DESCRIPTION
**What this PR does / why we need it**

This PR fixes incorrect classification of HTTP probe connection errors in Litmus Chaos.

Currently, HTTP probes treat network-level connection errors (e.g., connection refused, timeout, network unreachable) as execution errors (HTTP_PROBE_ERROR) instead of probe failures.
This behavior causes chaos experiments to terminate even when stopOnFailure: false is configured.

This PR ensures that expected connection failures during network chaos are handled as probe failures, allowing experiments to proceed as intended.

Which issue this PR fixes
Fixes litmuschaos/litmus#5351

**Checklist:**
-   [ ] Fixes litmuschaos/litmus#5351
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
