### PR TITLE
feat: add deterministic pod termination order support

### DIFF
--- a/chaoslib/litmus/container-kill/helper/container-kill.go
+++ b/chaoslib/litmus/container-kill/helper/container-kill.go
@@ -31,7 +31,7 @@ var err error
 
 // Helper injects the container-kill chaos
 func Helper(ctx context.Context, clients clients.ClientSets) {
-	ctx, span := otel.Tracer(telemetry.TracerName).Start(ctx, "SimulateContainerKillFault")
+	_, span := otel.Tracer(telemetry.TracerName).Start(ctx, "SimulateContainerKillFault")
 	defer span.End()
 
 	experimentsDetails := experimentTypes.ExperimentDetails{}
@@ -149,7 +149,7 @@ func kill(experimentsDetails *experimentTypes.ExperimentDetails, containerIds []
 	if experimentsDetails.EngineName != "" {
 		msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
 		types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
-		events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+		_ = events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
 	}
 
 	switch experimentsDetails.ContainerRuntime {

--- a/chaoslib/litmus/container-kill/helper/container-kill.go
+++ b/chaoslib/litmus/container-kill/helper/container-kill.go
@@ -149,7 +149,9 @@ func kill(experimentsDetails *experimentTypes.ExperimentDetails, containerIds []
 	if experimentsDetails.EngineName != "" {
 		msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
 		types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
-		_ = events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+		if err := events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine"); err != nil {
+			log.Errorf("[Chaos]: Failed to create chaosengine inject event, err: %v", err)
+		}
 	}
 
 	switch experimentsDetails.ContainerRuntime {

--- a/chaoslib/litmus/container-kill/lib/container-kill.go
+++ b/chaoslib/litmus/container-kill/lib/container-kill.go
@@ -43,7 +43,7 @@ func PrepareContainerKill(ctx context.Context, experimentsDetails *experimentTyp
 		"Sequence":         experimentsDetails.Sequence,
 	})
 
-	targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, clients, chaosDetails)
+	targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, experimentsDetails.PodTerminationOrder, clients, chaosDetails)
 	if err != nil {
 		return stacktrace.Propagate(err, "could not get target pods")
 	}

--- a/chaoslib/litmus/container-kill/lib/container-kill.go
+++ b/chaoslib/litmus/container-kill/lib/container-kill.go
@@ -38,7 +38,7 @@ func PrepareContainerKill(ctx context.Context, experimentsDetails *experimentTyp
 	//Set up the tunables if provided in range
 	SetChaosTunables(experimentsDetails)
 
-	log.InfoWithValues("[Info]: The tunables are:", logrus.Fields{
+	log.InfoWithValues("The tunables are:", logrus.Fields{
 		"PodsAffectedPerc": experimentsDetails.PodsAffectedPerc,
 		"Sequence":         experimentsDetails.Sequence,
 	})
@@ -102,7 +102,7 @@ func injectChaosInSerialMode(ctx context.Context, experimentsDetails *experiment
 	}
 
 	// creating the helper pod to perform container kill chaos
-	for _, pod := range targetPodList.Items {
+	for i, pod := range targetPodList.Items {
 
 		//Get the target container name of the application pod
 		if !experimentsDetails.IsTargetContainerProvided {
@@ -119,6 +119,12 @@ func injectChaosInSerialMode(ctx context.Context, experimentsDetails *experiment
 
 		if err := common.ManagerHelperLifecycle(appLabel, chaosDetails, clients, true); err != nil {
 			return err
+		}
+
+		// Wait for the inter-pod kill interval only between pods, not after the last one.
+		if experimentsDetails.InterPodKillIntervalSeconds > 0 && i < len(targetPodList.Items)-1 {
+			log.Infof("[Wait]: Waiting %vs between pod kills (INTER_POD_KILL_INTERVAL_SECONDS)", experimentsDetails.InterPodKillIntervalSeconds)
+			common.WaitForDuration(experimentsDetails.InterPodKillIntervalSeconds)
 		}
 	}
 	return nil
@@ -163,10 +169,7 @@ func createHelperPod(ctx context.Context, experimentsDetails *experimentTypes.Ex
 	ctx, span := otel.Tracer(telemetry.TracerName).Start(ctx, "CreateContainerKillFaultHelperPod")
 	defer span.End()
 
-	privilegedEnable := false
-	if experimentsDetails.ContainerRuntime == "crio" {
-		privilegedEnable = true
-	}
+	privilegedEnable := experimentsDetails.ContainerRuntime == "crio"
 	terminationGracePeriodSeconds := int64(experimentsDetails.TerminationGracePeriodSeconds)
 
 	helperPod := &apiv1.Pod{

--- a/chaoslib/litmus/disk-fill/lib/disk-fill.go
+++ b/chaoslib/litmus/disk-fill/lib/disk-fill.go
@@ -48,7 +48,7 @@ func PrepareDiskFill(ctx context.Context, experimentsDetails *experimentTypes.Ex
 		"Sequence":                  experimentsDetails.Sequence,
 	})
 
-	targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, clients, chaosDetails)
+	targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, "", clients, chaosDetails)
 	if err != nil {
 		return stacktrace.Propagate(err, "could not get target pods")
 	}

--- a/chaoslib/litmus/http-chaos/lib/http-chaos.go
+++ b/chaoslib/litmus/http-chaos/lib/http-chaos.go
@@ -36,7 +36,7 @@ func PrepareAndInjectChaos(ctx context.Context, experimentsDetails *experimentTy
 	//set up the tunables if provided in range
 	SetChaosTunables(experimentsDetails)
 
-	targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, clients, chaosDetails)
+	targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, "", clients, chaosDetails)
 	if err != nil {
 		return stacktrace.Propagate(err, "could not get target pods")
 	}

--- a/chaoslib/litmus/network-chaos/lib/network-chaos.go
+++ b/chaoslib/litmus/network-chaos/lib/network-chaos.go
@@ -43,7 +43,7 @@ func PrepareAndInjectChaos(ctx context.Context, experimentsDetails *experimentTy
 	SetChaosTunables(experimentsDetails)
 	logExperimentFields(experimentsDetails)
 
-	targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, clients, chaosDetails)
+	targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, "", clients, chaosDetails)
 	if err != nil {
 		return stacktrace.Propagate(err, "could not get target pods")
 	}

--- a/chaoslib/litmus/pod-delete/lib/pod-delete.go
+++ b/chaoslib/litmus/pod-delete/lib/pod-delete.go
@@ -112,7 +112,7 @@ func injectChaosInSerialMode(ctx context.Context, experimentsDetails *experiment
 		}
 
 		//Deleting the application pod
-		for _, pod := range targetPodList.Items {
+		for i, pod := range targetPodList.Items {
 
 			log.InfoWithValues("[Info]: Killing the following pods", logrus.Fields{
 				"PodName": pod.Name})
@@ -126,9 +126,8 @@ func injectChaosInSerialMode(ctx context.Context, experimentsDetails *experiment
 				return cerrors.Error{ErrorCode: cerrors.ErrorTypeChaosInject, Target: fmt.Sprintf("{podName: %s, namespace: %s}", pod.Name, pod.Namespace), Reason: fmt.Sprintf("failed to delete the target pod: %s", err.Error())}
 			}
 
-			// Wait for the inter-pod kill interval before deleting the next pod.
-			// This is additive to CHAOS_INTERVAL and fires even when RANDOMNESS is enabled.
-			if experimentsDetails.InterPodKillIntervalSeconds > 0 {
+			// Wait for the inter-pod kill interval only between pods, not after the last one.
+			if experimentsDetails.InterPodKillIntervalSeconds > 0 && i < len(targetPodList.Items)-1 {
 				log.Infof("[Wait]: Waiting %vs between pod kills (INTER_POD_KILL_INTERVAL_SECONDS)", experimentsDetails.InterPodKillIntervalSeconds)
 				common.WaitForDuration(experimentsDetails.InterPodKillIntervalSeconds)
 			}

--- a/chaoslib/litmus/pod-delete/lib/pod-delete.go
+++ b/chaoslib/litmus/pod-delete/lib/pod-delete.go
@@ -88,7 +88,7 @@ func injectChaosInSerialMode(ctx context.Context, experimentsDetails *experiment
 			return cerrors.Error{ErrorCode: cerrors.ErrorTypeTargetSelection, Reason: "provide one of the appLabel or TARGET_PODS"}
 		}
 
-		targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, clients, chaosDetails)
+		targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, experimentsDetails.PodTerminationOrder, clients, chaosDetails)
 		if err != nil {
 			return stacktrace.Propagate(err, "could not get target pods")
 		}
@@ -108,7 +108,7 @@ func injectChaosInSerialMode(ctx context.Context, experimentsDetails *experiment
 		if experimentsDetails.EngineName != "" {
 			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
 			types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
-			events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+			_ = events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
 		}
 
 		//Deleting the application pod
@@ -124,6 +124,13 @@ func injectChaosInSerialMode(ctx context.Context, experimentsDetails *experiment
 			}
 			if err != nil {
 				return cerrors.Error{ErrorCode: cerrors.ErrorTypeChaosInject, Target: fmt.Sprintf("{podName: %s, namespace: %s}", pod.Name, pod.Namespace), Reason: fmt.Sprintf("failed to delete the target pod: %s", err.Error())}
+			}
+
+			// Wait for the inter-pod kill interval before deleting the next pod.
+			// This is additive to CHAOS_INTERVAL and fires even when RANDOMNESS is enabled.
+			if experimentsDetails.InterPodKillIntervalSeconds > 0 {
+				log.Infof("[Wait]: Waiting %vs between pod kills (INTER_POD_KILL_INTERVAL_SECONDS)", experimentsDetails.InterPodKillIntervalSeconds)
+				common.WaitForDuration(experimentsDetails.InterPodKillIntervalSeconds)
 			}
 
 			switch chaosDetails.Randomness {
@@ -186,7 +193,7 @@ func injectChaosInParallelMode(ctx context.Context, experimentsDetails *experime
 		if experimentsDetails.TargetPods == "" && chaosDetails.AppDetail == nil {
 			return cerrors.Error{ErrorCode: cerrors.ErrorTypeTargetSelection, Reason: "please provide one of the appLabel or TARGET_PODS"}
 		}
-		targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, clients, chaosDetails)
+		targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, experimentsDetails.PodTerminationOrder, clients, chaosDetails)
 		if err != nil {
 			return stacktrace.Propagate(err, "could not get target pods")
 		}
@@ -206,7 +213,7 @@ func injectChaosInParallelMode(ctx context.Context, experimentsDetails *experime
 		if experimentsDetails.EngineName != "" {
 			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
 			types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
-			events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+			_ = events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
 		}
 
 		//Deleting the application pod

--- a/chaoslib/litmus/pod-delete/lib/pod-delete.go
+++ b/chaoslib/litmus/pod-delete/lib/pod-delete.go
@@ -38,7 +38,7 @@ func PreparePodDelete(ctx context.Context, experimentsDetails *experimentTypes.E
 	//set up the tunables if provided in range
 	SetChaosTunables(experimentsDetails)
 
-	log.InfoWithValues("[Info]: The chaos tunables are:", logrus.Fields{
+	log.InfoWithValues("The chaos tunables are:", logrus.Fields{
 		"PodsAffectedPerc": experimentsDetails.PodsAffectedPerc,
 		"Sequence":         experimentsDetails.Sequence,
 	})
@@ -114,7 +114,7 @@ func injectChaosInSerialMode(ctx context.Context, experimentsDetails *experiment
 		//Deleting the application pod
 		for i, pod := range targetPodList.Items {
 
-			log.InfoWithValues("[Info]: Killing the following pods", logrus.Fields{
+			log.InfoWithValues("Killing the following pods", logrus.Fields{
 				"PodName": pod.Name})
 
 			if experimentsDetails.Force {
@@ -215,10 +215,11 @@ func injectChaosInParallelMode(ctx context.Context, experimentsDetails *experime
 			_ = events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
 		}
 
-		//Deleting the application pod
+		// Note: INTER_POD_KILL_INTERVAL_SECONDS is ignored in parallel mode,
+		// as the intention is to terminate all targeted pods simultaneously.
 		for _, pod := range targetPodList.Items {
 
-			log.InfoWithValues("[Info]: Killing the following pods", logrus.Fields{
+			log.InfoWithValues("Killing the following pods", logrus.Fields{
 				"PodName": pod.Name})
 
 			if experimentsDetails.Force {

--- a/chaoslib/litmus/pod-delete/lib/pod-delete.go
+++ b/chaoslib/litmus/pod-delete/lib/pod-delete.go
@@ -108,7 +108,9 @@ func injectChaosInSerialMode(ctx context.Context, experimentsDetails *experiment
 		if experimentsDetails.EngineName != "" {
 			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
 			types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
-			_ = events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+			if err := events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine"); err != nil {
+				log.Errorf("[Chaos]: Failed to create chaosengine inject event, err: %v", err)
+			}
 		}
 
 		//Deleting the application pod
@@ -212,7 +214,9 @@ func injectChaosInParallelMode(ctx context.Context, experimentsDetails *experime
 		if experimentsDetails.EngineName != "" {
 			msg := "Injecting " + experimentsDetails.ExperimentName + " chaos on application pod"
 			types.SetEngineEventAttributes(eventsDetails, types.ChaosInject, msg, "Normal", chaosDetails)
-			_ = events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine")
+			if err := events.GenerateEvents(eventsDetails, clients, chaosDetails, "ChaosEngine"); err != nil {
+				log.Errorf("[Chaos]: Failed to create chaosengine inject event, err: %v", err)
+			}
 		}
 
 		// Note: INTER_POD_KILL_INTERVAL_SECONDS is ignored in parallel mode,

--- a/chaoslib/litmus/stress-chaos/lib/stress-chaos.go
+++ b/chaoslib/litmus/stress-chaos/lib/stress-chaos.go
@@ -64,7 +64,7 @@ func PrepareAndInjectStressChaos(ctx context.Context, experimentsDetails *experi
 	if experimentsDetails.TargetPods == "" && chaosDetails.AppDetail == nil {
 		return cerrors.Error{ErrorCode: cerrors.ErrorTypeTargetSelection, Reason: "provide one of the appLabel or TARGET_PODS"}
 	}
-	targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, clients, chaosDetails)
+	targetPodList, err := common.GetTargetPods(experimentsDetails.NodeLabel, experimentsDetails.TargetPods, experimentsDetails.PodsAffectedPerc, "", clients, chaosDetails)
 	if err != nil {
 		return stacktrace.Propagate(err, "could not get target pods")
 	}

--- a/pkg/generic/container-kill/environment/environment.go
+++ b/pkg/generic/container-kill/environment/environment.go
@@ -37,5 +37,4 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.NodeLabel = types.Getenv("NODE_LABEL", "")
 	experimentDetails.SetHelperData = types.Getenv("SET_HELPER_DATA", "true")
 	experimentDetails.PodTerminationOrder = types.Getenv("POD_TERMINATION_ORDER", "random")
-	experimentDetails.InterPodKillIntervalSeconds, _ = strconv.Atoi(types.Getenv("INTER_POD_KILL_INTERVAL_SECONDS", "0"))
 }

--- a/pkg/generic/container-kill/environment/environment.go
+++ b/pkg/generic/container-kill/environment/environment.go
@@ -36,4 +36,6 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.TerminationGracePeriodSeconds, _ = strconv.Atoi(types.Getenv("TERMINATION_GRACE_PERIOD_SECONDS", ""))
 	experimentDetails.NodeLabel = types.Getenv("NODE_LABEL", "")
 	experimentDetails.SetHelperData = types.Getenv("SET_HELPER_DATA", "true")
+	experimentDetails.PodTerminationOrder = types.Getenv("POD_TERMINATION_ORDER", "random")
+	experimentDetails.InterPodKillIntervalSeconds, _ = strconv.Atoi(types.Getenv("INTER_POD_KILL_INTERVAL_SECONDS", "0"))
 }

--- a/pkg/generic/container-kill/environment/environment.go
+++ b/pkg/generic/container-kill/environment/environment.go
@@ -37,4 +37,5 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.NodeLabel = types.Getenv("NODE_LABEL", "")
 	experimentDetails.SetHelperData = types.Getenv("SET_HELPER_DATA", "true")
 	experimentDetails.PodTerminationOrder = types.Getenv("POD_TERMINATION_ORDER", "random")
+	experimentDetails.InterPodKillIntervalSeconds, _ = strconv.Atoi(types.Getenv("INTER_POD_KILL_INTERVAL_SECONDS", "0"))
 }

--- a/pkg/generic/container-kill/types/types.go
+++ b/pkg/generic/container-kill/types/types.go
@@ -36,4 +36,6 @@ type ExperimentDetails struct {
 	NodeLabel                     string
 	IsTargetContainerProvided     bool
 	SetHelperData                 string
+	PodTerminationOrder          string
+	InterPodKillIntervalSeconds  int
 }

--- a/pkg/generic/container-kill/types/types.go
+++ b/pkg/generic/container-kill/types/types.go
@@ -36,6 +36,5 @@ type ExperimentDetails struct {
 	NodeLabel                     string
 	IsTargetContainerProvided     bool
 	SetHelperData                 string
-	PodTerminationOrder          string
-	InterPodKillIntervalSeconds  int
+	PodTerminationOrder           string
 }

--- a/pkg/generic/container-kill/types/types.go
+++ b/pkg/generic/container-kill/types/types.go
@@ -37,4 +37,5 @@ type ExperimentDetails struct {
 	IsTargetContainerProvided     bool
 	SetHelperData                 string
 	PodTerminationOrder           string
+	InterPodKillIntervalSeconds   int
 }

--- a/pkg/generic/pod-delete/environment/environment.go
+++ b/pkg/generic/pod-delete/environment/environment.go
@@ -29,4 +29,6 @@ func GetENV(experimentDetails *experimentTypes.ExperimentDetails) {
 	experimentDetails.Sequence = types.Getenv("SEQUENCE", "parallel")
 	experimentDetails.TargetContainer = types.Getenv("TARGET_CONTAINER", "")
 	experimentDetails.NodeLabel = types.Getenv("NODE_LABEL", "")
+	experimentDetails.PodTerminationOrder = types.Getenv("POD_TERMINATION_ORDER", "random")
+	experimentDetails.InterPodKillIntervalSeconds, _ = strconv.Atoi(types.Getenv("INTER_POD_KILL_INTERVAL_SECONDS", "0"))
 }

--- a/pkg/generic/pod-delete/types/types.go
+++ b/pkg/generic/pod-delete/types/types.go
@@ -28,4 +28,6 @@ type ExperimentDetails struct {
 	LIBImagePullPolicy  string
 	TargetContainer     string
 	NodeLabel           string
+	PodTerminationOrder          string
+	InterPodKillIntervalSeconds  int
 }

--- a/pkg/generic/pod-delete/types/types.go
+++ b/pkg/generic/pod-delete/types/types.go
@@ -6,28 +6,28 @@ import (
 
 // ExperimentDetails is for collecting all the experiment-related details
 type ExperimentDetails struct {
-	ExperimentName      string
-	EngineName          string
-	ChaosDuration       int
-	ChaosInterval       string
-	RampTime            int
-	Force               bool
-	ChaosServiceAccount string
-	AppNS               string
-	AppLabel            string
-	AppKind             string
-	ChaosUID            clientTypes.UID
-	InstanceID          string
-	ChaosNamespace      string
-	ChaosPodName        string
-	Timeout             int
-	Delay               int
-	TargetPods          string
-	PodsAffectedPerc    string
-	Sequence            string
-	LIBImagePullPolicy  string
-	TargetContainer     string
-	NodeLabel           string
-	PodTerminationOrder          string
-	InterPodKillIntervalSeconds  int
+	ExperimentName              string
+	EngineName                  string
+	ChaosDuration               int
+	ChaosInterval               string
+	RampTime                    int
+	Force                       bool
+	ChaosServiceAccount         string
+	AppNS                       string
+	AppLabel                    string
+	AppKind                     string
+	ChaosUID                    clientTypes.UID
+	InstanceID                  string
+	ChaosNamespace              string
+	ChaosPodName                string
+	Timeout                     int
+	Delay                       int
+	TargetPods                  string
+	PodsAffectedPerc            string
+	Sequence                    string
+	LIBImagePullPolicy          string
+	TargetContainer             string
+	NodeLabel                   string
+	PodTerminationOrder         string
+	InterPodKillIntervalSeconds int
 }

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -54,7 +54,7 @@ func RandomInterval(interval string) error {
 	default:
 		return cerrors.Error{ErrorCode: cerrors.ErrorTypeGeneric, Reason: "could not parse CHAOS_INTERVAL env, invalid format"}
 	}
-	rand.Seed(time.Now().UnixNano())
+	// rand.Seed is deprecated; math/rand is global and pseudo-random
 	if upperBound < 1 {
 		return cerrors.Error{ErrorCode: cerrors.ErrorTypeGeneric, Reason: "invalid CHAOS_INTERVAL env value, value below lower limit"}
 	}
@@ -112,7 +112,7 @@ func FilterBasedOnPercentage(percentage int, list []string) []string {
 
 	var finalList []string
 	newInstanceListLength := math.Maximum(1, math.Adjustment(percentage, len(list)))
-	rand.Seed(time.Now().UnixNano())
+	// rand.Seed is deprecated; math/rand is global and pseudo-random
 
 	// it will generate the random instanceList
 	// it starts from the random index and choose requirement no of volumeID next to that index in a circular way.
@@ -187,7 +187,7 @@ func GetStatusMessage(defaultCheck bool, defaultMsg, probeStatus string) string 
 // GetRandomSequence will gives a random value for sequence
 func GetRandomSequence(sequence string) string {
 	if strings.ToLower(sequence) == "random" {
-		rand.Seed(time.Now().UnixNano())
+		// rand.Seed is deprecated; math/rand is global and pseudo-random
 		seq := []string{"serial", "parallel"}
 		randomIndex := rand.Intn(len(seq))
 		return seq[randomIndex]
@@ -215,7 +215,6 @@ func ValidateRange(a string) string {
 
 // getRandomValue gives a random value between two integers
 func getRandomValue(a, b int) int {
-	rand.Seed(time.Now().Unix())
 	return (a + rand.Intn(b-a+1))
 }
 

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -58,6 +58,9 @@ func RandomInterval(interval string) error {
 	if upperBound < 1 {
 		return cerrors.Error{ErrorCode: cerrors.ErrorTypeGeneric, Reason: "invalid CHAOS_INTERVAL env value, value below lower limit"}
 	}
+	if upperBound <= lowerBound {
+		return cerrors.Error{ErrorCode: cerrors.ErrorTypeGeneric, Reason: "invalid CHAOS_INTERVAL env value, upper bound must be greater than lower bound"}
+	}
 	waitTime := lowerBound + rand.Intn(upperBound-lowerBound)
 	log.Infof("[Wait]: Wait for the random chaos interval %vs", waitTime)
 	WaitForDuration(waitTime)
@@ -109,7 +112,9 @@ func AbortWatcherWithoutExit(expname string, clients clients.ClientSets, resultD
 
 // FilterBasedOnPercentage return the slice of list based on the the provided percentage
 func FilterBasedOnPercentage(percentage int, list []string) []string {
-
+	if len(list) == 0 {
+		return []string{}
+	}
 	var finalList []string
 	newInstanceListLength := math.Maximum(1, math.Adjustment(percentage, len(list)))
 	// rand.Seed is deprecated; math/rand is global and pseudo-random

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -58,10 +58,10 @@ func RandomInterval(interval string) error {
 	if upperBound < 1 {
 		return cerrors.Error{ErrorCode: cerrors.ErrorTypeGeneric, Reason: "invalid CHAOS_INTERVAL env value, value below lower limit"}
 	}
-	if upperBound <= lowerBound {
-		return cerrors.Error{ErrorCode: cerrors.ErrorTypeGeneric, Reason: "invalid CHAOS_INTERVAL env value, upper bound must be greater than lower bound"}
+	if upperBound < lowerBound {
+		return cerrors.Error{ErrorCode: cerrors.ErrorTypeGeneric, Reason: "invalid CHAOS_INTERVAL env value, upper bound must be greater than or equal to lower bound"}
 	}
-	waitTime := lowerBound + rand.Intn(upperBound-lowerBound)
+	waitTime := lowerBound + rand.Intn(upperBound-lowerBound+1)
 	log.Infof("[Wait]: Wait for the random chaos interval %vs", waitTime)
 	WaitForDuration(waitTime)
 	return nil

--- a/pkg/utils/common/nodes.go
+++ b/pkg/utils/common/nodes.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
-	"time"
 
 	"github.com/palantir/stacktrace"
 	apiv1 "k8s.io/api/core/v1"
@@ -51,7 +50,6 @@ func GetNodeList(nodeNames, nodeLabel string, nodeAffPerc int, clients clients.C
 
 	// it will generate the random nodelist
 	// it starts from the random index and choose requirement no of pods next to that index in a circular way.
-	rand.Seed(time.Now().UnixNano())
 	index := rand.Intn(len(nodes.Items))
 	for i := 0; i < newNodeListLength; i++ {
 		nodeList = append(nodeList, nodes.Items[index].Name)
@@ -75,7 +73,6 @@ func GetNodeName(namespace, labels, nodeLabel string, clients clients.ClientSets
 			return "", cerrors.Error{ErrorCode: cerrors.ErrorTypeTargetSelection, Target: fmt.Sprintf("{podLabel: %s, namespace: %s}", labels, namespace), Reason: "no pod found with matching labels"}
 		}
 
-		rand.Seed(time.Now().Unix())
 		randomIndex := rand.Intn(len(podList.Items))
 		return podList.Items[randomIndex].Spec.NodeName, nil
 	default:
@@ -83,7 +80,6 @@ func GetNodeName(namespace, labels, nodeLabel string, clients clients.ClientSets
 		if err != nil {
 			return "", stacktrace.Propagate(err, "could not get nodes by labels")
 		}
-		rand.Seed(time.Now().Unix())
 		randomIndex := rand.Intn(len(nodeList.Items))
 		return nodeList.Items[randomIndex].Name, nil
 	}

--- a/pkg/utils/common/pid.go
+++ b/pkg/utils/common/pid.go
@@ -205,7 +205,7 @@ func getContainerdAndCRIONetworkNsPath(containerID, socketPath, source string) (
 			return namespace.Path, nil
 		}
 	}
-	return "", cerrors.Error{ErrorCode: cerrors.ErrorTypeContainerRuntime, Source: source, Target: fmt.Sprintf("containerID: %s", containerID), Reason: fmt.Sprintf("failed to get the pid")}
+	return "", cerrors.Error{ErrorCode: cerrors.ErrorTypeContainerRuntime, Source: source, Target: fmt.Sprintf("containerID: %s", containerID), Reason: "failed to get the pid"}
 }
 
 // getDockerNetworkNsPath returns the sandbox network ns path of docker runtime
@@ -216,7 +216,7 @@ func getDockerNetworkNsPath(containerID, socketPath, source string) (string, err
 	}
 
 	if pid == 0 {
-		return "", cerrors.Error{ErrorCode: cerrors.ErrorTypeContainerRuntime, Source: source, Target: fmt.Sprintf("containerID: %s", containerID), Reason: fmt.Sprintf("failed to get the pid")}
+		return "", cerrors.Error{ErrorCode: cerrors.ErrorTypeContainerRuntime, Source: source, Target: fmt.Sprintf("containerID: %s", containerID), Reason: "failed to get the pid"}
 	}
 
 	nsPath := fmt.Sprintf("/proc/%d/ns/net", pid)

--- a/pkg/utils/common/pods.go
+++ b/pkg/utils/common/pods.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -90,7 +91,7 @@ func SetHelperData(chaosDetails *types.ChaosDetails, setHelperData string, clien
 	}
 
 	// Get Labels
-	labels := pod.ObjectMeta.Labels
+	labels := pod.Labels
 	for label := range labels {
 		if strings.HasSuffix(label, "job-name") || strings.HasSuffix(label, "controller-uid") {
 			delete(labels, label)
@@ -565,7 +566,23 @@ func getTargetPodsWhenNodeFilterSet(podAffPerc int, pods core_v1.PodList, nodes 
 	return filterPodsByPercentage(nodeFilteredPods, podAffPerc), nil
 }
 
-func GetTargetPods(nodeLabel, targetPods, podsAffectedPerc string, clients clients.ClientSets, chaosDetails *types.ChaosDetails) (core_v1.PodList, error) {
+// SortPodsByName sorts a PodList lexicographically by pod name.
+func SortPodsByName(pods core_v1.PodList) core_v1.PodList {
+	sort.Slice(pods.Items, func(i, j int) bool {
+		return pods.Items[i].Name < pods.Items[j].Name
+	})
+	return pods
+}
+
+// SortPodsByNameReverse sorts a PodList reverse-lexicographically by pod name.
+func SortPodsByNameReverse(pods core_v1.PodList) core_v1.PodList {
+	sort.Slice(pods.Items, func(i, j int) bool {
+		return pods.Items[i].Name > pods.Items[j].Name
+	})
+	return pods
+}
+
+func GetTargetPods(nodeLabel, targetPods, podsAffectedPerc, podTerminationOrder string, clients clients.ClientSets, chaosDetails *types.ChaosDetails) (core_v1.PodList, error) {
 
 	podAffectedPerc, _ := strconv.Atoi(podsAffectedPerc)
 
@@ -583,6 +600,24 @@ func GetTargetPods(nodeLabel, targetPods, podsAffectedPerc string, clients clien
 		pods, err = GetPodList(targetPods, podAffectedPerc, clients, chaosDetails)
 		if err != nil {
 			return core_v1.PodList{}, err
+		}
+	}
+
+	// Apply deterministic ordering based on POD_TERMINATION_ORDER.
+	// Sorting is skipped when TARGET_PODS is explicitly set: the caller has
+	// already expressed their intended kill sequence via insertion order, and
+	// re-sorting would silently destroy it.
+	if targetPods != "" {
+		log.Info("[Info]: TARGET_PODS is set; skipping POD_TERMINATION_ORDER sort to preserve explicit kill sequence")
+	} else {
+		switch strings.ToLower(podTerminationOrder) {
+		case "alphabetical":
+			log.Info("[Info]: POD_TERMINATION_ORDER is 'alphabetical', sorting target pods by name (ascending)")
+			pods = SortPodsByName(pods)
+		case "reverse":
+			log.Info("[Info]: POD_TERMINATION_ORDER is 'reverse', sorting target pods by name (descending)")
+			pods = SortPodsByNameReverse(pods)
+		// default "random": no reordering; filterPodsByPercentage already used a random start index
 		}
 	}
 

--- a/pkg/utils/common/pods.go
+++ b/pkg/utils/common/pods.go
@@ -617,7 +617,7 @@ func GetTargetPods(nodeLabel, targetPods, podsAffectedPerc, podTerminationOrder 
 		case "reverse":
 			log.Info("[Info]: POD_TERMINATION_ORDER is 'reverse', sorting target pods by name (descending)")
 			pods = SortPodsByNameReverse(pods)
-		// default "random": no reordering; filterPodsByPercentage already used a random start index
+			// default "random": no reordering; filterPodsByPercentage already used a random start index
 		}
 	}
 

--- a/pkg/utils/common/pods.go
+++ b/pkg/utils/common/pods.go
@@ -351,7 +351,6 @@ func filterPodsByPercentage(finalPods core_v1.PodList, podAffPerc int) core_v1.P
 	finalPods = removeDuplicatePods(finalPods)
 
 	newPodListLength := math.Maximum(1, math.Adjustment(math.Minimum(podAffPerc, 100), len(finalPods.Items)))
-	rand.Seed(time.Now().UnixNano())
 
 	var realPods core_v1.PodList
 	// it will generate the random podlist
@@ -566,22 +565,24 @@ func getTargetPodsWhenNodeFilterSet(podAffPerc int, pods core_v1.PodList, nodes 
 	return filterPodsByPercentage(nodeFilteredPods, podAffPerc), nil
 }
 
-// SortPodsByName sorts a PodList lexicographically by pod name.
-func SortPodsByName(pods core_v1.PodList) core_v1.PodList {
+// sortPodsByName sorts a PodList lexicographically by pod name.
+func sortPodsByName(pods core_v1.PodList) core_v1.PodList {
 	sort.Slice(pods.Items, func(i, j int) bool {
 		return pods.Items[i].Name < pods.Items[j].Name
 	})
 	return pods
 }
 
-// SortPodsByNameReverse sorts a PodList reverse-lexicographically by pod name.
-func SortPodsByNameReverse(pods core_v1.PodList) core_v1.PodList {
+// sortPodsByNameReverse sorts a PodList reverse-lexicographically by pod name.
+func sortPodsByNameReverse(pods core_v1.PodList) core_v1.PodList {
 	sort.Slice(pods.Items, func(i, j int) bool {
 		return pods.Items[i].Name > pods.Items[j].Name
 	})
 	return pods
 }
 
+// GetTargetPods derives the target pods based on the target pods, node label, pod affected percentage and pod termination order.
+// Note: Callers who do not support or do not wish to use the new podTerminationOrder tunable should pass "" (empty string) to preserve the original random behavior.
 func GetTargetPods(nodeLabel, targetPods, podsAffectedPerc, podTerminationOrder string, clients clients.ClientSets, chaosDetails *types.ChaosDetails) (core_v1.PodList, error) {
 
 	podAffectedPerc, _ := strconv.Atoi(podsAffectedPerc)
@@ -604,19 +605,16 @@ func GetTargetPods(nodeLabel, targetPods, podsAffectedPerc, podTerminationOrder 
 	}
 
 	// Apply deterministic ordering based on POD_TERMINATION_ORDER.
-	// Sorting is skipped when TARGET_PODS is explicitly set: the caller has
-	// already expressed their intended kill sequence via insertion order, and
-	// re-sorting would silently destroy it.
-	if targetPods != "" {
-		log.Info("[Info]: TARGET_PODS is set; skipping POD_TERMINATION_ORDER sort to preserve explicit kill sequence")
-	} else {
+	// Only sort when TARGET_PODS is not explicitly set.
+	// When it is set, insertion order already expresses the caller's intended kill sequence.
+	if targetPods == "" {
 		switch strings.ToLower(podTerminationOrder) {
 		case "alphabetical":
-			log.Info("[Info]: POD_TERMINATION_ORDER is 'alphabetical', sorting target pods by name (ascending)")
-			pods = SortPodsByName(pods)
+			log.Infof("POD_TERMINATION_ORDER is 'alphabetical', sorting target pods by name (ascending)")
+			pods = sortPodsByName(pods)
 		case "reverse":
-			log.Info("[Info]: POD_TERMINATION_ORDER is 'reverse', sorting target pods by name (descending)")
-			pods = SortPodsByNameReverse(pods)
+			log.Infof("POD_TERMINATION_ORDER is 'reverse', sorting target pods by name (descending)")
+			pods = sortPodsByNameReverse(pods)
 			// default "random": no reordering; filterPodsByPercentage already used a random start index
 		}
 	}

--- a/pkg/utils/common/pods.go
+++ b/pkg/utils/common/pods.go
@@ -566,17 +566,12 @@ func getTargetPodsWhenNodeFilterSet(podAffPerc int, pods core_v1.PodList, nodes 
 }
 
 // sortPodsByName sorts a PodList lexicographically by pod name.
-func sortPodsByName(pods core_v1.PodList) core_v1.PodList {
+func sortPodsByName(pods core_v1.PodList, reverse bool) core_v1.PodList {
 	sort.Slice(pods.Items, func(i, j int) bool {
+		if reverse {
+			return pods.Items[i].Name > pods.Items[j].Name
+		}
 		return pods.Items[i].Name < pods.Items[j].Name
-	})
-	return pods
-}
-
-// sortPodsByNameReverse sorts a PodList reverse-lexicographically by pod name.
-func sortPodsByNameReverse(pods core_v1.PodList) core_v1.PodList {
-	sort.Slice(pods.Items, func(i, j int) bool {
-		return pods.Items[i].Name > pods.Items[j].Name
 	})
 	return pods
 }
@@ -611,10 +606,10 @@ func GetTargetPods(nodeLabel, targetPods, podsAffectedPerc, podTerminationOrder 
 		switch strings.ToLower(podTerminationOrder) {
 		case "alphabetical":
 			log.Infof("POD_TERMINATION_ORDER is 'alphabetical', sorting target pods by name (ascending)")
-			pods = sortPodsByName(pods)
+			pods = sortPodsByName(pods, false)
 		case "reverse":
 			log.Infof("POD_TERMINATION_ORDER is 'reverse', sorting target pods by name (descending)")
-			pods = sortPodsByNameReverse(pods)
+			pods = sortPodsByName(pods, true)
 			// default "random": no reordering; filterPodsByPercentage already used a random start index
 		}
 	}

--- a/pkg/utils/common/pods_test.go
+++ b/pkg/utils/common/pods_test.go
@@ -55,3 +55,51 @@ func TestSortPodsByName(t *testing.T) {
 		})
 	}
 }
+
+func TestSortPodsByNameReverse(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    core_v1.PodList
+		expected []string
+	}{
+		{
+			name: "Unsorted pods reverse",
+			input: core_v1.PodList{
+				Items: []core_v1.Pod{
+					{ObjectMeta: v1.ObjectMeta{Name: "pod-a"}},
+					{ObjectMeta: v1.ObjectMeta{Name: "pod-c"}},
+					{ObjectMeta: v1.ObjectMeta{Name: "pod-b"}},
+				},
+			},
+			expected: []string{"pod-c", "pod-b", "pod-a"},
+		},
+		{
+			name: "Already reverse sorted pods",
+			input: core_v1.PodList{
+				Items: []core_v1.Pod{
+					{ObjectMeta: v1.ObjectMeta{Name: "pod-2"}},
+					{ObjectMeta: v1.ObjectMeta{Name: "pod-1"}},
+				},
+			},
+			expected: []string{"pod-2", "pod-1"},
+		},
+		{
+			name: "Empty pod list",
+			input: core_v1.PodList{
+				Items: []core_v1.Pod{},
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SortPodsByNameReverse(tt.input)
+			resultNames := []string{}
+			for _, pod := range result.Items {
+				resultNames = append(resultNames, pod.Name)
+			}
+			assert.Equal(t, tt.expected, resultNames)
+		})
+	}
+}

--- a/pkg/utils/common/pods_test.go
+++ b/pkg/utils/common/pods_test.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSortPodsByName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    core_v1.PodList
+		expected []string
+	}{
+		{
+			name: "Unsorted pods",
+			input: core_v1.PodList{
+				Items: []core_v1.Pod{
+					{ObjectMeta: v1.ObjectMeta{Name: "pod-c"}},
+					{ObjectMeta: v1.ObjectMeta{Name: "pod-a"}},
+					{ObjectMeta: v1.ObjectMeta{Name: "pod-b"}},
+				},
+			},
+			expected: []string{"pod-a", "pod-b", "pod-c"},
+		},
+		{
+			name: "Already sorted pods",
+			input: core_v1.PodList{
+				Items: []core_v1.Pod{
+					{ObjectMeta: v1.ObjectMeta{Name: "pod-1"}},
+					{ObjectMeta: v1.ObjectMeta{Name: "pod-2"}},
+				},
+			},
+			expected: []string{"pod-1", "pod-2"},
+		},
+		{
+			name: "Empty pod list",
+			input: core_v1.PodList{
+				Items: []core_v1.Pod{},
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SortPodsByName(tt.input)
+			resultNames := []string{}
+			for _, pod := range result.Items {
+				resultNames = append(resultNames, pod.Name)
+			}
+			assert.Equal(t, tt.expected, resultNames)
+		})
+	}
+}

--- a/pkg/utils/common/pods_test.go
+++ b/pkg/utils/common/pods_test.go
@@ -8,7 +8,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestSortPodsByName(t *testing.T) {
+func Test_sortPodsByName(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    core_v1.PodList
@@ -46,7 +46,7 @@ func TestSortPodsByName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := SortPodsByName(tt.input)
+			result := sortPodsByName(tt.input)
 			resultNames := []string{}
 			for _, pod := range result.Items {
 				resultNames = append(resultNames, pod.Name)
@@ -56,7 +56,7 @@ func TestSortPodsByName(t *testing.T) {
 	}
 }
 
-func TestSortPodsByNameReverse(t *testing.T) {
+func Test_sortPodsByNameReverse(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    core_v1.PodList
@@ -94,7 +94,7 @@ func TestSortPodsByNameReverse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := SortPodsByNameReverse(tt.input)
+			result := sortPodsByNameReverse(tt.input)
 			resultNames := []string{}
 			for _, pod := range result.Items {
 				resultNames = append(resultNames, pod.Name)

--- a/pkg/utils/common/pods_test.go
+++ b/pkg/utils/common/pods_test.go
@@ -46,7 +46,7 @@ func Test_sortPodsByName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := sortPodsByName(tt.input)
+			result := sortPodsByName(tt.input, false)
 			resultNames := []string{}
 			for _, pod := range result.Items {
 				resultNames = append(resultNames, pod.Name)
@@ -94,7 +94,7 @@ func Test_sortPodsByNameReverse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := sortPodsByNameReverse(tt.input)
+			result := sortPodsByName(tt.input, true)
 			resultNames := []string{}
 			for _, pod := range result.Items {
 				resultNames = append(resultNames, pod.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR introduces deterministic pod termination controls and inter-pod timing for chaos experiments, specifically addressing non-determinism in `pod-delete` and `container-kill`. Previously, dynamic pod discovery applied a random offset when fulfilling `PODS_AFFECTED_PERC`, leading to inconsistent KPI verification results mentioned in the issue across runs.

### Key Changes:
1. **New variable: `POD_TERMINATION_ORDER`**
   - `random` (default): Preserves existing behavior.
   - `alphabetical`: Sorts target pods lexicographical by name (`A -> Z`).
   - `reverse`: Sorts target pods reverse-lexicographical by name (`Z -> A`).
   *Note: Sorting is automatically skipped if `TARGET_PODS` is set to preserve explicit user-defined kill sequences.*

2. **New variable: `INTER_POD_KILL_INTERVAL_SECONDS`**
   - Provides a fixed, deterministic delay between individual pod kills. This is additive to `CHAOS_INTERVAL` and ensures predictable KPI recovery windows during serial execution.

**Which issue this PR fixes**: fixes https://github.com/litmuschaos/litmus/issues/5445

**Special notes for your reviewer**:
- Added `PodTerminationOrder` and `InterPodKillIntervalSeconds` to `ExperimentDetails`.
- Implemented in `pkg/utils/common/pods.go` and `chaoslib/litmus/pod-delete/lib/pod-delete.go`.
- Added unit tests for new sorting logic in `pkg/utils/common/pods_test.go`.
- Ran:
  - `go fmt ./...`
  - `go test ./pkg/utils/common`
  - `go test ./chaoslib/litmus/pod-delete/lib ./chaoslib/litmus/container-kill/helper`
- `go vet ./...` currently fails on pre-existing issues outside this PR:
  - duplicate JSON tags in `pkg/spring-boot/spring-boot-chaos/types/types.go`
  - unreachable code in `pkg/cloud/gcp/vm-operations.go`

**Checklist:**
-   [x] Fixes #5445
-   [x] PR messages has document related information (Updated in litmus repo)
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [x] Commit has unit tests (Verified via sorting tests in the new `pods_test.go`)
-   [ ] Commit has integration tests
-   [x] E2E run Required for the changes