### PR TITLE
feat: add Job workload type support for pod targeting

### DIFF
--- a/pkg/workloads/workloads.go
+++ b/pkg/workloads/workloads.go
@@ -74,7 +74,7 @@ func GetPodOwnerTypeAndName(pod *kcorev1.Pod, dynamicClient dynamic.Interface) (
 	for _, owner := range pod.GetOwnerReferences() {
 		parentName = owner.Name
 		parentType = strings.ToLower(owner.Kind)
-		if owner.Kind == "StatefulSet" || owner.Kind == "DaemonSet" {
+		if owner.Kind == "StatefulSet" || owner.Kind == "DaemonSet" || owner.Kind == "Job" {
 			return strings.ToLower(owner.Kind), parentName, nil
 		}
 

--- a/pkg/workloads/workloads_test.go
+++ b/pkg/workloads/workloads_test.go
@@ -250,6 +250,22 @@ func Test_GetPodOwnerTypeAndName(t *testing.T) {
 			dynamicClient: nil,
 		},
 		{
+			name: "Job owner",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-job",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Job", Name: "my-job"},
+					},
+				},
+			},
+			expectedKind:  "job",
+			expectedName:  "my-job",
+			expectErr:     false,
+			dynamicClient: nil,
+		},
+		{
 			name: "ReplicaSet with pod-template-hash match",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**
This PR adds support for targeting pods owned by Kubernetes Jobs in chaos experiments. Previously, the GetPodOwnerTypeAndName function did not recognize Jobs, causing targeting to fail. I’ve updated the logic to include Job as a valid owner

**Which issue this PR fixes**
Fixes litmuschaos/litmus#5000

**Special notes for your reviewer**
Logic update including a unit test. It is needed for adding Job targeting in the main litmus repo as told by @ispeakc0de 

**Checklist**
[ ] PR message has document related information
[ ] Labelled this PR & related issue with breaking-changes tag
[ ] PR message has breaking changes related information
[ ] Labelled this PR & related issue with requires-upgrade tag
[ ] PR message has upgrade related information
[x] Commit has unit tests
[ ] Commit has integration tests
[ ] E2E run Required for the changes