### PR TITLE
fix(kubelet-service-kill): add HostPID:true and use chroot /node for systemctl

### DIFF
--- a/chaoslib/litmus/kubelet-service-kill/lib/kubelet-service-kill.go
+++ b/chaoslib/litmus/kubelet-service-kill/lib/kubelet-service-kill.go
@@ -111,6 +111,7 @@ func createHelperPod(ctx context.Context, experimentsDetails *experimentTypes.Ex
 			Annotations: chaosDetails.Annotations,
 		},
 		Spec: apiv1.PodSpec{
+			HostPID:                       true,
 			RestartPolicy:                 apiv1.RestartPolicyNever,
 			ImagePullSecrets:              chaosDetails.ImagePullSecrets,
 			NodeName:                      appNodeName,
@@ -143,7 +144,7 @@ func createHelperPod(ctx context.Context, experimentsDetails *experimentTypes.Ex
 					},
 					Args: []string{
 						"-c",
-						"sleep 10 && systemctl stop kubelet && sleep " + strconv.Itoa(experimentsDetails.ChaosDuration) + " && systemctl start kubelet",
+						"sleep 10 && chroot /node systemctl stop kubelet && sleep " + strconv.Itoa(experimentsDetails.ChaosDuration) + " && chroot /node systemctl start kubelet",
 					},
 					Resources: chaosDetails.Resources,
 					VolumeMounts: []apiv1.VolumeMount{


### PR DESCRIPTION
## What this PR does / why we need it

The `kubelet-service-kill` helper pod runs `systemctl stop/start kubelet` to inject chaos.
This fails on OpenShift clusters and with any non-EOL image with:

`Failed to connect to bus: No data available`

The official Litmus documentation for `kubelet-service-kill` states ( [as mentioned here](https://litmuschaos.github.io/litmus/experiments/categories/nodes/kubelet-service-kill/#experiment-tunables) )

> LIB_IMAGE — The lib image used to inject kubelet kill chaos. **Defaults to ubuntu:16.04**

This default needs to be updated. **`ubuntu:16.04` reached End of Life in April 2021 and has
known unpatched security vulnerabilities. It should no longer be recommended or used as a default.**

Nonetheless, the old `ubuntu:16.04` worked because its old `libdbus-1` used a
simple legacy D-Bus connection path that can no longer be used.

**This PR fixes two separate but related problems:**

**1. OpenShift**:  The experiment never worked on OpenShift because `hostPID: true` was not
set on the helper pod. OpenShift's SCC admission controller blocks host access without it,
so `systemctl` had no way to reach the host systemd at all.

**2. Any cluster with a non-EOL image**: Without `chroot /node`, the container's own
`systemctl` binary is used. Modern `systemctl` tries `/run/systemd/private/sysbus` first
(not accessible from a container) and fails. `chroot /node` runs the host's own `systemctl`
instead, which works on any `LIB_IMAGE`.

Both changes are required together for the experiment to work reliably.

**Tested on:** kubeadm with Ubuntu 24.04 nodes : node goes NotReady, experiment passes ✅ 

**Note for OpenShift users:** `HostPID: true` requires the SA to have the `privileged` SCC
granted via a `ClusterRoleBinding` (OpenShift specific operational requirement, not a code change).

## Which issue this PR fixes

fixes #797 

## Checklist
- [x] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [x] E2E run Required for the changes