### PR TITLE
fix: preserve imagePullSecrets for helper pods when set_helper_data is false

### DIFF
--- a/pkg/utils/common/pods.go
+++ b/pkg/utils/common/pods.go
@@ -100,6 +100,10 @@ func SetHelperData(chaosDetails *types.ChaosDetails, setHelperData string, clien
 
 	chaosDetails.Labels = labels
 
+	// Retain ImagePullSecrets even when setHelperData=false
+    // so helper pods can pull images from private registries
+	chaosDetails.ImagePullSecrets = pod.Spec.ImagePullSecrets
+
 	switch setHelperData {
 	case "false":
 		return nil
@@ -107,9 +111,6 @@ func SetHelperData(chaosDetails *types.ChaosDetails, setHelperData string, clien
 	default:
 		// Get Chaos Pod Annotation
 		chaosDetails.Annotations = pod.Annotations
-
-		// Get ImagePullSecrets
-		chaosDetails.ImagePullSecrets = pod.Spec.ImagePullSecrets
 
 		//Get Tolerations
 		chaosDetails.Tolerations = pod.Spec.Tolerations
@@ -119,15 +120,7 @@ func SetHelperData(chaosDetails *types.ChaosDetails, setHelperData string, clien
 		if err != nil {
 			return stacktrace.Propagate(err, "could not inherit resource requirements")
 		}
-
-		switch setHelperData {
-		case "false":
-			return nil
-		default:
-			// Get Chaos Pod Annotation
-			chaosDetails.Annotations = pod.Annotations
-			return nil
-		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
## What

This PR fixes an issue where `imagePullSecrets` were being cleared for helper pods when the `set_helper_data` flag was set to `false`.

The fix ensures that helper pods retain the configured `imagePullSecrets` even when helper data injection is disabled.

## Why

In OpenShift and air-gapped environments, helper pod images are commonly hosted in private registries that require authentication.

Currently, when `set_helper_data=false`, the `SetHelperData` function sets `ImagePullSecrets` to `nil`. As a result, helper pods fail to pull images and enter `ErrImagePull` or `ImagePullBackOff` states.

This impacts LitmusChaos experiments running in:

* OpenShift clusters
* air-gapped environments
* secured/private container registries

## Fix

Updated the `SetHelperData` logic to preserve configured `imagePullSecrets` even when `set_helper_data` is disabled.

This allows helper pods to authenticate successfully and pull required images from private registries.

Fixes #731

Testing Proof Link: https://github.com/litmuschaos/litmus-go/pull/800#issuecomment-4532733176

**Checklist:**
-   [ ] Fixes #731 
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
