### PR TITLE
fix: allow stopped state for managed nodegroup EC2 wait checks

### DIFF
--- a/pkg/cloud/aws/ec2/ec2-operations.go
+++ b/pkg/cloud/aws/ec2/ec2-operations.go
@@ -92,11 +92,19 @@ func WaitForEC2Down(timeout, delay int, managedNodegroup, region, instanceID str
 			if err != nil {
 				return stacktrace.Propagate(err, "failed to get the instance status")
 			}
-			if (managedNodegroup != "enable" && instanceState != "stopped") || (managedNodegroup == "enable" && instanceState != "terminated") {
+			if managedNodegroup != "enable" && instanceState != "stopped" {
 				log.Infof("The instance state is %v", instanceState)
 				return cerrors.Error{
 					ErrorCode: cerrors.ErrorTypeChaosInject,
 					Reason:    "instance is not in stopped state",
+					Target:    fmt.Sprintf("{EC2 Instance ID: %v, Region: %v}", instanceID, region),
+				}
+			}
+			if managedNodegroup == "enable" && instanceState != "stopped" && instanceState != "terminated" {
+				log.Infof("The instance state is %v", instanceState)
+				return cerrors.Error{
+					ErrorCode: cerrors.ErrorTypeChaosInject,
+					Reason:    "instance is not in stopped or terminated state",
 					Target:    fmt.Sprintf("{EC2 Instance ID: %v, Region: %v}", instanceID, region),
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR fixes the EC2 wait-state check for AWS fault runs with
`MANAGED_NODEGROUP=enable`.

Previously, `WaitForEC2Down` treated `MANAGED_NODEGROUP=enable` as successful only when the instance state became `terminated`. In practice, some ASG/nodegroup flows keep the target instance in `stopped` state for an extended period before replacement or termination completes. That caused a false `CHAOS_INJECT_ERROR` even though the target instance had already transitioned to a valid down state.

This change treats both `stopped` and `terminated` as valid down states for the managed nodegroup flow. The post-chaos active node count check continues to validate the replacement behavior.

---
**Which issue this PR fixes** : 

fixes 5491

Original issue: https://github.com/litmuschaos/litmus/issues/5491 (litmus)  


---
**Special notes for your reviewer**:

- Reproduced the reported failure locally with `MANAGED_NODEGROUP=enable`, where the instance remained in `stopped` state and the experiment failed with `instance is not in stopped state`.
- Re-ran the same scenario with a locally built patched `go-runner` image and verified that the experiment progressed past the `stopped` state and completed successfully.
- This PR keeps the code change minimal and does not alter the post-chaos node count validation flow.
- For the managed nodegroup flow, the post-chaos active node count check already validates whether replacement completed successfully. This change allows `WaitForEC2Down` to succeed once the target instance reaches a valid down state.


---
Issue log excerpt:
```text
time="2026-04-28T02:29:58Z" level=info msg="The instance state is stopped"
time="2026-04-28T02:30:00Z" level=info msg="The instance state is stopped"
time="2026-04-28T02:30:02Z" level=info msg="The instance state is stopped"
time="2026-04-28T02:30:04Z" level=info msg="[Probe]: {Actual value: 2}, {Expected value: 0}, {Operator: >=}"
time="2026-04-28T02:30:04Z" level=info msg="The instance state is stopped"
time="2026-04-28T02:30:06Z" level=error msg="Chaos injection failed: could not run chaos in parallel mode\n --- at /litmus-go/chaoslib/litmus/ec2-terminate-by-tag/lib/ec2-terminate-by-tag.go:63 (PrepareEC2TerminateByTag) ---\nCaused by: ec2 instance failed to stop\n --- at /litmus-go/chaoslib/litmus/ec2-terminate-by-tag/lib/ec2-terminate-by-tag.go:188 (injectChaosInParallelMode) ---\nCaused by: {\"errorCode\":\"CHAOS_INJECT_ERROR\",\"reason\":\"instance is not in stopped state\",\"target\":\"{EC2 Instance ID: i-xxxxx, Region: ap-northeast-2}\"}"
```

Log excerpt after the fix:
```text
time="2026-05-21T06:39:49Z" level=info msg="[Wait]: Wait for EC2 instance 'i-xxxxx' to get in stopped state"
time="2026-05-21T06:40:04Z" level=info msg="The instance state is stopped"
time="2026-05-21T06:40:06Z" level=info msg="[Wait]: Wait for EC2 instance 'i-xxxxx' to get in stopped state"
time="2026-05-21T06:40:10Z" level=info msg="The instance state is stopped"
time="2026-05-21T06:40:12Z" level=info msg="[Wait]: Waiting for chaos interval of 300s"
time="2026-05-21T06:45:12Z" level=info msg="[Confirmation]: ec2-stop-by-tag chaos has been injected successfully"
time="2026-05-21T06:45:12Z" level=info msg="[Status]: Counting and verifying number of active nodes in the node group (post-chaos)"
time="2026-05-21T06:45:13Z" level=info msg="[Info]: Post-Chaos Active Node Count: 2"
time="2026-05-21T06:45:13Z" level=info msg="[The End]: Updating the chaos result of ec2-stop-by-tag experiment (EOT)"
```
---


**Checklist:**
-   [x] Fixes [#5491(ec2-terminate-by-tag: WaitForEC2Down reports "instance is not in stopped state")](https://github.com/litmuschaos/litmus/issues/5491)
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
